### PR TITLE
Expose projection and coordinate conversion APIs

### DIFF
--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -70,6 +70,7 @@ typedef enum mln_status : int32_t {
 
 typedef struct mln_runtime mln_runtime;
 typedef struct mln_map mln_map;
+typedef struct mln_map_projection mln_map_projection;
 typedef struct mln_resource_request_handle mln_resource_request_handle;
 typedef struct mln_texture_session mln_texture_session;
 
@@ -595,7 +596,7 @@ MLN_API mln_status mln_runtime_run_once(mln_runtime* runtime) MLN_NOEXCEPT;
 
 #pragma endregion
 
-#pragma region Map, camera, and events
+#pragma region Map types, lifecycle, style, and events
 /** Field mask values for mln_camera_options. */
 typedef enum mln_camera_option_field : uint32_t {
   MLN_CAMERA_OPTION_CENTER = 1u << 0u,
@@ -603,6 +604,13 @@ typedef enum mln_camera_option_field : uint32_t {
   MLN_CAMERA_OPTION_BEARING = 1u << 2u,
   MLN_CAMERA_OPTION_PITCH = 1u << 3u,
 } mln_camera_option_field;
+
+/** Field mask values for MapLibre axonometric rendering options. */
+typedef enum mln_projection_mode_field : uint32_t {
+  MLN_PROJECTION_MODE_AXONOMETRIC = 1u << 0u,
+  MLN_PROJECTION_MODE_X_SKEW = 1u << 1u,
+  MLN_PROJECTION_MODE_Y_SKEW = 1u << 2u,
+} mln_projection_mode_field;
 
 /** Map rendering modes used when creating a map. */
 typedef enum mln_map_mode : uint32_t {
@@ -651,11 +659,58 @@ typedef struct mln_camera_options {
   double pitch;
 } mln_camera_options;
 
+/** Geographic coordinate in degrees used by map and projection APIs. */
+typedef struct mln_lat_lng {
+  /** Latitude in degrees. Input latitude must be finite and within [-90, 90].
+   */
+  double latitude;
+  /** Longitude in degrees. Input longitude must be finite. */
+  double longitude;
+} mln_lat_lng;
+
 /** Screen-space point in logical map pixels. */
 typedef struct mln_screen_point {
   double x;
   double y;
 } mln_screen_point;
+
+/** Screen-space inset in logical map pixels. */
+typedef struct mln_edge_insets {
+  double top;
+  double left;
+  double bottom;
+  double right;
+} mln_edge_insets;
+
+/**
+ * Lower-level Spherical Mercator projected-meter coordinate.
+ *
+ * Map coordinate conversion APIs use mln_lat_lng. This type is only for
+ * Mercator helper functions.
+ */
+typedef struct mln_projected_meters {
+  /** Distance measured northward from the equator, in meters. */
+  double northing;
+  /** Distance measured eastward from the prime meridian, in meters. */
+  double easting;
+} mln_projected_meters;
+
+/**
+ * MapLibre axonometric rendering options used for snapshots and commands.
+ *
+ * MapLibre Native names this native type ProjectionMode. It controls the live
+ * map render transform, not the geographic coordinate model.
+ */
+typedef struct mln_projection_mode {
+  uint32_t size;
+  uint32_t fields;
+  /** Enables a non-perspective axonometric render transform. */
+  bool axonometric;
+  /** Native x-skew factor used by the axonometric transform. */
+  double x_skew;
+  /** Native y-skew factor used by the axonometric transform. */
+  double y_skew;
+} mln_projection_mode;
 
 /** Map event payload returned by mln_map_poll_event(). */
 typedef struct mln_map_event {
@@ -672,11 +727,6 @@ typedef struct mln_map_event {
  * Returns map options initialized for this C API version.
  */
 MLN_API mln_map_options mln_map_options_default(void) MLN_NOEXCEPT;
-
-/**
- * Returns empty camera options initialized for this C API version.
- */
-MLN_API mln_camera_options mln_camera_options_default(void) MLN_NOEXCEPT;
 
 /**
  * Creates a map handle on the runtime owner thread.
@@ -769,6 +819,42 @@ mln_map_set_style_url(mln_map* map, const char* url) MLN_NOEXCEPT;
  */
 MLN_API mln_status
 mln_map_set_style_json(mln_map* map, const char* json) MLN_NOEXCEPT;
+
+/**
+ * Pops the next queued map event.
+ *
+ * On success, *out_event is overwritten and *out_has_event indicates whether an
+ * event was available. When an event is available, out_event->message points to
+ * map-owned storage that remains valid until the next mln_map_poll_event() call
+ * for the same map or until the map is destroyed. Copy message bytes before
+ * then when they must outlive that window.
+ *
+ * Returns:
+ * - MLN_STATUS_OK when the poll completed; out_has_event indicates whether an
+ *   event was written to out_event.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_event is
+ *   null, out_has_event is null, or out_event->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_poll_event(
+  mln_map* map, mln_map_event* out_event, bool* out_has_event
+) MLN_NOEXCEPT;
+
+#pragma endregion
+
+#pragma region Map camera, render transform, and coordinate conversion
+/**
+ * Returns empty camera options initialized for this C API version.
+ */
+MLN_API mln_camera_options mln_camera_options_default(void) MLN_NOEXCEPT;
+
+/**
+ * Returns empty axonometric rendering options initialized for this C API
+ * version.
+ */
+MLN_API mln_projection_mode mln_projection_mode_default(void) MLN_NOEXCEPT;
 
 /**
  * Copies the current camera snapshot.
@@ -870,25 +956,274 @@ MLN_API mln_status mln_map_pitch_by(mln_map* map, double pitch) MLN_NOEXCEPT;
 MLN_API mln_status mln_map_cancel_transitions(mln_map* map) MLN_NOEXCEPT;
 
 /**
- * Pops the next queued map event.
+ * Copies the current axonometric rendering options.
  *
- * On success, *out_event is overwritten and *out_has_event indicates whether an
- * event was available. When an event is available, out_event->message points to
- * map-owned storage that remains valid until the next mln_map_poll_event() call
- * for the same map or until the map is destroyed. Copy message bytes before
- * then when they must outlive that window.
+ * On success, *out_mode is overwritten. MapLibre currently reports all fields.
  *
  * Returns:
- * - MLN_STATUS_OK when the poll completed; out_has_event indicates whether an
- *   event was written to out_event.
- * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_event is
- *   null, out_has_event is null, or out_event->size is too small.
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_mode is null,
+ *   or out_mode->size is too small.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
-MLN_API mln_status mln_map_poll_event(
-  mln_map* map, mln_map_event* out_event, bool* out_has_event
+MLN_API mln_status mln_map_get_projection_mode(
+  mln_map* map, mln_projection_mode* out_mode
+) MLN_NOEXCEPT;
+
+/**
+ * Applies axonometric rendering option fields to a map.
+ *
+ * Only fields indicated by mode->fields affect the map. Unspecified fields keep
+ * their current native values. These options mutate the live map render
+ * transform and do not change coordinate conversion units or formulas.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, mode is null,
+ *   mode->size is too small, mode->fields contains unknown bits, or an enabled
+ *   skew value is non-finite.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_projection_mode(
+  mln_map* map, const mln_projection_mode* mode
+) MLN_NOEXCEPT;
+
+/**
+ * Converts a geographic world coordinate to a screen point for the current map.
+ *
+ * The output point uses logical map pixels with an origin at the top-left of
+ * the map viewport.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_point is
+ *   null, or coordinate contains invalid latitude or longitude values.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_pixel_for_lat_lng(
+  mln_map* map, mln_lat_lng coordinate, mln_screen_point* out_point
+) MLN_NOEXCEPT;
+
+/**
+ * Converts a screen point to a geographic world coordinate for the current map.
+ *
+ * The input point uses logical map pixels with an origin at the top-left of the
+ * map viewport.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_coordinate is
+ *   null, or point contains non-finite values.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_lat_lng_for_pixel(
+  mln_map* map, mln_screen_point point, mln_lat_lng* out_coordinate
+) MLN_NOEXCEPT;
+
+/**
+ * Converts geographic world coordinates to screen points for the current map.
+ *
+ * The caller owns both arrays. On success, out_points receives coordinate_count
+ * entries. coordinates and out_points may be null only when coordinate_count is
+ * 0.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, a required array
+ *   is null, or any coordinate contains invalid latitude or longitude values.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_pixels_for_lat_lngs(
+  mln_map* map, const mln_lat_lng* coordinates, size_t coordinate_count,
+  mln_screen_point* out_points
+) MLN_NOEXCEPT;
+
+/**
+ * Converts screen points to geographic world coordinates for the current map.
+ *
+ * The caller owns both arrays. On success, out_coordinates receives point_count
+ * entries. points and out_coordinates may be null only when point_count is 0.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, a required array
+ *   is null, or any point contains non-finite values.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_lat_lngs_for_pixels(
+  mln_map* map, const mln_screen_point* points, size_t point_count,
+  mln_lat_lng* out_coordinates
+) MLN_NOEXCEPT;
+
+#pragma endregion
+
+#pragma region Projection helpers and utilities
+
+/**
+ * Creates a standalone projection helper from the current map transform.
+ *
+ * The helper owns projection and camera transform state only. It does not own
+ * style, resources, render targets, or map events. Use it to convert
+ * coordinates or compute camera fitting without changing the source map.
+ *
+ * Creation snapshots the map's transform. Later map camera or projection
+ * changes do not update the helper. The creating thread owns the helper and
+ * must call projection functions on that thread.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_projection is
+ *   null, or *out_projection is not null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_projection_create(
+  mln_map* map, mln_map_projection** out_projection
+) MLN_NOEXCEPT;
+
+/**
+ * Destroys a standalone projection helper.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when projection is null or not live.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the projection
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_map_projection_destroy(mln_map_projection* projection) MLN_NOEXCEPT;
+
+/**
+ * Copies the current camera snapshot from a standalone projection helper.
+ *
+ * On success, *out_camera is overwritten.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when projection is null or not live, out_camera
+ *   is null, or out_camera->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the projection
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_projection_get_camera(
+  mln_map_projection* projection, mln_camera_options* out_camera
+) MLN_NOEXCEPT;
+
+/**
+ * Applies camera fields to a standalone projection helper.
+ *
+ * Only fields indicated by camera->fields affect the helper.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when projection is null or not live, camera is
+ *   null, camera->size is too small, or camera->fields contains unknown bits.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the projection
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_projection_set_camera(
+  mln_map_projection* projection, const mln_camera_options* camera
+) MLN_NOEXCEPT;
+
+/**
+ * Updates a projection helper camera so coordinates are visible within padding.
+ *
+ * The caller owns coordinates. Use mln_map_projection_get_camera() after this
+ * call to read the computed camera.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when projection is null or not live,
+ *   coordinates is null, coordinate_count is 0, padding contains negative or
+ *   non-finite values, or any coordinate contains invalid latitude or longitude
+ *   values.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the projection
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_projection_set_visible_coordinates(
+  mln_map_projection* projection, const mln_lat_lng* coordinates,
+  size_t coordinate_count, mln_edge_insets padding
+) MLN_NOEXCEPT;
+
+/**
+ * Converts a geographic world coordinate using a standalone projection helper.
+ *
+ * The output point uses logical map pixels with an origin at the top-left of
+ * the helper viewport.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when projection is null or not live, out_point
+ *   is null, or coordinate contains invalid latitude or longitude values.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the projection
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_projection_pixel_for_lat_lng(
+  mln_map_projection* projection, mln_lat_lng coordinate,
+  mln_screen_point* out_point
+) MLN_NOEXCEPT;
+
+/**
+ * Converts a screen point using a standalone projection helper.
+ *
+ * The input point uses logical map pixels with an origin at the top-left of the
+ * helper viewport.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when projection is null or not live,
+ *   out_coordinate is null, or point contains non-finite values.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the projection
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_projection_lat_lng_for_pixel(
+  mln_map_projection* projection, mln_screen_point point,
+  mln_lat_lng* out_coordinate
+) MLN_NOEXCEPT;
+
+/**
+ * Converts a geographic coordinate to spherical Mercator projected meters.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when out_meters is null or coordinate contains
+ *   invalid latitude or longitude values.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_projected_meters_for_lat_lng(
+  mln_lat_lng coordinate, mln_projected_meters* out_meters
+) MLN_NOEXCEPT;
+
+/**
+ * Converts spherical Mercator projected meters to a geographic coordinate.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when out_coordinate is null or meters contains
+ *   non-finite values.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_lat_lng_for_projected_meters(
+  mln_projected_meters meters, mln_lat_lng* out_coordinate
 ) MLN_NOEXCEPT;
 
 #pragma endregion

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -1,5 +1,7 @@
 #define MLN_BUILDING_C
 
+#include <cstddef>
+
 #include "map/map.hpp"
 
 #include "c_api/boundary.hpp"
@@ -11,6 +13,10 @@ auto mln_map_options_default(void) noexcept -> mln_map_options {
 
 auto mln_camera_options_default(void) noexcept -> mln_camera_options {
   return mln::core::camera_options_default();
+}
+
+auto mln_projection_mode_default(void) noexcept -> mln_projection_mode {
+  return mln::core::projection_mode_default();
 }
 
 auto mln_map_create(
@@ -58,6 +64,140 @@ auto mln_map_jump_to(mln_map* map, const mln_camera_options* camera) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_jump_to(map, camera);
+  });
+}
+
+auto mln_map_get_projection_mode(
+  mln_map* map, mln_projection_mode* out_mode
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_projection_mode(map, out_mode);
+  });
+}
+
+auto mln_map_set_projection_mode(
+  mln_map* map, const mln_projection_mode* mode
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_projection_mode(map, mode);
+  });
+}
+
+auto mln_map_pixel_for_lat_lng(
+  mln_map* map, mln_lat_lng coordinate, mln_screen_point* out_point
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_pixel_for_lat_lng(map, coordinate, out_point);
+  });
+}
+
+auto mln_map_lat_lng_for_pixel(
+  mln_map* map, mln_screen_point point, mln_lat_lng* out_coordinate
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_lat_lng_for_pixel(map, point, out_coordinate);
+  });
+}
+
+auto mln_map_pixels_for_lat_lngs(
+  mln_map* map, const mln_lat_lng* coordinates, size_t coordinate_count,
+  mln_screen_point* out_points
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_pixels_for_lat_lngs(
+      map, coordinates, coordinate_count, out_points
+    );
+  });
+}
+
+auto mln_map_lat_lngs_for_pixels(
+  mln_map* map, const mln_screen_point* points, size_t point_count,
+  mln_lat_lng* out_coordinates
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_lat_lngs_for_pixels(
+      map, points, point_count, out_coordinates
+    );
+  });
+}
+
+auto mln_map_projection_create(
+  mln_map* map, mln_map_projection** out_projection
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_projection_create(map, out_projection);
+  });
+}
+
+auto mln_map_projection_destroy(mln_map_projection* projection) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_projection_destroy(projection);
+  });
+}
+
+auto mln_map_projection_get_camera(
+  mln_map_projection* projection, mln_camera_options* out_camera
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_projection_get_camera(projection, out_camera);
+  });
+}
+
+auto mln_map_projection_set_camera(
+  mln_map_projection* projection, const mln_camera_options* camera
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_projection_set_camera(projection, camera);
+  });
+}
+
+auto mln_map_projection_set_visible_coordinates(
+  mln_map_projection* projection, const mln_lat_lng* coordinates,
+  size_t coordinate_count, mln_edge_insets padding
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_projection_set_visible_coordinates(
+      projection, coordinates, coordinate_count, padding
+    );
+  });
+}
+
+auto mln_map_projection_pixel_for_lat_lng(
+  mln_map_projection* projection, mln_lat_lng coordinate,
+  mln_screen_point* out_point
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_projection_pixel_for_lat_lng(
+      projection, coordinate, out_point
+    );
+  });
+}
+
+auto mln_map_projection_lat_lng_for_pixel(
+  mln_map_projection* projection, mln_screen_point point,
+  mln_lat_lng* out_coordinate
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_projection_lat_lng_for_pixel(
+      projection, point, out_coordinate
+    );
+  });
+}
+
+auto mln_projected_meters_for_lat_lng(
+  mln_lat_lng coordinate, mln_projected_meters* out_meters
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::projected_meters_for_lat_lng(coordinate, out_meters);
+  });
+}
+
+auto mln_lat_lng_for_projected_meters(
+  mln_projected_meters meters, mln_lat_lng* out_coordinate
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::lat_lng_for_projected_meters(meters, out_coordinate);
   });
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1,26 +1,32 @@
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <exception>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/map_options.hpp>
+#include <mbgl/map/map_projection.hpp>
 #include <mbgl/map/mode.hpp>
+#include <mbgl/map/projection_mode.hpp>
 #include <mbgl/renderer/renderer_frontend.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/projection.hpp>
 #include <mbgl/util/size.hpp>
 
 #include "map/map.hpp"
@@ -31,6 +37,8 @@
 
 namespace {
 using MapRegistry = std::unordered_map<mln_map*, std::unique_ptr<mln_map>>;
+using ProjectionRegistry =
+  std::unordered_map<mln_map_projection*, std::unique_ptr<mln_map_projection>>;
 
 constexpr auto default_map_width = uint32_t{256};
 constexpr auto default_map_height = uint32_t{256};
@@ -43,6 +51,16 @@ auto map_registry_mutex() -> std::mutex& {
 
 auto map_registry() -> MapRegistry& {
   static MapRegistry value;
+  return value;
+}
+
+auto map_projection_registry_mutex() -> std::mutex& {
+  static std::mutex value;
+  return value;
+}
+
+auto map_projection_registry() -> ProjectionRegistry& {
+  static ProjectionRegistry value;
   return value;
 }
 
@@ -312,6 +330,136 @@ auto validate_camera_options(const mln_camera_options* camera) -> mln_status {
   return MLN_STATUS_OK;
 }
 
+auto validate_projection_mode_options(const mln_projection_mode* mode)
+  -> mln_status {
+  if (mode == nullptr) {
+    mln::core::set_thread_error("projection mode must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  if (mode->size < sizeof(mln_projection_mode)) {
+    mln::core::set_thread_error("mln_projection_mode.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_PROJECTION_MODE_AXONOMETRIC) |
+    MLN_PROJECTION_MODE_X_SKEW | MLN_PROJECTION_MODE_Y_SKEW;
+  if ((mode->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_projection_mode.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  if (
+    ((mode->fields & MLN_PROJECTION_MODE_X_SKEW) != 0U &&
+     !std::isfinite(mode->x_skew)) ||
+    ((mode->fields & MLN_PROJECTION_MODE_Y_SKEW) != 0U &&
+     !std::isfinite(mode->y_skew))
+  ) {
+    mln::core::set_thread_error("projection skew values must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  return MLN_STATUS_OK;
+}
+
+auto validate_lat_lng(mln_lat_lng coordinate) -> mln_status {
+  if (
+    !std::isfinite(coordinate.latitude) || coordinate.latitude < -90.0 ||
+    coordinate.latitude > 90.0 || !std::isfinite(coordinate.longitude)
+  ) {
+    mln::core::set_thread_error(
+      "latitude must be finite and within [-90, 90], and longitude must be "
+      "finite"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_lat_lng_array(
+  const mln_lat_lng* coordinates, size_t coordinate_count, bool allow_empty
+) -> mln_status {
+  if (coordinate_count == 0) {
+    if (allow_empty) {
+      return MLN_STATUS_OK;
+    }
+    mln::core::set_thread_error("coordinate_count must be greater than 0");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  if (coordinates == nullptr) {
+    mln::core::set_thread_error("coordinates must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto coordinate_span =
+    std::span<const mln_lat_lng>{coordinates, coordinate_count};
+  for (const auto coordinate : coordinate_span) {
+    const auto status = validate_lat_lng(coordinate);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_screen_point(mln_screen_point point) -> mln_status {
+  if (!std::isfinite(point.x) || !std::isfinite(point.y)) {
+    mln::core::set_thread_error("screen point values must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_screen_point_array(
+  const mln_screen_point* points, size_t point_count
+) -> mln_status {
+  if (point_count == 0) {
+    return MLN_STATUS_OK;
+  }
+
+  if (points == nullptr) {
+    mln::core::set_thread_error("points must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto point_span =
+    std::span<const mln_screen_point>{points, point_count};
+  for (const auto point : point_span) {
+    const auto status = validate_screen_point(point);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_edge_insets(mln_edge_insets padding) -> mln_status {
+  if (
+    !std::isfinite(padding.top) || !std::isfinite(padding.left) ||
+    !std::isfinite(padding.bottom) || !std::isfinite(padding.right) ||
+    padding.top < 0.0 || padding.left < 0.0 || padding.bottom < 0.0 ||
+    padding.right < 0.0
+  ) {
+    mln::core::set_thread_error(
+      "padding values must be finite and greater than or equal to 0"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_projected_meters(mln_projected_meters meters) -> mln_status {
+  if (!std::isfinite(meters.northing) || !std::isfinite(meters.easting)) {
+    mln::core::set_thread_error("projected meter values must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
 auto to_native_camera(const mln_camera_options& camera) -> mbgl::CameraOptions {
   auto result = mbgl::CameraOptions{};
   if ((camera.fields & MLN_CAMERA_OPTION_CENTER) != 0U) {
@@ -352,6 +500,88 @@ auto from_native_camera(const mbgl::CameraOptions& camera)
   return result;
 }
 
+auto to_native_projection_mode(const mln_projection_mode& mode)
+  -> mbgl::ProjectionMode {
+  auto result = mbgl::ProjectionMode{};
+  if ((mode.fields & MLN_PROJECTION_MODE_AXONOMETRIC) != 0U) {
+    result.withAxonometric(mode.axonometric);
+  }
+  if ((mode.fields & MLN_PROJECTION_MODE_X_SKEW) != 0U) {
+    result.withXSkew(mode.x_skew);
+  }
+  if ((mode.fields & MLN_PROJECTION_MODE_Y_SKEW) != 0U) {
+    result.withYSkew(mode.y_skew);
+  }
+  return result;
+}
+
+auto from_native_projection_mode(const mbgl::ProjectionMode& mode)
+  -> mln_projection_mode {
+  auto result = mln::core::projection_mode_default();
+  if (mode.axonometric) {
+    result.fields |= MLN_PROJECTION_MODE_AXONOMETRIC;
+    result.axonometric = *mode.axonometric;
+  }
+  if (mode.xSkew) {
+    result.fields |= MLN_PROJECTION_MODE_X_SKEW;
+    result.x_skew = *mode.xSkew;
+  }
+  if (mode.ySkew) {
+    result.fields |= MLN_PROJECTION_MODE_Y_SKEW;
+    result.y_skew = *mode.ySkew;
+  }
+  return result;
+}
+
+auto to_native_lat_lng(mln_lat_lng coordinate) -> mbgl::LatLng {
+  return mbgl::LatLng{coordinate.latitude, coordinate.longitude};
+}
+
+auto from_native_lat_lng(const mbgl::LatLng& coordinate) -> mln_lat_lng {
+  return mln_lat_lng{
+    .latitude = coordinate.latitude(), .longitude = coordinate.longitude()
+  };
+}
+
+auto to_native_lat_lngs(const mln_lat_lng* coordinates, size_t coordinate_count)
+  -> std::vector<mbgl::LatLng> {
+  auto result = std::vector<mbgl::LatLng>{};
+  result.reserve(coordinate_count);
+  const auto coordinate_span =
+    std::span<const mln_lat_lng>{coordinates, coordinate_count};
+  for (const auto coordinate : coordinate_span) {
+    result.emplace_back(to_native_lat_lng(coordinate));
+  }
+  return result;
+}
+
+auto to_native_screen_point(mln_screen_point point) -> mbgl::ScreenCoordinate {
+  return mbgl::ScreenCoordinate{point.x, point.y};
+}
+
+auto from_native_screen_point(const mbgl::ScreenCoordinate& point)
+  -> mln_screen_point {
+  return mln_screen_point{.x = point.x, .y = point.y};
+}
+
+auto to_native_screen_points(const mln_screen_point* points, size_t point_count)
+  -> std::vector<mbgl::ScreenCoordinate> {
+  auto result = std::vector<mbgl::ScreenCoordinate>{};
+  result.reserve(point_count);
+  const auto point_span =
+    std::span<const mln_screen_point>{points, point_count};
+  for (const auto point : point_span) {
+    result.emplace_back(to_native_screen_point(point));
+  }
+  return result;
+}
+
+auto to_native_edge_insets(mln_edge_insets padding) -> mbgl::EdgeInsets {
+  return mbgl::EdgeInsets{
+    padding.top, padding.left, padding.bottom, padding.right
+  };
+}
+
 auto screen_point(mln_screen_point point) -> mbgl::ScreenCoordinate {
   return mbgl::ScreenCoordinate{point.x, point.y};
 }
@@ -367,6 +597,11 @@ struct mln_map {
   std::unique_ptr<HeadlessFrontend> frontend;
   std::unique_ptr<mbgl::Map> map;
   mln_texture_session* texture_session = nullptr;
+};
+
+struct mln_map_projection {
+  std::thread::id owner_thread;
+  std::unique_ptr<mbgl::MapProjection> projection;
 };
 
 namespace mln::core {
@@ -427,6 +662,16 @@ auto camera_options_default() noexcept -> mln_camera_options {
   };
 }
 
+auto projection_mode_default() noexcept -> mln_projection_mode {
+  return mln_projection_mode{
+    .size = sizeof(mln_projection_mode),
+    .fields = 0,
+    .axonometric = false,
+    .x_skew = 0,
+    .y_skew = 0
+  };
+}
+
 auto validate_map(mln_map* map) -> mln_status {
   if (map == nullptr) {
     set_thread_error("map must not be null");
@@ -441,6 +686,26 @@ auto validate_map(mln_map* map) -> mln_status {
 
   if (map->owner_thread != std::this_thread::get_id()) {
     set_thread_error("map call must be made on its owner thread");
+    return MLN_STATUS_WRONG_THREAD;
+  }
+
+  return MLN_STATUS_OK;
+}
+
+auto validate_map_projection(mln_map_projection* projection) -> mln_status {
+  if (projection == nullptr) {
+    set_thread_error("projection must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const std::scoped_lock lock(map_projection_registry_mutex());
+  if (!map_projection_registry().contains(projection)) {
+    set_thread_error("projection is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  if (projection->owner_thread != std::this_thread::get_id()) {
+    set_thread_error("projection call must be made on its owner thread");
     return MLN_STATUS_WRONG_THREAD;
   }
 
@@ -681,6 +946,337 @@ auto map_jump_to(mln_map* map, const mln_camera_options* camera) -> mln_status {
     return camera_status;
   }
   map->map->jumpTo(to_native_camera(*camera));
+  return MLN_STATUS_OK;
+}
+
+auto map_get_projection_mode(mln_map* map, mln_projection_mode* out_mode)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_mode == nullptr || out_mode->size < sizeof(mln_projection_mode)) {
+    set_thread_error("out_mode must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_mode = from_native_projection_mode(map->map->getProjectionMode());
+  return MLN_STATUS_OK;
+}
+
+auto map_set_projection_mode(mln_map* map, const mln_projection_mode* mode)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto mode_status = validate_projection_mode_options(mode);
+  if (mode_status != MLN_STATUS_OK) {
+    return mode_status;
+  }
+
+  map->map->setProjectionMode(to_native_projection_mode(*mode));
+  return MLN_STATUS_OK;
+}
+
+auto map_pixel_for_lat_lng(
+  mln_map* map, mln_lat_lng coordinate, mln_screen_point* out_point
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_point == nullptr) {
+    set_thread_error("out_point must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto coordinate_status = validate_lat_lng(coordinate);
+  if (coordinate_status != MLN_STATUS_OK) {
+    return coordinate_status;
+  }
+
+  *out_point = from_native_screen_point(
+    map->map->pixelForLatLng(to_native_lat_lng(coordinate))
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_lat_lng_for_pixel(
+  mln_map* map, mln_screen_point point, mln_lat_lng* out_coordinate
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_coordinate == nullptr) {
+    set_thread_error("out_coordinate must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto point_status = validate_screen_point(point);
+  if (point_status != MLN_STATUS_OK) {
+    return point_status;
+  }
+
+  *out_coordinate = from_native_lat_lng(
+    map->map->latLngForPixel(to_native_screen_point(point))
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_pixels_for_lat_lngs(
+  mln_map* map, const mln_lat_lng* coordinates, size_t coordinate_count,
+  mln_screen_point* out_points
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (coordinate_count != 0 && out_points == nullptr) {
+    set_thread_error(
+      "out_points must not be null when coordinate_count is nonzero"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto coordinates_status =
+    validate_lat_lng_array(coordinates, coordinate_count, true);
+  if (coordinates_status != MLN_STATUS_OK) {
+    return coordinates_status;
+  }
+  if (coordinate_count == 0) {
+    return MLN_STATUS_OK;
+  }
+
+  const auto native_coordinates =
+    to_native_lat_lngs(coordinates, coordinate_count);
+  const auto pixels = map->map->pixelsForLatLngs(native_coordinates);
+  auto output = std::span<mln_screen_point>{out_points, pixels.size()};
+  auto output_position = output.begin();
+  for (const auto& pixel : pixels) {
+    *output_position = from_native_screen_point(pixel);
+    ++output_position;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_lat_lngs_for_pixels(
+  mln_map* map, const mln_screen_point* points, size_t point_count,
+  mln_lat_lng* out_coordinates
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (point_count != 0 && out_coordinates == nullptr) {
+    set_thread_error(
+      "out_coordinates must not be null when point_count is nonzero"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto points_status = validate_screen_point_array(points, point_count);
+  if (points_status != MLN_STATUS_OK) {
+    return points_status;
+  }
+  if (point_count == 0) {
+    return MLN_STATUS_OK;
+  }
+
+  const auto native_points = to_native_screen_points(points, point_count);
+  const auto coordinates = map->map->latLngsForPixels(native_points);
+  auto output = std::span<mln_lat_lng>{out_coordinates, coordinates.size()};
+  auto output_position = output.begin();
+  for (const auto& coordinate : coordinates) {
+    *output_position = from_native_lat_lng(coordinate);
+    ++output_position;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_projection_create(mln_map* map, mln_map_projection** out_projection)
+  -> mln_status {
+  if (out_projection == nullptr) {
+    set_thread_error("out_projection must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (*out_projection != nullptr) {
+    set_thread_error("out_projection must point to a null handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  auto owned_projection = std::make_unique<mln_map_projection>();
+  owned_projection->owner_thread = std::this_thread::get_id();
+  owned_projection->projection =
+    std::make_unique<mbgl::MapProjection>(*map->map);
+
+  auto* handle = owned_projection.get();
+  {
+    const std::scoped_lock lock(map_projection_registry_mutex());
+    map_projection_registry().emplace(handle, std::move(owned_projection));
+  }
+  *out_projection = handle;
+  return MLN_STATUS_OK;
+}
+
+auto map_projection_destroy(mln_map_projection* projection) -> mln_status {
+  const auto status = validate_map_projection(projection);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  auto owned_projection = std::unique_ptr<mln_map_projection>{};
+  {
+    const std::scoped_lock lock(map_projection_registry_mutex());
+    const auto found = map_projection_registry().find(projection);
+    owned_projection = std::move(found->second);
+    map_projection_registry().erase(found);
+  }
+  owned_projection.reset();
+  return MLN_STATUS_OK;
+}
+
+auto map_projection_get_camera(
+  mln_map_projection* projection, mln_camera_options* out_camera
+) -> mln_status {
+  const auto status = validate_map_projection(projection);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_camera == nullptr || out_camera->size < sizeof(mln_camera_options)) {
+    set_thread_error("out_camera must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_camera = from_native_camera(projection->projection->getCamera());
+  return MLN_STATUS_OK;
+}
+
+auto map_projection_set_camera(
+  mln_map_projection* projection, const mln_camera_options* camera
+) -> mln_status {
+  const auto status = validate_map_projection(projection);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto camera_status = validate_camera_options(camera);
+  if (camera_status != MLN_STATUS_OK) {
+    return camera_status;
+  }
+
+  projection->projection->setCamera(to_native_camera(*camera));
+  return MLN_STATUS_OK;
+}
+
+auto map_projection_set_visible_coordinates(
+  mln_map_projection* projection, const mln_lat_lng* coordinates,
+  size_t coordinate_count, mln_edge_insets padding
+) -> mln_status {
+  const auto status = validate_map_projection(projection);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto coordinates_status =
+    validate_lat_lng_array(coordinates, coordinate_count, false);
+  if (coordinates_status != MLN_STATUS_OK) {
+    return coordinates_status;
+  }
+  const auto padding_status = validate_edge_insets(padding);
+  if (padding_status != MLN_STATUS_OK) {
+    return padding_status;
+  }
+
+  projection->projection->setVisibleCoordinates(
+    to_native_lat_lngs(coordinates, coordinate_count),
+    to_native_edge_insets(padding)
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_projection_pixel_for_lat_lng(
+  mln_map_projection* projection, mln_lat_lng coordinate,
+  mln_screen_point* out_point
+) -> mln_status {
+  const auto status = validate_map_projection(projection);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_point == nullptr) {
+    set_thread_error("out_point must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto coordinate_status = validate_lat_lng(coordinate);
+  if (coordinate_status != MLN_STATUS_OK) {
+    return coordinate_status;
+  }
+
+  *out_point = from_native_screen_point(
+    projection->projection->pixelForLatLng(to_native_lat_lng(coordinate))
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_projection_lat_lng_for_pixel(
+  mln_map_projection* projection, mln_screen_point point,
+  mln_lat_lng* out_coordinate
+) -> mln_status {
+  const auto status = validate_map_projection(projection);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_coordinate == nullptr) {
+    set_thread_error("out_coordinate must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto point_status = validate_screen_point(point);
+  if (point_status != MLN_STATUS_OK) {
+    return point_status;
+  }
+
+  *out_coordinate = from_native_lat_lng(
+    projection->projection->latLngForPixel(to_native_screen_point(point))
+  );
+  return MLN_STATUS_OK;
+}
+
+auto projected_meters_for_lat_lng(
+  mln_lat_lng coordinate, mln_projected_meters* out_meters
+) -> mln_status {
+  if (out_meters == nullptr) {
+    set_thread_error("out_meters must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto coordinate_status = validate_lat_lng(coordinate);
+  if (coordinate_status != MLN_STATUS_OK) {
+    return coordinate_status;
+  }
+
+  const auto meters =
+    mbgl::Projection::projectedMetersForLatLng(to_native_lat_lng(coordinate));
+  *out_meters = mln_projected_meters{
+    .northing = meters.northing(), .easting = meters.easting()
+  };
+  return MLN_STATUS_OK;
+}
+
+auto lat_lng_for_projected_meters(
+  mln_projected_meters meters, mln_lat_lng* out_coordinate
+) -> mln_status {
+  if (out_coordinate == nullptr) {
+    set_thread_error("out_coordinate must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto meters_status = validate_projected_meters(meters);
+  if (meters_status != MLN_STATUS_OK) {
+    return meters_status;
+  }
+
+  *out_coordinate = from_native_lat_lng(
+    mbgl::Projection::latLngForProjectedMeters(
+      mbgl::ProjectedMeters{meters.northing, meters.easting}
+    )
+  );
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <thread>
 
@@ -15,6 +16,7 @@ namespace mln::core {
 
 auto map_options_default() noexcept -> mln_map_options;
 auto camera_options_default() noexcept -> mln_camera_options;
+auto projection_mode_default() noexcept -> mln_projection_mode;
 auto create_map(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) -> mln_status;
@@ -24,6 +26,51 @@ auto map_set_style_url(mln_map* map, const char* url) -> mln_status;
 auto map_set_style_json(mln_map* map, const char* json) -> mln_status;
 auto map_get_camera(mln_map* map, mln_camera_options* out_camera) -> mln_status;
 auto map_jump_to(mln_map* map, const mln_camera_options* camera) -> mln_status;
+auto map_get_projection_mode(mln_map* map, mln_projection_mode* out_mode)
+  -> mln_status;
+auto map_set_projection_mode(mln_map* map, const mln_projection_mode* mode)
+  -> mln_status;
+auto map_pixel_for_lat_lng(
+  mln_map* map, mln_lat_lng coordinate, mln_screen_point* out_point
+) -> mln_status;
+auto map_lat_lng_for_pixel(
+  mln_map* map, mln_screen_point point, mln_lat_lng* out_coordinate
+) -> mln_status;
+auto map_pixels_for_lat_lngs(
+  mln_map* map, const mln_lat_lng* coordinates, size_t coordinate_count,
+  mln_screen_point* out_points
+) -> mln_status;
+auto map_lat_lngs_for_pixels(
+  mln_map* map, const mln_screen_point* points, size_t point_count,
+  mln_lat_lng* out_coordinates
+) -> mln_status;
+auto map_projection_create(mln_map* map, mln_map_projection** out_projection)
+  -> mln_status;
+auto map_projection_destroy(mln_map_projection* projection) -> mln_status;
+auto map_projection_get_camera(
+  mln_map_projection* projection, mln_camera_options* out_camera
+) -> mln_status;
+auto map_projection_set_camera(
+  mln_map_projection* projection, const mln_camera_options* camera
+) -> mln_status;
+auto map_projection_set_visible_coordinates(
+  mln_map_projection* projection, const mln_lat_lng* coordinates,
+  size_t coordinate_count, mln_edge_insets padding
+) -> mln_status;
+auto map_projection_pixel_for_lat_lng(
+  mln_map_projection* projection, mln_lat_lng coordinate,
+  mln_screen_point* out_point
+) -> mln_status;
+auto map_projection_lat_lng_for_pixel(
+  mln_map_projection* projection, mln_screen_point point,
+  mln_lat_lng* out_coordinate
+) -> mln_status;
+auto projected_meters_for_lat_lng(
+  mln_lat_lng coordinate, mln_projected_meters* out_meters
+) -> mln_status;
+auto lat_lng_for_projected_meters(
+  mln_projected_meters meters, mln_lat_lng* out_coordinate
+) -> mln_status;
 auto map_move_by(mln_map* map, double delta_x, double delta_y) -> mln_status;
 auto map_scale_by(mln_map* map, double scale, const mln_screen_point* anchor)
   -> mln_status;

--- a/tests/c/main.zig
+++ b/tests/c/main.zig
@@ -4,6 +4,7 @@ comptime {
     _ = @import("style.zig");
     _ = @import("resources.zig");
     _ = @import("camera.zig");
+    _ = @import("projection.zig");
     _ = @import("diagnostics.zig");
     _ = @import("events.zig");
     _ = @import("logging.zig");

--- a/tests/c/projection.zig
+++ b/tests/c/projection.zig
@@ -1,0 +1,245 @@
+const std = @import("std");
+const testing = std.testing;
+const support = @import("support.zig");
+const c = support.c;
+
+const center = c.mln_lat_lng{ .latitude = 37.7749, .longitude = -122.4194 };
+
+fn centeredCamera() c.mln_camera_options {
+    var camera = c.mln_camera_options_default();
+    camera.fields = c.MLN_CAMERA_OPTION_CENTER | c.MLN_CAMERA_OPTION_ZOOM;
+    camera.latitude = center.latitude;
+    camera.longitude = center.longitude;
+    camera.zoom = 10.0;
+    return camera;
+}
+
+fn expectCenterPoint(point: c.mln_screen_point) !void {
+    try testing.expectApproxEqAbs(@as(f64, 256.0), point.x, 0.001);
+    try testing.expectApproxEqAbs(@as(f64, 256.0), point.y, 0.001);
+}
+
+fn expectLatLngApprox(expected: c.mln_lat_lng, actual: c.mln_lat_lng) !void {
+    try testing.expectApproxEqAbs(expected.latitude, actual.latitude, 0.000001);
+    try testing.expectApproxEqAbs(expected.longitude, actual.longitude, 0.000001);
+}
+
+test "projection mode exposes default options" {
+    const mode = c.mln_projection_mode_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_projection_mode)), mode.size);
+    try testing.expectEqual(@as(u32, 0), mode.fields);
+}
+
+test "map projection mode updates snapshot fields" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var mode = c.mln_projection_mode_default();
+    mode.fields = c.MLN_PROJECTION_MODE_AXONOMETRIC | c.MLN_PROJECTION_MODE_X_SKEW | c.MLN_PROJECTION_MODE_Y_SKEW;
+    mode.axonometric = true;
+    mode.x_skew = 0.25;
+    mode.y_skew = -0.125;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_projection_mode(map, &mode));
+
+    var snapshot = c.mln_projection_mode_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_projection_mode(map, &snapshot));
+    try testing.expect((snapshot.fields & c.MLN_PROJECTION_MODE_AXONOMETRIC) != 0);
+    try testing.expect((snapshot.fields & c.MLN_PROJECTION_MODE_X_SKEW) != 0);
+    try testing.expect((snapshot.fields & c.MLN_PROJECTION_MODE_Y_SKEW) != 0);
+    try testing.expect(snapshot.axonometric);
+    try testing.expectApproxEqAbs(mode.x_skew, snapshot.x_skew, 0.000001);
+    try testing.expectApproxEqAbs(mode.y_skew, snapshot.y_skew, 0.000001);
+}
+
+test "map projection mode rejects invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_projection_mode(map, null));
+
+    var snapshot = c.mln_projection_mode_default();
+    snapshot.size = @sizeOf(c.mln_projection_mode) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_projection_mode(map, &snapshot));
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_projection_mode(map, null));
+
+    var mode = c.mln_projection_mode_default();
+    mode.size = @sizeOf(c.mln_projection_mode) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_projection_mode(map, &mode));
+
+    mode = c.mln_projection_mode_default();
+    mode.fields = @as(u32, 1) << 31;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_projection_mode(map, &mode));
+
+    mode = c.mln_projection_mode_default();
+    mode.fields = c.MLN_PROJECTION_MODE_X_SKEW;
+    mode.x_skew = std.math.inf(f64);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_projection_mode(map, &mode));
+}
+
+test "map converts between lat lngs and screen points" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var camera = centeredCamera();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_jump_to(map, &camera));
+
+    var point: c.mln_screen_point = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_pixel_for_lat_lng(map, center, &point));
+    try expectCenterPoint(point);
+
+    var coordinate: c.mln_lat_lng = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_lat_lng_for_pixel(map, point, &coordinate));
+    try expectLatLngApprox(center, coordinate);
+
+    var coordinates = [_]c.mln_lat_lng{
+        center,
+        .{ .latitude = 0.0, .longitude = 0.0 },
+    };
+    var points: [coordinates.len]c.mln_screen_point = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_pixels_for_lat_lngs(map, coordinates[0..].ptr, coordinates.len, points[0..].ptr));
+    try expectCenterPoint(points[0]);
+
+    var roundtrip: [points.len]c.mln_lat_lng = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_lat_lngs_for_pixels(map, points[0..].ptr, points.len, roundtrip[0..].ptr));
+    try expectLatLngApprox(coordinates[0], roundtrip[0]);
+    try expectLatLngApprox(coordinates[1], roundtrip[1]);
+}
+
+test "map coordinate conversion rejects invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var point: c.mln_screen_point = undefined;
+    var coordinate: c.mln_lat_lng = undefined;
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_pixel_for_lat_lng(map, center, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_pixel_for_lat_lng(map, .{ .latitude = 91.0, .longitude = 0.0 }, &point));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_lat_lng_for_pixel(map, .{ .x = std.math.inf(f64), .y = 0.0 }, &coordinate));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_lat_lng_for_pixel(map, .{ .x = 0.0, .y = 0.0 }, null));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_pixels_for_lat_lngs(map, null, 0, null));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_lat_lngs_for_pixels(map, null, 0, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_pixels_for_lat_lngs(map, null, 1, &point));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_lat_lngs_for_pixels(map, null, 1, &coordinate));
+}
+
+test "standalone projection converts and updates camera" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var camera = centeredCamera();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_jump_to(map, &camera));
+
+    var projection: ?*c.mln_map_projection = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_create(map, &projection));
+    const helper = projection orelse return error.ProjectionCreateFailed;
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_destroy(helper)) catch @panic("projection destroy failed");
+
+    var point: c.mln_screen_point = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_pixel_for_lat_lng(helper, center, &point));
+    try expectCenterPoint(point);
+
+    var coordinate: c.mln_lat_lng = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_lat_lng_for_pixel(helper, point, &coordinate));
+    try expectLatLngApprox(center, coordinate);
+
+    var helper_camera = c.mln_camera_options_default();
+    helper_camera.fields = c.MLN_CAMERA_OPTION_CENTER | c.MLN_CAMERA_OPTION_ZOOM;
+    helper_camera.latitude = 0.0;
+    helper_camera.longitude = 0.0;
+    helper_camera.zoom = 3.0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_set_camera(helper, &helper_camera));
+
+    var snapshot = c.mln_camera_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_get_camera(helper, &snapshot));
+    try testing.expect((snapshot.fields & c.MLN_CAMERA_OPTION_CENTER) != 0);
+    try testing.expect((snapshot.fields & c.MLN_CAMERA_OPTION_ZOOM) != 0);
+    try testing.expectApproxEqAbs(helper_camera.latitude, snapshot.latitude, 0.000001);
+    try testing.expectApproxEqAbs(helper_camera.longitude, snapshot.longitude, 0.000001);
+    try testing.expectApproxEqAbs(helper_camera.zoom, snapshot.zoom, 0.000001);
+
+    var visible = [_]c.mln_lat_lng{
+        .{ .latitude = -10.0, .longitude = -10.0 },
+        .{ .latitude = 10.0, .longitude = 10.0 },
+    };
+    const padding = c.mln_edge_insets{ .top = 10.0, .left = 20.0, .bottom = 10.0, .right = 20.0 };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_set_visible_coordinates(helper, visible[0..].ptr, visible.len, padding));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_get_camera(helper, &snapshot));
+    try testing.expect((snapshot.fields & c.MLN_CAMERA_OPTION_CENTER) != 0);
+    try testing.expect((snapshot.fields & c.MLN_CAMERA_OPTION_ZOOM) != 0);
+}
+
+test "standalone projection rejects invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_create(map, null));
+
+    var non_null_projection: ?*c.mln_map_projection = @ptrFromInt(1);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_create(map, &non_null_projection));
+
+    var projection: ?*c.mln_map_projection = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_create(map, &projection));
+    const helper = projection orelse return error.ProjectionCreateFailed;
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_destroy(helper)) catch @panic("projection destroy failed");
+
+    var camera = c.mln_camera_options_default();
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_get_camera(helper, null));
+    camera.size = @sizeOf(c.mln_camera_options) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_get_camera(helper, &camera));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_camera(helper, null));
+
+    const padding = c.mln_edge_insets{ .top = 0.0, .left = 0.0, .bottom = 0.0, .right = 0.0 };
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_coordinates(helper, null, 0, padding));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_coordinates(helper, null, 1, padding));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_coordinates(helper, &center, 1, .{ .top = -1.0, .left = 0.0, .bottom = 0.0, .right = 0.0 }));
+
+    var point: c.mln_screen_point = undefined;
+    var coordinate: c.mln_lat_lng = undefined;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_pixel_for_lat_lng(helper, center, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_pixel_for_lat_lng(helper, .{ .latitude = std.math.nan(f64), .longitude = 0.0 }, &point));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_lat_lng_for_pixel(helper, .{ .x = 0.0, .y = std.math.inf(f64) }, &coordinate));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_lat_lng_for_pixel(helper, .{ .x = 0.0, .y = 0.0 }, null));
+}
+
+test "projected meters convert to and from lat lng" {
+    const origin = c.mln_lat_lng{ .latitude = 0.0, .longitude = 0.0 };
+    var meters: c.mln_projected_meters = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_projected_meters_for_lat_lng(origin, &meters));
+    try testing.expectApproxEqAbs(@as(f64, 0.0), meters.northing, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, 0.0), meters.easting, 0.000001);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_projected_meters_for_lat_lng(center, &meters));
+    var roundtrip: c.mln_lat_lng = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_lat_lng_for_projected_meters(meters, &roundtrip));
+    try expectLatLngApprox(center, roundtrip);
+}
+
+test "projected meters reject invalid arguments" {
+    var meters: c.mln_projected_meters = undefined;
+    var coordinate: c.mln_lat_lng = undefined;
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_projected_meters_for_lat_lng(center, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_projected_meters_for_lat_lng(.{ .latitude = 0.0, .longitude = std.math.inf(f64) }, &meters));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_lat_lng_for_projected_meters(.{ .northing = std.math.nan(f64), .easting = 0.0 }, &coordinate));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_lat_lng_for_projected_meters(.{ .northing = 0.0, .easting = 0.0 }, null));
+}


### PR DESCRIPTION
Add C ABI entry points for map projection, unprojection, and coordinate conversion. The implementation routes through the native map state and includes C tests for success, null, and edge cases.

Resolves #18 