### PR TITLE
Expose map render modes and requests

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "hverlin.mise-vscode",
     "okerew.shader-with-metal",
     "ziglang.vscode-zig",
-    "llvm-vs-code-extensions.vscode-clangd"
+    "llvm-vs-code-extensions.vscode-clangd",
+    "bierner.markdown-mermaid"
   ]
 }

--- a/examples/swift-map/Sources/SwiftMap/MapState.swift
+++ b/examples/swift-map/Sources/SwiftMap/MapState.swift
@@ -95,7 +95,8 @@ final class MapState {
     mapOptions.width = viewport.logicalWidth
     mapOptions.height = viewport.logicalHeight
     mapOptions.scale_factor = viewport.scaleFactor
-      try checkCAPI(mln_map_create(runtime, &mapOptions, &outMap), "map create failed")
+    mapOptions.map_mode = MLN_MAP_MODE_CONTINUOUS.rawValue
+    try checkCAPI(mln_map_create(runtime, &mapOptions, &outMap), "map create failed")
   }
 
   private static func loadStyle(map: OpaquePointer?) throws {

--- a/examples/zig-map/map_state.zig
+++ b/examples/zig-map/map_state.zig
@@ -24,6 +24,7 @@ pub const MapState = struct {
         map_options.width = viewport.logical_width;
         map_options.height = viewport.logical_height;
         map_options.scale_factor = viewport.scale_factor;
+        map_options.map_mode = c.MLN_MAP_MODE_CONTINUOUS;
         if (c.mln_map_create(runtime.?, &map_options, &map) != c.MLN_STATUS_OK or map == null) {
             diagnostics.logAbiError("map create failed");
             return types.AppError.MapCreateFailed;

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -602,6 +602,16 @@ typedef enum mln_camera_option_field {
   MLN_CAMERA_OPTION_PITCH = 1u << 3u,
 } mln_camera_option_field;
 
+/** Map rendering modes used when creating a map. */
+typedef enum mln_map_mode {
+  /** Continuously updates as data arrives and map state changes. */
+  MLN_MAP_MODE_CONTINUOUS = 0,
+  /** Produces one-off still renders of an arbitrary viewport. */
+  MLN_MAP_MODE_STATIC = 1,
+  /** Produces one-off still renders for a single tile. */
+  MLN_MAP_MODE_TILE = 2,
+} mln_map_mode;
+
 /** Map event types returned by mln_map_poll_event(). */
 typedef enum mln_map_event_type {
   MLN_MAP_EVENT_CAMERA_WILL_CHANGE = 1,
@@ -614,6 +624,8 @@ typedef enum mln_map_event_type {
   MLN_MAP_EVENT_MAP_IDLE = 8,
   MLN_MAP_EVENT_RENDER_INVALIDATED = 9,
   MLN_MAP_EVENT_RENDER_ERROR = 10,
+  MLN_MAP_EVENT_RENDER_REQUEST_FINISHED = 11,
+  MLN_MAP_EVENT_RENDER_REQUEST_FAILED = 12,
 } mln_map_event_type;
 
 /** Options used when creating a map. */
@@ -622,6 +634,8 @@ typedef struct mln_map_options {
   uint32_t width;
   uint32_t height;
   double scale_factor;
+  /** One of mln_map_mode. Defaults to MLN_MAP_MODE_CONTINUOUS. */
+  uint32_t map_mode;
 } mln_map_options;
 
 /** Camera fields used for snapshots and camera commands. */
@@ -675,6 +689,30 @@ MLN_API mln_camera_options mln_camera_options_default(void) MLN_NOEXCEPT;
 MLN_API mln_status mln_map_create(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) MLN_NOEXCEPT;
+
+/**
+ * Requests a render update for a map.
+ *
+ * In MLN_MAP_MODE_CONTINUOUS, this forces a repaint. Continuous maps also
+ * invalidate automatically when style data, resources, camera, and transitions
+ * change.
+ *
+ * In MLN_MAP_MODE_STATIC and MLN_MAP_MODE_TILE, this starts one still-render
+ * request. After calling it, pump the runtime, render invalidated updates into
+ * an attached render target, and poll events until
+ * MLN_MAP_EVENT_RENDER_REQUEST_FINISHED or MLN_MAP_EVENT_RENDER_REQUEST_FAILED
+ * is reported.
+ *
+ * Returns:
+ * - MLN_STATUS_OK when the request was accepted.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_INVALID_STATE when a static or tile render request is already
+ *   pending.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_request_render(mln_map* map) MLN_NOEXCEPT;
 
 /**
  * Destroys a map handle on its owner thread.
@@ -1023,8 +1061,9 @@ MLN_API mln_status mln_texture_resize(
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when texture is null or not live.
- * - MLN_STATUS_INVALID_STATE when no render update is available, the session is
- *   detached, or a frame is currently acquired.
+ * - MLN_STATUS_INVALID_STATE when no render update is available, the current
+ *   update does not produce a frame, the session is detached, or a frame is
+ *   currently acquired.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -27,6 +27,12 @@ auto mln_map_destroy(mln_map* map) noexcept -> mln_status {
   });
 }
 
+auto mln_map_request_render(mln_map* map) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_request_render(map);
+  });
+}
+
 auto mln_map_set_style_url(mln_map* map, const char* url) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -241,7 +241,46 @@ auto validate_map_options(const mln_map_options* options) -> mln_status {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
+  switch (options->map_mode) {
+    case MLN_MAP_MODE_CONTINUOUS:
+    case MLN_MAP_MODE_STATIC:
+    case MLN_MAP_MODE_TILE:
+      break;
+    default:
+      mln::core::set_thread_error("map_mode is invalid");
+      return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
   return MLN_STATUS_OK;
+}
+
+auto to_native_map_mode(uint32_t mode) -> mbgl::MapMode {
+  switch (mode) {
+    case MLN_MAP_MODE_STATIC:
+      return mbgl::MapMode::Static;
+    case MLN_MAP_MODE_TILE:
+      return mbgl::MapMode::Tile;
+    case MLN_MAP_MODE_CONTINUOUS:
+    default:
+      return mbgl::MapMode::Continuous;
+  }
+}
+
+auto is_still_map_mode(uint32_t mode) -> bool {
+  return mode == MLN_MAP_MODE_STATIC || mode == MLN_MAP_MODE_TILE;
+}
+
+auto exception_message(std::exception_ptr error) -> std::string {
+  if (!error) {
+    return {};
+  }
+  try {
+    std::rethrow_exception(error);
+  } catch (const std::exception& exception) {
+    return exception.what();
+  } catch (...) {
+    return "unknown render request error";
+  }
 }
 
 auto validate_camera_options(const mln_camera_options* camera) -> mln_status {
@@ -316,6 +355,8 @@ auto screen_point(mln_screen_point point) -> mbgl::ScreenCoordinate {
 struct mln_map {
   mln_runtime* runtime = nullptr;
   std::thread::id owner_thread;
+  uint32_t map_mode = MLN_MAP_MODE_CONTINUOUS;
+  bool render_request_pending = false;
   EventQueue events;
   std::unique_ptr<HeadlessObserver> observer;
   std::unique_ptr<HeadlessFrontend> frontend;
@@ -346,6 +387,17 @@ class RuntimeMapRetainGuard final {
   mln_runtime* runtime_ = nullptr;
 };
 
+auto finish_render_request(mln_map* map, std::exception_ptr error) -> void {
+  map->render_request_pending = false;
+  if (error) {
+    const auto message = exception_message(error);
+    map->events.push(MLN_MAP_EVENT_RENDER_REQUEST_FAILED, 0, message.c_str());
+    return;
+  }
+
+  map->events.push(MLN_MAP_EVENT_RENDER_REQUEST_FINISHED);
+}
+
 }  // namespace
 
 auto map_options_default() noexcept -> mln_map_options {
@@ -353,7 +405,8 @@ auto map_options_default() noexcept -> mln_map_options {
     .size = sizeof(mln_map_options),
     .width = default_map_width,
     .height = default_map_height,
-    .scale_factor = default_scale_factor
+    .scale_factor = default_scale_factor,
+    .map_mode = MLN_MAP_MODE_CONTINUOUS
   };
 }
 
@@ -415,11 +468,12 @@ auto create_map(
   auto owned_map = std::make_unique<mln_map>();
   owned_map->runtime = runtime;
   owned_map->owner_thread = std::this_thread::get_id();
+  owned_map->map_mode = effective.map_mode;
   owned_map->observer = std::make_unique<HeadlessObserver>(owned_map->events);
   owned_map->frontend = std::make_unique<HeadlessFrontend>(owned_map->events);
 
   auto map_options = mbgl::MapOptions{};
-  map_options.withMapMode(mbgl::MapMode::Continuous)
+  map_options.withMapMode(to_native_map_mode(effective.map_mode))
     .withSize(mbgl::Size{effective.width, effective.height})
     .withPixelRatio(static_cast<float>(effective.scale_factor));
   owned_map->map = std::make_unique<mbgl::Map>(
@@ -458,6 +512,29 @@ auto destroy_map(mln_map* map) -> mln_status {
   }
   owned_map.reset();
   release_runtime_map(runtime);
+  return MLN_STATUS_OK;
+}
+
+auto map_request_render(mln_map* map) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  if (!is_still_map_mode(map->map_mode)) {
+    map->map->triggerRepaint();
+    return MLN_STATUS_OK;
+  }
+
+  if (map->render_request_pending) {
+    set_thread_error("map already has a pending render request");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  map->render_request_pending = true;
+  map->map->renderStill([map](std::exception_ptr error) -> void {
+    finish_render_request(map, error);
+  });
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -19,6 +19,7 @@ auto create_map(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) -> mln_status;
 auto destroy_map(mln_map* map) -> mln_status;
+auto map_request_render(mln_map* map) -> mln_status;
 auto map_set_style_url(mln_map* map, const char* url) -> mln_status;
 auto map_set_style_json(mln_map* map, const char* json) -> mln_status;
 auto map_get_camera(mln_map* map, mln_camera_options* out_camera) -> mln_status;

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -354,8 +354,8 @@ auto texture_render(mln_texture_session* texture) -> mln_status {
   texture->renderer->render(update);
   texture->rendered_texture = texture->backend->metal_texture();
   if (texture->rendered_texture == nullptr) {
-    set_thread_error("render did not produce a Metal texture");
-    return MLN_STATUS_NATIVE_ERROR;
+    set_thread_error("render update did not produce a Metal texture");
+    return MLN_STATUS_INVALID_STATE;
   }
   texture->rendered_generation = texture->generation;
   return MLN_STATUS_OK;

--- a/tests/c/map_lifecycle.zig
+++ b/tests/c/map_lifecycle.zig
@@ -9,12 +9,17 @@ fn pollMapOnThread(map: *c.mln_map, out_status: *c.mln_status) void {
     out_status.* = c.mln_map_poll_event(map, &event, &has_event);
 }
 
+fn requestRenderOnThread(map: *c.mln_map, out_status: *c.mln_status) void {
+    out_status.* = c.mln_map_request_render(map);
+}
+
 test "map exposes default options" {
     const options = c.mln_map_options_default();
     try testing.expectEqual(@as(u32, @sizeOf(c.mln_map_options)), options.size);
     try testing.expect(options.width > 0);
     try testing.expect(options.height > 0);
     try testing.expect(options.scale_factor > 0);
+    try testing.expectEqual(@as(u32, c.MLN_MAP_MODE_CONTINUOUS), options.map_mode);
 }
 
 test "map create rejects invalid arguments" {
@@ -48,6 +53,10 @@ test "map create rejects invalid arguments" {
     invalid_options = c.mln_map_options_default();
     invalid_options.scale_factor = 0;
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_create(runtime, &invalid_options, &map));
+
+    invalid_options = c.mln_map_options_default();
+    invalid_options.map_mode = 999;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_create(runtime, &invalid_options, &map));
 }
 
 test "map lifecycle rejects invalid state and stale handles" {
@@ -59,6 +68,7 @@ test "map lifecycle rejects invalid state and stale handles" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_destroy(map));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_destroy(map));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_style_json(map, support.style_json));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_request_render(map));
 
     var camera = c.mln_camera_options_default();
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_camera(map, &camera));
@@ -68,6 +78,18 @@ test "map lifecycle rejects invalid state and stale handles" {
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_poll_event(map, &event, &has_event));
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_destroy(runtime));
+}
+
+test "continuous render request invalidates map" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    _ = try support.drainEvents(map);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_request_render(map));
+    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_RENDER_INVALIDATED));
 }
 
 test "runtime supports multiple maps" {
@@ -93,6 +115,11 @@ test "map rejects wrong-thread calls" {
     var status: c.mln_status = c.MLN_STATUS_OK;
     const thread = try std.Thread.spawn(.{}, pollMapOnThread, .{ map, &status });
     thread.join();
+
+    try testing.expectEqual(c.MLN_STATUS_WRONG_THREAD, status);
+
+    const request_thread = try std.Thread.spawn(.{}, requestRenderOnThread, .{ map, &status });
+    request_thread.join();
 
     try testing.expectEqual(c.MLN_STATUS_WRONG_THREAD, status);
 }

--- a/tests/c/support.zig
+++ b/tests/c/support.zig
@@ -41,10 +41,15 @@ pub fn createRuntime() !*c.mln_runtime {
 }
 
 pub fn createMap(runtime: *c.mln_runtime) !*c.mln_map {
+    return createMapWithMode(runtime, c.MLN_MAP_MODE_CONTINUOUS);
+}
+
+pub fn createMapWithMode(runtime: *c.mln_runtime, map_mode: u32) !*c.mln_map {
     var map: ?*c.mln_map = null;
     var options = c.mln_map_options_default();
     options.width = 512;
     options.height = 512;
+    options.map_mode = map_mode;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_create(runtime, &options, &map));
     return map orelse error.MapCreateFailed;
 }

--- a/tests/c/texture.zig
+++ b/tests/c/texture.zig
@@ -3,6 +3,8 @@ const testing = std.testing;
 const support = @import("support.zig");
 const c = support.c;
 
+extern fn usleep(useconds: c_uint) c_int;
+
 const ThreadCall = enum { resize, render, acquire, release, detach, destroy };
 
 pub fn expectDescriptorDefaults() !void {
@@ -190,6 +192,60 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     try Backend.expectResizedFrame(&frame);
     try testing.expectEqual(c.MLN_STATUS_OK, fixture.release(&frame));
     frame_acquired = false;
+}
+
+pub fn expectStillModeRenderRequest(comptime Backend: type, map_mode: u32) !void {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMapWithMode(runtime, map_mode);
+    defer support.destroyMap(map);
+    var fixture = try Backend.Fixture.create(map);
+    defer fixture.destroy();
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_render(fixture.texture));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_request_render(map));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_map_request_render(map));
+
+    var rendered_frame = false;
+    for (0..1000) |_| {
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_once(runtime));
+
+        while (true) {
+            var event = support.emptyEvent();
+            var has_event = false;
+            try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_poll_event(map, &event, &has_event));
+            if (!has_event) break;
+
+            switch (event.type) {
+                c.MLN_MAP_EVENT_RENDER_INVALIDATED => {
+                    const render_status = c.mln_texture_render(fixture.texture);
+                    if (render_status == c.MLN_STATUS_OK) {
+                        rendered_frame = true;
+                    } else if (render_status != c.MLN_STATUS_INVALID_STATE) {
+                        try testing.expectEqual(c.MLN_STATUS_OK, render_status);
+                    }
+                },
+                c.MLN_MAP_EVENT_RENDER_REQUEST_FINISHED => {
+                    try testing.expect(rendered_frame);
+                    var frame = Backend.Frame.empty(fixture.texture);
+                    try testing.expectEqual(c.MLN_STATUS_OK, fixture.acquire(&frame));
+                    try Backend.expectInitialFrame(&frame);
+                    try testing.expectEqual(c.MLN_STATUS_OK, fixture.release(&frame));
+                    return;
+                },
+                c.MLN_MAP_EVENT_RENDER_REQUEST_FAILED => return error.RenderRequestFailed,
+                else => {},
+            }
+        }
+
+        _ = usleep(1000);
+    }
+    return error.EventNotFound;
 }
 
 pub fn expectDetachLeavesHandleLiveButUnusable(comptime Backend: type) !void {

--- a/tests/c/texture_metal.zig
+++ b/tests/c/texture_metal.zig
@@ -170,6 +170,16 @@ test "Metal texture render acquire release and resize generation" {
     try common.expectRenderAcquireReleaseAndResizeGeneration(Backend);
 }
 
+test "Metal texture supports static render requests" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try common.expectStillModeRenderRequest(Backend, c.MLN_MAP_MODE_STATIC);
+}
+
+test "Metal texture supports tile render requests" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try common.expectStillModeRenderRequest(Backend, c.MLN_MAP_MODE_TILE);
+}
+
 test "Metal texture detach leaves handle live but unusable for rendering" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
     try common.expectDetachLeavesHandleLiveButUnusable(Backend);

--- a/tests/c/texture_vulkan.zig
+++ b/tests/c/texture_vulkan.zig
@@ -267,6 +267,16 @@ test "Vulkan texture render acquire release and resize generation" {
     try common.expectRenderAcquireReleaseAndResizeGeneration(Backend);
 }
 
+test "Vulkan texture supports static render requests" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    try common.expectStillModeRenderRequest(Backend, c.MLN_MAP_MODE_STATIC);
+}
+
+test "Vulkan texture supports tile render requests" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    try common.expectStillModeRenderRequest(Backend, c.MLN_MAP_MODE_TILE);
+}
+
 test "Vulkan texture detach leaves handle live but unusable for rendering" {
     if (builtin.os.tag != .linux) return error.SkipZigTest;
     try common.expectDetachLeavesHandleLiveButUnusable(Backend);


### PR DESCRIPTION
Expose render mode selection and explicit render requests through the C ABI. This lets callers drive continuous or on-demand rendering while tests cover lifecycle and texture render paths.

Resolves #65 