### PR TITLE
Clarify render lifecycle API

### DIFF
--- a/examples/swift-map/Sources/SwiftMap/MapState.swift
+++ b/examples/swift-map/Sources/SwiftMap/MapState.swift
@@ -57,21 +57,21 @@ final class MapState {
   }
 
   func drainEvents() throws -> Bool {
-    var renderInvalidated = false
+    var renderUpdateAvailable = false
     while true {
       var event = mln_map_event()
       event.size = UInt32(MemoryLayout<mln_map_event>.size)
       var hasEvent = false
       try checkCAPI(mln_map_poll_event(map, &event, &hasEvent), "event poll failed")
-      if !hasEvent { return renderInvalidated }
-      if event.type == MLN_MAP_EVENT_RENDER_INVALIDATED.rawValue {
-        renderInvalidated = true
+      if !hasEvent { return renderUpdateAvailable }
+      if event.type == MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE.rawValue {
+        renderUpdateAvailable = true
       }
     }
   }
 
   func render() throws -> Bool {
-    let status = mln_texture_render(texture)
+    let status = mln_texture_render_update(texture)
     if status == MLN_STATUS_OK { return true }
     if status == MLN_STATUS_INVALID_STATE { return false }
     try checkCAPI(status, "texture render failed")

--- a/examples/zig-map/main.zig
+++ b/examples/zig-map/main.zig
@@ -91,14 +91,14 @@ pub fn main(init_args: std.process.Init) !void {
         }
 
         _ = c.mln_runtime_run_once(map.runtime);
-        const render_invalidated = try map_state.drainEvents(map.map);
-        render_pending = render_pending or render_invalidated;
-        did_work = did_work or render_invalidated;
+        const render_update_available = try map_state.drainEvents(map.map);
+        render_pending = render_pending or render_update_available;
+        did_work = did_work or render_update_available;
 
         try backend.finishFrame();
 
         if (render_pending) {
-            const render_status = c.mln_texture_render(map.texture);
+            const render_status = c.mln_texture_render_update(map.texture);
             if (render_status == c.MLN_STATUS_OK) {
                 render_pending = false;
                 did_work = true;

--- a/examples/zig-map/map_state.zig
+++ b/examples/zig-map/map_state.zig
@@ -58,7 +58,7 @@ pub const MapState = struct {
 };
 
 pub fn drainEvents(map: *c.mln_map) !bool {
-    var render_invalidated = false;
+    var render_update_available = false;
     while (true) {
         var event: c.mln_map_event = .{
             .size = @sizeOf(c.mln_map_event),
@@ -72,8 +72,8 @@ pub fn drainEvents(map: *c.mln_map) !bool {
             diagnostics.logAbiError("event poll failed");
             return types.AppError.TextureRenderFailed;
         }
-        if (!has_event) return render_invalidated;
-        if (event.type == c.MLN_MAP_EVENT_RENDER_INVALIDATED) render_invalidated = true;
+        if (!has_event) return render_update_available;
+        if (event.type == c.MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE) render_update_available = true;
     }
 }
 

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -616,9 +616,9 @@ typedef enum mln_projection_mode_field : uint32_t {
 typedef enum mln_map_mode : uint32_t {
   /** Continuously updates as data arrives and map state changes. */
   MLN_MAP_MODE_CONTINUOUS = 0,
-  /** Produces one-off still renders of an arbitrary viewport. */
+  /** Produces one-off still images of an arbitrary viewport. */
   MLN_MAP_MODE_STATIC = 1,
-  /** Produces one-off still renders for a single tile. */
+  /** Produces one-off still images for a single tile. */
   MLN_MAP_MODE_TILE = 2,
 } mln_map_mode;
 
@@ -632,10 +632,10 @@ typedef enum mln_map_event_type : uint32_t {
   MLN_MAP_EVENT_MAP_LOADING_FINISHED = 6,
   MLN_MAP_EVENT_MAP_LOADING_FAILED = 7,
   MLN_MAP_EVENT_MAP_IDLE = 8,
-  MLN_MAP_EVENT_RENDER_INVALIDATED = 9,
+  MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE = 9,
   MLN_MAP_EVENT_RENDER_ERROR = 10,
-  MLN_MAP_EVENT_RENDER_REQUEST_FINISHED = 11,
-  MLN_MAP_EVENT_RENDER_REQUEST_FAILED = 12,
+  MLN_MAP_EVENT_STILL_IMAGE_FINISHED = 11,
+  MLN_MAP_EVENT_STILL_IMAGE_FAILED = 12,
 } mln_map_event_type;
 
 /** Options used when creating a map. */
@@ -746,28 +746,47 @@ MLN_API mln_status mln_map_create(
 ) MLN_NOEXCEPT;
 
 /**
- * Requests a render update for a map.
+ * Requests a repaint for a continuous map.
  *
- * In MLN_MAP_MODE_CONTINUOUS, this forces a repaint. Continuous maps also
- * invalidate automatically when style data, resources, camera, and transitions
- * change.
- *
- * In MLN_MAP_MODE_STATIC and MLN_MAP_MODE_TILE, this starts one still-render
- * request. After calling it, pump the runtime, render invalidated updates into
- * an attached render target, and poll events until
- * MLN_MAP_EVENT_RENDER_REQUEST_FINISHED or MLN_MAP_EVENT_RENDER_REQUEST_FAILED
- * is reported.
+ * Continuous maps also invalidate automatically when style data, resources,
+ * camera, or transitions change. Ask attached render targets to process the
+ * latest update when MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE is reported. Repaint
+ * requests do not produce MLN_MAP_EVENT_STILL_IMAGE_FINISHED or
+ * MLN_MAP_EVENT_STILL_IMAGE_FAILED events.
  *
  * Returns:
  * - MLN_STATUS_OK when the request was accepted.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
- * - MLN_STATUS_INVALID_STATE when a static or tile render request is already
- *   pending.
+ * - MLN_STATUS_INVALID_STATE when map is not in MLN_MAP_MODE_CONTINUOUS.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
-MLN_API mln_status mln_map_request_render(mln_map* map) MLN_NOEXCEPT;
+MLN_API mln_status mln_map_request_repaint(mln_map* map) MLN_NOEXCEPT;
+
+/**
+ * Requests one still image for a static or tile map.
+ *
+ * Pump the runtime and poll map events until
+ * MLN_MAP_EVENT_STILL_IMAGE_FINISHED or MLN_MAP_EVENT_STILL_IMAGE_FAILED is
+ * reported. While the request is pending, ask the attached render target to
+ * process the latest update whenever MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE is
+ * reported. Texture targets do this with mln_texture_render_update(), which can
+ * return MLN_STATUS_INVALID_STATE when no frame is produced for that update.
+ * Keep pumping and polling in that case. After
+ * MLN_MAP_EVENT_STILL_IMAGE_FINISHED, acquire the frame produced by the most
+ * recent successful target update.
+ *
+ * Returns:
+ * - MLN_STATUS_OK when the request was accepted.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_INVALID_STATE when map is not in MLN_MAP_MODE_STATIC or
+ *   MLN_MAP_MODE_TILE, or when a still-image request is already pending.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_request_still_image(mln_map* map) MLN_NOEXCEPT;
 
 /**
  * Destroys a map handle on its owner thread.
@@ -1395,10 +1414,11 @@ MLN_API mln_status mln_texture_resize(
 ) MLN_NOEXCEPT;
 
 /**
- * Renders the latest map update into the offscreen texture session.
+ * Processes the latest map render update for an offscreen texture session.
  *
- * A successful render makes a frame available to the backend-specific acquire
- * function for the same session generation.
+ * When the update produces a frame, this renders into the texture and makes a
+ * frame available to the backend-specific acquire function for the same session
+ * generation.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -1411,15 +1431,15 @@ MLN_API mln_status mln_texture_resize(
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status
-mln_texture_render(mln_texture_session* texture) MLN_NOEXCEPT;
+mln_texture_render_update(mln_texture_session* texture) MLN_NOEXCEPT;
 
 /**
  * Acquires the most recently rendered Metal texture frame.
  *
  * The returned texture and device pointers are borrowed and remain valid only
  * until mln_metal_texture_release_frame() is called for the same frame. While
- * acquired, resize, render, detach, destroy, and a second acquire return
- * MLN_STATUS_INVALID_STATE.
+ * acquired, resize, mln_texture_render_update(), detach, destroy, and a second
+ * acquire return MLN_STATUS_INVALID_STATE.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -1442,8 +1462,8 @@ MLN_API mln_status mln_metal_texture_acquire_frame(
  *
  * The returned image, image view, and device pointers are borrowed and remain
  * valid only until mln_vulkan_texture_release_frame() is called for the same
- * frame. While acquired, resize, render, detach, destroy, and a second acquire
- * return MLN_STATUS_INVALID_STATE.
+ * frame. While acquired, resize, mln_texture_render_update(), detach, destroy,
+ * and a second acquire return MLN_STATUS_INVALID_STATE.
  *
  * On success, the image has been rendered and made available in the returned
  * layout for shader sampling through the returned image view until release.

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -33,9 +33,15 @@ auto mln_map_destroy(mln_map* map) noexcept -> mln_status {
   });
 }
 
-auto mln_map_request_render(mln_map* map) noexcept -> mln_status {
+auto mln_map_request_repaint(mln_map* map) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::map_request_render(map);
+    return mln::core::map_request_repaint(map);
+  });
+}
+
+auto mln_map_request_still_image(mln_map* map) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_request_still_image(map);
   });
 }
 

--- a/src/c_api/texture.cpp
+++ b/src/c_api/texture.cpp
@@ -43,9 +43,10 @@ auto mln_texture_resize(
   });
 }
 
-auto mln_texture_render(mln_texture_session* texture) noexcept -> mln_status {
+auto mln_texture_render_update(mln_texture_session* texture) noexcept
+  -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::texture_render(texture);
+    return mln::core::texture_render_update(texture);
   });
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -216,7 +216,7 @@ class HeadlessFrontend final : public mbgl::RendererFrontend {
   void update(std::shared_ptr<mbgl::UpdateParameters> update) override {
     const std::scoped_lock lock(latest_update_mutex_);
     latest_update_ = std::move(update);
-    events_->push(MLN_MAP_EVENT_RENDER_INVALIDATED);
+    events_->push(MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE);
   }
 
   [[nodiscard]] auto latest_update() const
@@ -302,7 +302,7 @@ auto exception_message(std::exception_ptr error) -> std::string {
   } catch (const std::exception& exception) {
     return exception.what();
   } catch (...) {
-    return "unknown render request error";
+    return "unknown still-image request error";
   }
 }
 
@@ -591,7 +591,7 @@ struct mln_map {
   mln_runtime* runtime = nullptr;
   std::thread::id owner_thread;
   uint32_t map_mode = MLN_MAP_MODE_CONTINUOUS;
-  bool render_request_pending = false;
+  bool still_image_request_pending = false;
   EventQueue events;
   std::unique_ptr<HeadlessObserver> observer;
   std::unique_ptr<HeadlessFrontend> frontend;
@@ -627,15 +627,16 @@ class RuntimeMapRetainGuard final {
   mln_runtime* runtime_ = nullptr;
 };
 
-auto finish_render_request(mln_map* map, std::exception_ptr error) -> void {
-  map->render_request_pending = false;
+auto finish_still_image_request(mln_map* map, std::exception_ptr error)
+  -> void {
+  map->still_image_request_pending = false;
   if (error) {
     const auto message = exception_message(error);
-    map->events.push(MLN_MAP_EVENT_RENDER_REQUEST_FAILED, 0, message.c_str());
+    map->events.push(MLN_MAP_EVENT_STILL_IMAGE_FAILED, 0, message.c_str());
     return;
   }
 
-  map->events.push(MLN_MAP_EVENT_RENDER_REQUEST_FINISHED);
+  map->events.push(MLN_MAP_EVENT_STILL_IMAGE_FINISHED);
 }
 
 }  // namespace
@@ -785,25 +786,40 @@ auto destroy_map(mln_map* map) -> mln_status {
   return MLN_STATUS_OK;
 }
 
-auto map_request_render(mln_map* map) -> mln_status {
+auto map_request_repaint(mln_map* map) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  if (map->map_mode != MLN_MAP_MODE_CONTINUOUS) {
+    set_thread_error("map is not in continuous mode");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  map->map->triggerRepaint();
+  return MLN_STATUS_OK;
+}
+
+auto map_request_still_image(mln_map* map) -> mln_status {
   const auto status = validate_map(map);
   if (status != MLN_STATUS_OK) {
     return status;
   }
 
   if (!is_still_map_mode(map->map_mode)) {
-    map->map->triggerRepaint();
-    return MLN_STATUS_OK;
-  }
-
-  if (map->render_request_pending) {
-    set_thread_error("map already has a pending render request");
+    set_thread_error("map is not in static or tile mode");
     return MLN_STATUS_INVALID_STATE;
   }
 
-  map->render_request_pending = true;
+  if (map->still_image_request_pending) {
+    set_thread_error("map already has a pending still-image request");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  map->still_image_request_pending = true;
   map->map->renderStill([map](std::exception_ptr error) -> void {
-    finish_render_request(map, error);
+    finish_still_image_request(map, error);
   });
   return MLN_STATUS_OK;
 }

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -21,7 +21,8 @@ auto create_map(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) -> mln_status;
 auto destroy_map(mln_map* map) -> mln_status;
-auto map_request_render(mln_map* map) -> mln_status;
+auto map_request_repaint(mln_map* map) -> mln_status;
+auto map_request_still_image(mln_map* map) -> mln_status;
 auto map_set_style_url(mln_map* map, const char* url) -> mln_status;
 auto map_set_style_json(mln_map* map, const char* json) -> mln_status;
 auto map_get_camera(mln_map* map, mln_camera_options* out_camera) -> mln_status;

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -324,7 +324,7 @@ auto texture_resize(
   return MLN_STATUS_OK;
 }
 
-auto texture_render(mln_texture_session* texture) -> mln_status {
+auto texture_render_update(mln_texture_session* texture) -> mln_status {
   const auto status = validate_live_attached_texture(texture);
   if (status != MLN_STATUS_OK) {
     return status;

--- a/src/render/texture_session.hpp
+++ b/src/render/texture_session.hpp
@@ -22,7 +22,7 @@ auto texture_resize(
   mln_texture_session* texture, uint32_t width, uint32_t height,
   double scale_factor
 ) -> mln_status;
-auto texture_render(mln_texture_session* texture) -> mln_status;
+auto texture_render_update(mln_texture_session* texture) -> mln_status;
 auto metal_texture_acquire_frame(
   mln_texture_session* texture, mln_metal_texture_frame* out_frame
 ) -> mln_status;

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -370,7 +370,7 @@ auto texture_resize(
   return MLN_STATUS_OK;
 }
 
-auto texture_render(mln_texture_session* texture) -> mln_status {
+auto texture_render_update(mln_texture_session* texture) -> mln_status {
   const auto status = validate_live_attached_texture(texture);
   if (status != MLN_STATUS_OK) {
     return status;

--- a/tests/c/map_lifecycle.zig
+++ b/tests/c/map_lifecycle.zig
@@ -9,8 +9,8 @@ fn pollMapOnThread(map: *c.mln_map, out_status: *c.mln_status) void {
     out_status.* = c.mln_map_poll_event(map, &event, &has_event);
 }
 
-fn requestRenderOnThread(map: *c.mln_map, out_status: *c.mln_status) void {
-    out_status.* = c.mln_map_request_render(map);
+fn requestRepaintOnThread(map: *c.mln_map, out_status: *c.mln_status) void {
+    out_status.* = c.mln_map_request_repaint(map);
 }
 
 test "map exposes default options" {
@@ -68,7 +68,8 @@ test "map lifecycle rejects invalid state and stale handles" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_destroy(map));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_destroy(map));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_style_json(map, support.style_json));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_request_render(map));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_request_repaint(map));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_request_still_image(map));
 
     var camera = c.mln_camera_options_default();
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_camera(map, &camera));
@@ -80,7 +81,7 @@ test "map lifecycle rejects invalid state and stale handles" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_destroy(runtime));
 }
 
-test "continuous render request invalidates map" {
+test "continuous repaint request makes render update available" {
     const runtime = try support.createRuntime();
     defer support.destroyRuntime(runtime);
 
@@ -88,8 +89,9 @@ test "continuous render request invalidates map" {
     defer support.destroyMap(map);
 
     _ = try support.drainEvents(map);
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_request_render(map));
-    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_RENDER_INVALIDATED));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_map_request_still_image(map));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_request_repaint(map));
+    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE));
 }
 
 test "runtime supports multiple maps" {
@@ -118,7 +120,7 @@ test "map rejects wrong-thread calls" {
 
     try testing.expectEqual(c.MLN_STATUS_WRONG_THREAD, status);
 
-    const request_thread = try std.Thread.spawn(.{}, requestRenderOnThread, .{ map, &status });
+    const request_thread = try std.Thread.spawn(.{}, requestRepaintOnThread, .{ map, &status });
     request_thread.join();
 
     try testing.expectEqual(c.MLN_STATUS_WRONG_THREAD, status);

--- a/tests/c/texture.zig
+++ b/tests/c/texture.zig
@@ -5,7 +5,7 @@ const c = support.c;
 
 extern fn usleep(useconds: c_uint) c_int;
 
-const ThreadCall = enum { resize, render, acquire, release, detach, destroy };
+const ThreadCall = enum { resize, render_update, acquire, release, detach, destroy };
 
 pub fn expectDescriptorDefaults() !void {
     const metal = c.mln_metal_texture_descriptor_default();
@@ -88,7 +88,7 @@ pub fn expectLifecycleEnforcesActiveSessionAndStaleHandles(comptime Backend: typ
 
     fixture.destroy();
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_texture_destroy(fixture.texture));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_texture_render(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_texture_render_update(fixture.texture));
 
     var replacement = try Backend.Fixture.create(map);
     replacement.destroy();
@@ -105,7 +105,7 @@ pub fn expectWrongThreadCallsRejected(comptime Backend: type) !void {
         fn callTextureOnThread(args: ThreadCallArgs) void {
             args.out_status.* = switch (args.call) {
                 .resize => c.mln_texture_resize(args.fixture.texture, 128, 128, 1.0),
-                .render => c.mln_texture_render(args.fixture.texture),
+                .render_update => c.mln_texture_render_update(args.fixture.texture),
                 .acquire => args.fixture.acquire(args.frame),
                 .release => args.fixture.release(args.frame),
                 .detach => c.mln_texture_detach(args.fixture.texture),
@@ -114,7 +114,7 @@ pub fn expectWrongThreadCallsRejected(comptime Backend: type) !void {
         }
 
         fn renderTextureOnThread(texture: *c.mln_texture_session, out_status: *c.mln_status) void {
-            out_status.* = c.mln_texture_render(texture);
+            out_status.* = c.mln_texture_render_update(texture);
         }
     };
 
@@ -155,9 +155,9 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, fixture.acquire(&frame));
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
-    _ = try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_RENDER_INVALIDATED);
+    _ = try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE);
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(fixture.texture));
     try testing.expectEqual(c.MLN_STATUS_OK, fixture.acquire(&frame));
     var frame_acquired = true;
     errdefer {
@@ -184,7 +184,7 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_resize(fixture.texture, 128, 64, 2.0));
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, fixture.release(&old_frame));
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(fixture.texture));
     frame.resetSize();
     try testing.expectEqual(c.MLN_STATUS_OK, fixture.acquire(&frame));
     frame_acquired = true;
@@ -194,7 +194,7 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     frame_acquired = false;
 }
 
-pub fn expectStillModeRenderRequest(comptime Backend: type, map_mode: u32) !void {
+pub fn expectStillModeStillImageRequest(comptime Backend: type, map_mode: u32) !void {
     try support.suppressLogs();
     defer support.restoreLogs();
 
@@ -206,10 +206,11 @@ pub fn expectStillModeRenderRequest(comptime Backend: type, map_mode: u32) !void
     defer fixture.destroy();
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_render(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_render_update(fixture.texture));
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_request_render(map));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_map_request_render(map));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_map_request_repaint(map));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_request_still_image(map));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_map_request_still_image(map));
 
     var rendered_frame = false;
     for (0..1000) |_| {
@@ -222,15 +223,15 @@ pub fn expectStillModeRenderRequest(comptime Backend: type, map_mode: u32) !void
             if (!has_event) break;
 
             switch (event.type) {
-                c.MLN_MAP_EVENT_RENDER_INVALIDATED => {
-                    const render_status = c.mln_texture_render(fixture.texture);
+                c.MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE => {
+                    const render_status = c.mln_texture_render_update(fixture.texture);
                     if (render_status == c.MLN_STATUS_OK) {
                         rendered_frame = true;
                     } else if (render_status != c.MLN_STATUS_INVALID_STATE) {
                         try testing.expectEqual(c.MLN_STATUS_OK, render_status);
                     }
                 },
-                c.MLN_MAP_EVENT_RENDER_REQUEST_FINISHED => {
+                c.MLN_MAP_EVENT_STILL_IMAGE_FINISHED => {
                     try testing.expect(rendered_frame);
                     var frame = Backend.Frame.empty(fixture.texture);
                     try testing.expectEqual(c.MLN_STATUS_OK, fixture.acquire(&frame));
@@ -238,7 +239,7 @@ pub fn expectStillModeRenderRequest(comptime Backend: type, map_mode: u32) !void
                     try testing.expectEqual(c.MLN_STATUS_OK, fixture.release(&frame));
                     return;
                 },
-                c.MLN_MAP_EVENT_RENDER_REQUEST_FAILED => return error.RenderRequestFailed,
+                c.MLN_MAP_EVENT_STILL_IMAGE_FAILED => return error.StillImageFailed,
                 else => {},
             }
         }
@@ -257,7 +258,7 @@ pub fn expectDetachLeavesHandleLiveButUnusable(comptime Backend: type) !void {
     defer fixture.deinitContextOnly();
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_detach(fixture.texture));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_render(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_render_update(fixture.texture));
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_detach(fixture.texture));
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(fixture.texture));
     fixture.markDestroyed();

--- a/tests/c/texture_metal.zig
+++ b/tests/c/texture_metal.zig
@@ -170,14 +170,14 @@ test "Metal texture render acquire release and resize generation" {
     try common.expectRenderAcquireReleaseAndResizeGeneration(Backend);
 }
 
-test "Metal texture supports static render requests" {
+test "Metal texture supports static still-image requests" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
-    try common.expectStillModeRenderRequest(Backend, c.MLN_MAP_MODE_STATIC);
+    try common.expectStillModeStillImageRequest(Backend, c.MLN_MAP_MODE_STATIC);
 }
 
-test "Metal texture supports tile render requests" {
+test "Metal texture supports tile still-image requests" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
-    try common.expectStillModeRenderRequest(Backend, c.MLN_MAP_MODE_TILE);
+    try common.expectStillModeStillImageRequest(Backend, c.MLN_MAP_MODE_TILE);
 }
 
 test "Metal texture detach leaves handle live but unusable for rendering" {

--- a/tests/c/texture_vulkan.zig
+++ b/tests/c/texture_vulkan.zig
@@ -267,14 +267,14 @@ test "Vulkan texture render acquire release and resize generation" {
     try common.expectRenderAcquireReleaseAndResizeGeneration(Backend);
 }
 
-test "Vulkan texture supports static render requests" {
+test "Vulkan texture supports static still-image requests" {
     if (builtin.os.tag != .linux) return error.SkipZigTest;
-    try common.expectStillModeRenderRequest(Backend, c.MLN_MAP_MODE_STATIC);
+    try common.expectStillModeStillImageRequest(Backend, c.MLN_MAP_MODE_STATIC);
 }
 
-test "Vulkan texture supports tile render requests" {
+test "Vulkan texture supports tile still-image requests" {
     if (builtin.os.tag != .linux) return error.SkipZigTest;
-    try common.expectStillModeRenderRequest(Backend, c.MLN_MAP_MODE_TILE);
+    try common.expectStillModeStillImageRequest(Backend, c.MLN_MAP_MODE_TILE);
 }
 
 test "Vulkan texture detach leaves handle live but unusable for rendering" {


### PR DESCRIPTION
Rename render lifecycle types and callbacks to make the C ABI intent clearer. This updates examples, tests, and render backends to use the clarified naming consistently.

Relates to #65 