### PR TITLE
Move event delivery to runtime

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,9 +13,9 @@ snapshotting and platform integrations such as gestures and device sensors.
 Language bindings sit directly above the C API. They manage C handles, struct
 initialization, scoped lifetimes, status codes, diagnostics, borrowed data,
 events, threading, and event draining in the target language. They do not aim to
-provide fully idiomatic APIs, higher-level async models over map events, view
-lifecycle integrations, convenience workflows, or new abstractions beyond the C
-API's concepts.
+provide fully idiomatic APIs, higher-level async models over runtime events,
+view lifecycle integrations, convenience workflows, or new abstractions beyond
+the C API's concepts.
 
 ## Code Layout
 
@@ -77,7 +77,7 @@ entry points use the C API boundary helper to clear thread-local diagnostics on
 entry and convert exceptions to `MLN_STATUS_NATIVE_ERROR`.
 
 Set thread-local diagnostic strings for synchronous non-OK returns. Report
-asynchronous native failures through copied map events.
+asynchronous native failures through copied runtime events.
 
 ## Ownership And Lifetime
 
@@ -117,8 +117,9 @@ Preserve MapLibre Native's imperative, observer-driven model. C API calls return
 status for synchronous acceptance or failure. Later native work is reported
 through drained events.
 
-Map events are copied into map-owned storage and drained with C API calls. Event
-payloads use plain data with documented lifetimes.
+Events are copied into runtime-owned storage and drained with C API calls. Event
+payloads use plain data with documented lifetimes. Each event identifies its
+source kind and source handle.
 
 Classify each operation as one of:
 

--- a/examples/swift-map/Sources/SwiftMap/MapState.swift
+++ b/examples/swift-map/Sources/SwiftMap/MapState.swift
@@ -59,12 +59,15 @@ final class MapState {
   func drainEvents() throws -> Bool {
     var renderUpdateAvailable = false
     while true {
-      var event = mln_map_event()
-      event.size = UInt32(MemoryLayout<mln_map_event>.size)
+      var event = mln_runtime_event()
+      event.size = UInt32(MemoryLayout<mln_runtime_event>.size)
       var hasEvent = false
-      try checkCAPI(mln_map_poll_event(map, &event, &hasEvent), "event poll failed")
+      try checkCAPI(mln_runtime_poll_event(runtime, &event, &hasEvent), "event poll failed")
       if !hasEvent { return renderUpdateAvailable }
-      if event.type == MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE.rawValue {
+      if event.source_type == MLN_RUNTIME_EVENT_SOURCE_MAP.rawValue
+        && event.source == UnsafeMutableRawPointer(map)
+        && event.type == MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE.rawValue
+      {
         renderUpdateAvailable = true
       }
     }

--- a/examples/zig-map/main.zig
+++ b/examples/zig-map/main.zig
@@ -91,7 +91,7 @@ pub fn main(init_args: std.process.Init) !void {
         }
 
         _ = c.mln_runtime_run_once(map.runtime);
-        const render_update_available = try map_state.drainEvents(map.map);
+        const render_update_available = try map_state.drainEvents(map.runtime, map.map);
         render_pending = render_pending or render_update_available;
         did_work = did_work or render_update_available;
 

--- a/examples/zig-map/map_state.zig
+++ b/examples/zig-map/map_state.zig
@@ -57,23 +57,30 @@ pub const MapState = struct {
     }
 };
 
-pub fn drainEvents(map: *c.mln_map) !bool {
+pub fn drainEvents(runtime: *c.mln_runtime, map: *c.mln_map) !bool {
     var render_update_available = false;
     while (true) {
-        var event: c.mln_map_event = .{
-            .size = @sizeOf(c.mln_map_event),
+        var event: c.mln_runtime_event = .{
+            .size = @sizeOf(c.mln_runtime_event),
             .type = 0,
+            .source_type = c.MLN_RUNTIME_EVENT_SOURCE_RUNTIME,
+            .source = null,
             .code = 0,
+            .payload_type = c.MLN_RUNTIME_EVENT_PAYLOAD_NONE,
+            .payload = null,
+            .payload_size = 0,
             .message = null,
             .message_size = 0,
         };
         var has_event = false;
-        if (c.mln_map_poll_event(map, &event, &has_event) != c.MLN_STATUS_OK) {
+        if (c.mln_runtime_poll_event(runtime, &event, &has_event) != c.MLN_STATUS_OK) {
             diagnostics.logAbiError("event poll failed");
             return types.AppError.TextureRenderFailed;
         }
         if (!has_event) return render_update_available;
-        if (event.type == c.MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE) render_update_available = true;
+        if (event.source_type == c.MLN_RUNTIME_EVENT_SOURCE_MAP and
+            event.source == @as(?*anyopaque, @ptrCast(map)) and
+            event.type == c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE) render_update_available = true;
     }
 }
 

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -9,7 +9,7 @@
  * Status-returning functions clear thread-local diagnostics on entry. After a
  * synchronous failure status is returned, read
  * mln_thread_last_error_message() on the same thread before making another C
- * API call. Asynchronous native failures are reported through map events.
+ * API call. Asynchronous native failures are reported through runtime events.
  *
  * This header targets C23.
  */
@@ -219,6 +219,33 @@ typedef enum mln_ambient_cache_operation : uint32_t {
   MLN_AMBIENT_CACHE_OPERATION_CLEAR = 4,
 } mln_ambient_cache_operation;
 
+/** Runtime event types returned by mln_runtime_poll_event(). */
+typedef enum mln_runtime_event_type : uint32_t {
+  MLN_RUNTIME_EVENT_MAP_CAMERA_WILL_CHANGE = 1,
+  MLN_RUNTIME_EVENT_MAP_CAMERA_IS_CHANGING = 2,
+  MLN_RUNTIME_EVENT_MAP_CAMERA_DID_CHANGE = 3,
+  MLN_RUNTIME_EVENT_MAP_STYLE_LOADED = 4,
+  MLN_RUNTIME_EVENT_MAP_LOADING_STARTED = 5,
+  MLN_RUNTIME_EVENT_MAP_LOADING_FINISHED = 6,
+  MLN_RUNTIME_EVENT_MAP_LOADING_FAILED = 7,
+  MLN_RUNTIME_EVENT_MAP_IDLE = 8,
+  MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE = 9,
+  MLN_RUNTIME_EVENT_MAP_RENDER_ERROR = 10,
+  MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED = 11,
+  MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FAILED = 12,
+} mln_runtime_event_type;
+
+/** Source kinds used by mln_runtime_event.source_type. */
+typedef enum mln_runtime_event_source_type : uint32_t {
+  MLN_RUNTIME_EVENT_SOURCE_RUNTIME = 0,
+  MLN_RUNTIME_EVENT_SOURCE_MAP = 1,
+} mln_runtime_event_source_type;
+
+/** Payload kinds used by mln_runtime_event.payload_type. */
+typedef enum mln_runtime_event_payload_type : uint32_t {
+  MLN_RUNTIME_EVENT_PAYLOAD_NONE = 0,
+} mln_runtime_event_payload_type;
+
 typedef enum mln_resource_kind : uint32_t {
   MLN_RESOURCE_KIND_UNKNOWN = 0,
   MLN_RESOURCE_KIND_STYLE = 1,
@@ -309,6 +336,31 @@ typedef struct mln_runtime_options {
   /** Maximum ambient cache size in bytes when the matching flag is set. */
   uint64_t maximum_cache_size;
 } mln_runtime_options;
+
+/** Event payload returned by mln_runtime_poll_event(). */
+typedef struct mln_runtime_event {
+  uint32_t size;
+  uint32_t type;
+  /** One of mln_runtime_event_source_type. */
+  uint32_t source_type;
+  /**
+   * Source handle for this event. For map-originated events, this is an
+   * mln_map*. For runtime-originated events, this is an mln_runtime*. Borrowed;
+   * valid while the source handle remains live.
+   */
+  void* source;
+  int32_t code;
+  /** One of mln_runtime_event_payload_type. */
+  uint32_t payload_type;
+  /** Borrowed payload bytes. Null when payload_size is 0. */
+  const void* payload;
+  /** Number of bytes in payload. */
+  size_t payload_size;
+  /** Borrowed event message bytes. Null when message_size is 0. */
+  const char* message;
+  /** Number of bytes in message, excluding the trailing null terminator. */
+  size_t message_size;
+} mln_runtime_event;
 
 typedef struct mln_resource_transform_response {
   uint32_t size;
@@ -594,9 +646,37 @@ MLN_API mln_status mln_runtime_destroy(mln_runtime* runtime) MLN_NOEXCEPT;
  */
 MLN_API mln_status mln_runtime_run_once(mln_runtime* runtime) MLN_NOEXCEPT;
 
+/**
+ * Pops the next queued runtime event.
+ *
+ * On success, *out_event is reset and *out_has_event indicates whether an event
+ * was available. When an event is available, *out_event receives it.
+ * Map-originated events set out_event->source_type to
+ * MLN_RUNTIME_EVENT_SOURCE_MAP and out_event->source to the source map.
+ * Runtime-originated events set out_event->source_type to
+ * MLN_RUNTIME_EVENT_SOURCE_RUNTIME.
+ *
+ * When an event is available, out_event->payload and out_event->message point
+ * to runtime-owned storage that remains valid until the next
+ * mln_runtime_poll_event() call for the same runtime or until the runtime is
+ * destroyed. Copy those bytes before then when they must outlive that window.
+ *
+ * Returns:
+ * - MLN_STATUS_OK when the poll completed; out_has_event indicates whether an
+ *   event was written to out_event.
+ * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, out_event is
+ *   null, out_has_event is null, or out_event->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_runtime_poll_event(
+  mln_runtime* runtime, mln_runtime_event* out_event, bool* out_has_event
+) MLN_NOEXCEPT;
+
 #pragma endregion
 
-#pragma region Map types, lifecycle, style, and events
+#pragma region Map types, lifecycle, and style
 /** Field mask values for mln_camera_options. */
 typedef enum mln_camera_option_field : uint32_t {
   MLN_CAMERA_OPTION_CENTER = 1u << 0u,
@@ -621,22 +701,6 @@ typedef enum mln_map_mode : uint32_t {
   /** Produces one-off still images for a single tile. */
   MLN_MAP_MODE_TILE = 2,
 } mln_map_mode;
-
-/** Map event types returned by mln_map_poll_event(). */
-typedef enum mln_map_event_type : uint32_t {
-  MLN_MAP_EVENT_CAMERA_WILL_CHANGE = 1,
-  MLN_MAP_EVENT_CAMERA_IS_CHANGING = 2,
-  MLN_MAP_EVENT_CAMERA_DID_CHANGE = 3,
-  MLN_MAP_EVENT_STYLE_LOADED = 4,
-  MLN_MAP_EVENT_MAP_LOADING_STARTED = 5,
-  MLN_MAP_EVENT_MAP_LOADING_FINISHED = 6,
-  MLN_MAP_EVENT_MAP_LOADING_FAILED = 7,
-  MLN_MAP_EVENT_MAP_IDLE = 8,
-  MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE = 9,
-  MLN_MAP_EVENT_RENDER_ERROR = 10,
-  MLN_MAP_EVENT_STILL_IMAGE_FINISHED = 11,
-  MLN_MAP_EVENT_STILL_IMAGE_FAILED = 12,
-} mln_map_event_type;
 
 /** Options used when creating a map. */
 typedef struct mln_map_options {
@@ -712,17 +776,6 @@ typedef struct mln_projection_mode {
   double y_skew;
 } mln_projection_mode;
 
-/** Map event payload returned by mln_map_poll_event(). */
-typedef struct mln_map_event {
-  uint32_t size;
-  uint32_t type;
-  int32_t code;
-  /** Borrowed event message bytes. Null when message_size is 0. */
-  const char* message;
-  /** Number of bytes in message, excluding the trailing null terminator. */
-  size_t message_size;
-} mln_map_event;
-
 /**
  * Returns map options initialized for this C API version.
  */
@@ -750,9 +803,10 @@ MLN_API mln_status mln_map_create(
  *
  * Continuous maps also invalidate automatically when style data, resources,
  * camera, or transitions change. Ask attached render targets to process the
- * latest update when MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE is reported. Repaint
- * requests do not produce MLN_MAP_EVENT_STILL_IMAGE_FINISHED or
- * MLN_MAP_EVENT_STILL_IMAGE_FAILED events.
+ * latest update when MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE is reported.
+ * Repaint requests do not produce
+ * MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED or
+ * MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FAILED events.
  *
  * Returns:
  * - MLN_STATUS_OK when the request was accepted.
@@ -767,15 +821,16 @@ MLN_API mln_status mln_map_request_repaint(mln_map* map) MLN_NOEXCEPT;
 /**
  * Requests one still image for a static or tile map.
  *
- * Pump the runtime and poll map events until
- * MLN_MAP_EVENT_STILL_IMAGE_FINISHED or MLN_MAP_EVENT_STILL_IMAGE_FAILED is
- * reported. While the request is pending, ask the attached render target to
- * process the latest update whenever MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE is
- * reported. Texture targets do this with mln_texture_render_update(), which can
- * return MLN_STATUS_INVALID_STATE when no frame is produced for that update.
- * Keep pumping and polling in that case. After
- * MLN_MAP_EVENT_STILL_IMAGE_FINISHED, acquire the frame produced by the most
- * recent successful target update.
+ * Pump the runtime and poll runtime events for this map until
+ * MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED or
+ * MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FAILED is reported. While the request is
+ * pending, process render target updates for
+ * MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE events from this map. Texture
+ * targets do this with mln_texture_render_update(), which can return
+ * MLN_STATUS_INVALID_STATE when no frame is produced for that update. Keep
+ * pumping and polling in that case. After
+ * MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED, acquire the frame produced by the
+ * most recent successful target update.
  *
  * Returns:
  * - MLN_STATUS_OK when the request was accepted.
@@ -807,7 +862,8 @@ MLN_API mln_status mln_map_destroy(mln_map* map) MLN_NOEXCEPT;
  * Loads a style URL through MapLibre Native style APIs.
  *
  * This is a map command. The return status reports synchronous acceptance or
- * failure. Later native success and failure are reported through map events.
+ * failure. Later native success and failure are reported through runtime
+ * events.
  *
  * Returns:
  * - MLN_STATUS_OK when the load request was accepted.
@@ -824,9 +880,9 @@ mln_map_set_style_url(mln_map* map, const char* url) MLN_NOEXCEPT;
  * Loads inline style JSON through MapLibre Native style APIs.
  *
  * This is a map command. The return status reports synchronous acceptance or
- * failure. Later native success and failure are reported through map events.
- * Malformed JSON can fail synchronously and still enqueue a loading-failed
- * event.
+ * failure. Later native success and failure are reported through runtime
+ * events. Malformed JSON can fail synchronously and still enqueue a
+ * loading-failed event.
  *
  * Returns:
  * - MLN_STATUS_OK when the load request was accepted.
@@ -838,28 +894,6 @@ mln_map_set_style_url(mln_map* map, const char* url) MLN_NOEXCEPT;
  */
 MLN_API mln_status
 mln_map_set_style_json(mln_map* map, const char* json) MLN_NOEXCEPT;
-
-/**
- * Pops the next queued map event.
- *
- * On success, *out_event is overwritten and *out_has_event indicates whether an
- * event was available. When an event is available, out_event->message points to
- * map-owned storage that remains valid until the next mln_map_poll_event() call
- * for the same map or until the map is destroyed. Copy message bytes before
- * then when they must outlive that window.
- *
- * Returns:
- * - MLN_STATUS_OK when the poll completed; out_has_event indicates whether an
- *   event was written to out_event.
- * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_event is
- *   null, out_has_event is null, or out_event->size is too small.
- * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
- *   thread.
- * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
- */
-MLN_API mln_status mln_map_poll_event(
-  mln_map* map, mln_map_event* out_event, bool* out_has_event
-) MLN_NOEXCEPT;
 
 #pragma endregion
 
@@ -1094,7 +1128,7 @@ MLN_API mln_status mln_map_lat_lngs_for_pixels(
  * Creates a standalone projection helper from the current map transform.
  *
  * The helper owns projection and camera transform state only. It does not own
- * style, resources, render targets, or map events. Use it to convert
+ * style, resources, render targets, or runtime events. Use it to convert
  * coordinates or compute camera fitting without changing the source map.
  *
  * Creation snapshots the map's transform. Later map camera or projection

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -241,11 +241,3 @@ auto mln_map_cancel_transitions(mln_map* map) noexcept -> mln_status {
     return mln::core::map_cancel_transitions(map);
   });
 }
-
-auto mln_map_poll_event(
-  mln_map* map, mln_map_event* out_event, bool* out_has_event
-) noexcept -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::map_poll_event(map, out_event, out_has_event);
-  });
-}

--- a/src/c_api/runtime.cpp
+++ b/src/c_api/runtime.cpp
@@ -82,3 +82,11 @@ auto mln_runtime_run_once(mln_runtime* runtime) noexcept -> mln_status {
     return mln::core::run_runtime_once(runtime);
   });
 }
+
+auto mln_runtime_poll_event(
+  mln_runtime* runtime, mln_runtime_event* out_event, bool* out_has_event
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::poll_runtime_event(runtime, out_event, out_has_event);
+  });
+}

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1,7 +1,6 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <deque>
 #include <exception>
 #include <memory>
 #include <mutex>
@@ -64,142 +63,74 @@ auto map_projection_registry() -> ProjectionRegistry& {
   return value;
 }
 
-struct QueuedEvent {
-  mln_map_event_type type;
-  int32_t code;
-  std::string message;
-};
-
-class EventQueue final {
- public:
-  auto push(
-    mln_map_event_type type, int32_t code = 0, const char* message = nullptr
-  ) -> void {
-    auto event = QueuedEvent{
-      .type = type,
-      .code = code,
-      .message = message == nullptr ? std::string{} : std::string{message}
-    };
-
-    const std::scoped_lock lock(mutex_);
-    if (type == MLN_MAP_EVENT_MAP_LOADING_FAILED) {
-      failed_ = true;
-      failure_message_ = event.message;
-    }
-    events_.push_back(std::move(event));
-  }
-
-  auto clear_failure() -> void {
-    const std::scoped_lock lock(mutex_);
-    failed_ = false;
-    failure_message_.clear();
-  }
-
-  [[nodiscard]] auto failed() const -> bool {
-    const std::scoped_lock lock(mutex_);
-    return failed_;
-  }
-
-  [[nodiscard]] auto failure_message() const -> std::string {
-    const std::scoped_lock lock(mutex_);
-    return failure_message_;
-  }
-
-  auto poll(mln_map_event* out_event) -> bool {
-    const std::scoped_lock lock(mutex_);
-    last_polled_message_.clear();
-    *out_event = mln_map_event{
-      .size = sizeof(mln_map_event),
-      .type = 0,
-      .code = 0,
-      .message = nullptr,
-      .message_size = 0
-    };
-
-    if (events_.empty()) {
-      return false;
-    }
-
-    auto event = std::move(events_.front());
-    events_.pop_front();
-    last_polled_message_ = std::move(event.message);
-
-    out_event->type = static_cast<uint32_t>(event.type);
-    out_event->code = event.code;
-    out_event->message =
-      last_polled_message_.empty() ? nullptr : last_polled_message_.c_str();
-    out_event->message_size = last_polled_message_.size();
-    return true;
-  }
-
- private:
-  mutable std::mutex mutex_;
-  std::deque<QueuedEvent> events_;
-  std::string last_polled_message_;
-  bool failed_ = false;
-  std::string failure_message_;
-};
-
 class HeadlessObserver final : public mbgl::MapObserver {
  public:
-  explicit HeadlessObserver(EventQueue& events) : events_(&events) {}
+  HeadlessObserver(mln_runtime* runtime, mln_map* map)
+      : runtime_(runtime), map_(map) {}
 
   void onCameraWillChange(CameraChangeMode mode) override {
-    events_->push(MLN_MAP_EVENT_CAMERA_WILL_CHANGE, static_cast<int32_t>(mode));
+    push(MLN_RUNTIME_EVENT_MAP_CAMERA_WILL_CHANGE, static_cast<int32_t>(mode));
   }
 
   void onCameraIsChanging() override {
-    events_->push(MLN_MAP_EVENT_CAMERA_IS_CHANGING);
+    push(MLN_RUNTIME_EVENT_MAP_CAMERA_IS_CHANGING);
   }
 
   void onCameraDidChange(CameraChangeMode mode) override {
-    events_->push(MLN_MAP_EVENT_CAMERA_DID_CHANGE, static_cast<int32_t>(mode));
+    push(MLN_RUNTIME_EVENT_MAP_CAMERA_DID_CHANGE, static_cast<int32_t>(mode));
   }
 
   void onWillStartLoadingMap() override {
-    events_->push(MLN_MAP_EVENT_MAP_LOADING_STARTED);
+    push(MLN_RUNTIME_EVENT_MAP_LOADING_STARTED);
   }
 
   void onDidFinishLoadingMap() override {
-    events_->push(MLN_MAP_EVENT_MAP_LOADING_FINISHED);
+    push(MLN_RUNTIME_EVENT_MAP_LOADING_FINISHED);
   }
 
   void onDidFailLoadingMap(
     mbgl::MapLoadError error, const std::string& message
   ) override {
-    events_->push(
-      MLN_MAP_EVENT_MAP_LOADING_FAILED, static_cast<int32_t>(error),
+    push(
+      MLN_RUNTIME_EVENT_MAP_LOADING_FAILED, static_cast<int32_t>(error),
       message.c_str()
     );
   }
 
   void onDidFinishLoadingStyle() override {
-    events_->push(MLN_MAP_EVENT_STYLE_LOADED);
+    push(MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
   }
 
-  void onDidBecomeIdle() override { events_->push(MLN_MAP_EVENT_MAP_IDLE); }
+  void onDidBecomeIdle() override { push(MLN_RUNTIME_EVENT_MAP_IDLE); }
 
   void onRenderError(std::exception_ptr error) override {
     try {
       if (error) {
         std::rethrow_exception(error);
       }
-      events_->push(MLN_MAP_EVENT_RENDER_ERROR);
+      push(MLN_RUNTIME_EVENT_MAP_RENDER_ERROR);
     } catch (const std::exception& exception) {
-      events_->push(MLN_MAP_EVENT_RENDER_ERROR, 0, exception.what());
+      push(MLN_RUNTIME_EVENT_MAP_RENDER_ERROR, 0, exception.what());
     } catch (...) {
-      events_->push(MLN_MAP_EVENT_RENDER_ERROR, 0, "unknown render error");
+      push(MLN_RUNTIME_EVENT_MAP_RENDER_ERROR, 0, "unknown render error");
     }
   }
 
  private:
-  EventQueue* events_;
+  auto push(uint32_t type, int32_t code = 0, const char* message = nullptr)
+    -> void {
+    mln::core::push_runtime_map_event(runtime_, map_, type, code, message);
+  }
+
+  mln_runtime* runtime_;
+  mln_map* map_;
 };
 
 class HeadlessFrontend final : public mbgl::RendererFrontend {
  public:
-  explicit HeadlessFrontend(EventQueue& events)
-      : events_(&events),
+  HeadlessFrontend(mln_runtime* runtime, mln_map* map)
+      : runtime_(runtime),
+        map_(map),
         thread_pool_(
           mbgl::Scheduler::GetBackground(), mbgl::util::SimpleIdentity::Empty
         ) {}
@@ -216,7 +147,9 @@ class HeadlessFrontend final : public mbgl::RendererFrontend {
   void update(std::shared_ptr<mbgl::UpdateParameters> update) override {
     const std::scoped_lock lock(latest_update_mutex_);
     latest_update_ = std::move(update);
-    events_->push(MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE);
+    mln::core::push_runtime_map_event(
+      runtime_, map_, MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE
+    );
   }
 
   [[nodiscard]] auto latest_update() const
@@ -237,7 +170,8 @@ class HeadlessFrontend final : public mbgl::RendererFrontend {
   }
 
  private:
-  EventQueue* events_;
+  mln_runtime* runtime_;
+  mln_map* map_;
   mbgl::RendererObserver* observer_ = nullptr;
   mbgl::TaggedScheduler thread_pool_;
   mutable std::mutex latest_update_mutex_;
@@ -592,7 +526,6 @@ struct mln_map {
   std::thread::id owner_thread;
   uint32_t map_mode = MLN_MAP_MODE_CONTINUOUS;
   bool still_image_request_pending = false;
-  EventQueue events;
   std::unique_ptr<HeadlessObserver> observer;
   std::unique_ptr<HeadlessFrontend> frontend;
   std::unique_ptr<mbgl::Map> map;
@@ -632,11 +565,16 @@ auto finish_still_image_request(mln_map* map, std::exception_ptr error)
   map->still_image_request_pending = false;
   if (error) {
     const auto message = exception_message(error);
-    map->events.push(MLN_MAP_EVENT_STILL_IMAGE_FAILED, 0, message.c_str());
+    push_runtime_map_event(
+      map->runtime, map, MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FAILED, 0,
+      message.c_str()
+    );
     return;
   }
 
-  map->events.push(MLN_MAP_EVENT_STILL_IMAGE_FINISHED);
+  push_runtime_map_event(
+    map->runtime, map, MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED
+  );
 }
 
 }  // namespace
@@ -737,25 +675,29 @@ auto create_map(
 
   const auto effective = options == nullptr ? map_options_default() : *options;
   auto owned_map = std::make_unique<mln_map>();
+  auto* handle = owned_map.get();
+  register_runtime_map_events(runtime, handle);
   owned_map->runtime = runtime;
   owned_map->owner_thread = std::this_thread::get_id();
   owned_map->map_mode = effective.map_mode;
-  owned_map->observer = std::make_unique<HeadlessObserver>(owned_map->events);
-  owned_map->frontend = std::make_unique<HeadlessFrontend>(owned_map->events);
+  try {
+    owned_map->observer = std::make_unique<HeadlessObserver>(runtime, handle);
+    owned_map->frontend = std::make_unique<HeadlessFrontend>(runtime, handle);
 
-  auto map_options = mbgl::MapOptions{};
-  map_options.withMapMode(to_native_map_mode(effective.map_mode))
-    .withSize(mbgl::Size{effective.width, effective.height})
-    .withPixelRatio(static_cast<float>(effective.scale_factor));
-  owned_map->map = std::make_unique<mbgl::Map>(
-    *owned_map->frontend, *owned_map->observer, map_options,
-    resource_options_for_runtime(runtime)
-  );
+    auto map_options = mbgl::MapOptions{};
+    map_options.withMapMode(to_native_map_mode(effective.map_mode))
+      .withSize(mbgl::Size{effective.width, effective.height})
+      .withPixelRatio(static_cast<float>(effective.scale_factor));
+    owned_map->map = std::make_unique<mbgl::Map>(
+      *owned_map->frontend, *owned_map->observer, map_options,
+      resource_options_for_runtime(runtime)
+    );
 
-  auto* handle = owned_map.get();
-  {
     const std::scoped_lock lock(map_registry_mutex());
     map_registry().emplace(handle, std::move(owned_map));
+  } catch (...) {
+    discard_runtime_map_events(runtime, handle);
+    throw;
   }
   *out_map = handle;
   retain_guard.dismiss();
@@ -781,6 +723,7 @@ auto destroy_map(mln_map* map) -> mln_status {
     owned_map = std::move(found->second);
     map_registry().erase(found);
   }
+  discard_runtime_map_events(runtime, map);
   owned_map.reset();
   release_runtime_map(runtime);
   return MLN_STATUS_OK;
@@ -905,10 +848,12 @@ auto map_set_style_url(mln_map* map, const char* url) -> mln_status {
     set_thread_error("url must not be null");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  map->events.clear_failure();
+  clear_runtime_map_loading_failure(map->runtime, map);
   map->map->getStyle().loadURL(url);
-  if (map->events.failed()) {
-    set_thread_error(map->events.failure_message().c_str());
+  if (runtime_map_loading_failed(map->runtime, map)) {
+    set_thread_error(
+      runtime_map_loading_failure_message(map->runtime, map).c_str()
+    );
     return MLN_STATUS_NATIVE_ERROR;
   }
   return MLN_STATUS_OK;
@@ -924,15 +869,20 @@ auto map_set_style_json(mln_map* map, const char* json) -> mln_status {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
   try {
-    map->events.clear_failure();
+    clear_runtime_map_loading_failure(map->runtime, map);
     map->map->getStyle().loadJSON(json);
   } catch (const std::exception& exception) {
     set_thread_error(exception.what());
-    map->events.push(MLN_MAP_EVENT_MAP_LOADING_FAILED, 0, exception.what());
+    push_runtime_map_event(
+      map->runtime, map, MLN_RUNTIME_EVENT_MAP_LOADING_FAILED, 0,
+      exception.what()
+    );
     return MLN_STATUS_NATIVE_ERROR;
   }
-  if (map->events.failed()) {
-    set_thread_error(map->events.failure_message().c_str());
+  if (runtime_map_loading_failed(map->runtime, map)) {
+    set_thread_error(
+      runtime_map_loading_failure_message(map->runtime, map).c_str()
+    );
     return MLN_STATUS_NATIVE_ERROR;
   }
   return MLN_STATUS_OK;
@@ -1345,27 +1295,6 @@ auto map_cancel_transitions(mln_map* map) -> mln_status {
     return status;
   }
   map->map->cancelTransitions();
-  return MLN_STATUS_OK;
-}
-
-auto map_poll_event(mln_map* map, mln_map_event* out_event, bool* out_has_event)
-  -> mln_status {
-  const auto status = validate_map(map);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (
-    out_event == nullptr || out_has_event == nullptr ||
-    out_event->size < sizeof(mln_map_event)
-  ) {
-    set_thread_error(
-      "out_event and out_has_event must not be null, and out_event must have a "
-      "valid size"
-    );
-    return MLN_STATUS_INVALID_ARGUMENT;
-  }
-
-  *out_has_event = map->events.poll(out_event);
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -80,8 +80,6 @@ auto map_rotate_by(
 ) -> mln_status;
 auto map_pitch_by(mln_map* map, double pitch) -> mln_status;
 auto map_cancel_transitions(mln_map* map) -> mln_status;
-auto map_poll_event(mln_map* map, mln_map_event* out_event, bool* out_has_event)
-  -> mln_status;
 auto validate_map(mln_map* map) -> mln_status;
 auto map_owner_thread(const mln_map* map) -> std::thread::id;
 auto map_native(mln_map* map) -> mbgl::Map*;

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -179,21 +179,23 @@ auto create_runtime(
     return MLN_STATUS_INVALID_STATE;
   }
 
-  auto owned_runtime = std::make_unique<mln_runtime>(mln_runtime{
-    .owner_thread = owner_thread,
-    .run_loop =
-      std::make_unique<mbgl::util::RunLoop>(mbgl::util::RunLoop::Type::New),
-    .asset_path = options == nullptr || options->asset_path == nullptr
-                    ? std::string{}
-                    : std::string{options->asset_path},
-    .cache_path = options == nullptr || options->cache_path == nullptr
-                    ? std::string{}
-                    : std::string{options->cache_path},
-    .has_maximum_cache_size =
-      options != nullptr &&
-      (options->flags & MLN_RUNTIME_OPTION_MAXIMUM_CACHE_SIZE) != 0,
-    .maximum_cache_size = options == nullptr ? 0 : options->maximum_cache_size,
-  });
+  auto owned_runtime = std::make_unique<mln_runtime>();
+  owned_runtime->owner_thread = owner_thread;
+  owned_runtime->run_loop =
+    std::make_unique<mbgl::util::RunLoop>(mbgl::util::RunLoop::Type::New);
+  owned_runtime->asset_path =
+    options == nullptr || options->asset_path == nullptr
+      ? std::string{}
+      : std::string{options->asset_path};
+  owned_runtime->cache_path =
+    options == nullptr || options->cache_path == nullptr
+      ? std::string{}
+      : std::string{options->cache_path};
+  owned_runtime->has_maximum_cache_size =
+    options != nullptr &&
+    (options->flags & MLN_RUNTIME_OPTION_MAXIMUM_CACHE_SIZE) != 0;
+  owned_runtime->maximum_cache_size =
+    options == nullptr ? 0 : options->maximum_cache_size;
   auto* runtime = owned_runtime.get();
   {
     const std::scoped_lock lock(runtime_registry_mutex());
@@ -350,6 +352,67 @@ auto run_runtime_once(mln_runtime* runtime) -> mln_status {
   return MLN_STATUS_OK;
 }
 
+auto poll_runtime_event(
+  mln_runtime* runtime, mln_runtime_event* out_event, bool* out_has_event
+) -> mln_status {
+  const auto status = validate_runtime(runtime);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (
+    out_event == nullptr || out_has_event == nullptr ||
+    out_event->size < sizeof(mln_runtime_event)
+  ) {
+    set_thread_error(
+      "out_event and out_has_event must not be null, and out_event must have a "
+      "valid size"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const std::scoped_lock lock(runtime->event_mutex);
+  runtime->last_polled_event_payload.clear();
+  runtime->last_polled_event_message.clear();
+  *out_event = mln_runtime_event{
+    .size = sizeof(mln_runtime_event),
+    .type = 0,
+    .source_type = MLN_RUNTIME_EVENT_SOURCE_RUNTIME,
+    .source = runtime,
+    .code = 0,
+    .payload_type = MLN_RUNTIME_EVENT_PAYLOAD_NONE,
+    .payload = nullptr,
+    .payload_size = 0,
+    .message = nullptr,
+    .message_size = 0
+  };
+
+  if (runtime->events.empty()) {
+    *out_has_event = false;
+    return MLN_STATUS_OK;
+  }
+
+  auto event = std::move(runtime->events.front());
+  runtime->events.pop_front();
+  runtime->last_polled_event_payload = std::move(event.payload);
+  runtime->last_polled_event_message = std::move(event.message);
+
+  out_event->type = event.type;
+  out_event->source_type = event.source_type;
+  out_event->source = event.source;
+  out_event->code = event.code;
+  out_event->payload_type = event.payload_type;
+  out_event->payload = runtime->last_polled_event_payload.empty()
+                         ? nullptr
+                         : runtime->last_polled_event_payload.data();
+  out_event->payload_size = runtime->last_polled_event_payload.size();
+  out_event->message = runtime->last_polled_event_message.empty()
+                         ? nullptr
+                         : runtime->last_polled_event_message.c_str();
+  out_event->message_size = runtime->last_polled_event_message.size();
+  *out_has_event = true;
+  return MLN_STATUS_OK;
+}
+
 auto retain_runtime_map(mln_runtime* runtime) -> mln_status {
   const auto status = validate_runtime(runtime);
   if (status != MLN_STATUS_OK) {
@@ -399,6 +462,92 @@ auto find_runtime_for_platform_context(void* platform_context) noexcept
   const std::scoped_lock lock(runtime_registry_mutex());
   auto* runtime = static_cast<mln_runtime*>(platform_context);
   return runtime_registry().contains(runtime) ? runtime : nullptr;
+}
+
+auto push_runtime_map_event(
+  mln_runtime* runtime, mln_map* map, uint32_t type, int32_t code,
+  const char* message
+) -> void {
+  if (runtime == nullptr) {
+    return;
+  }
+
+  auto event = QueuedRuntimeEvent{
+    .type = type,
+    .source_type = MLN_RUNTIME_EVENT_SOURCE_MAP,
+    .source = map,
+    .map = map,
+    .code = code,
+    .payload_type = MLN_RUNTIME_EVENT_PAYLOAD_NONE,
+    .payload = {},
+    .message = message == nullptr ? std::string{} : std::string{message}
+  };
+
+  const std::scoped_lock lock(runtime->event_mutex);
+  if (map != nullptr && !runtime->event_maps.contains(map)) {
+    return;
+  }
+  if (type == MLN_RUNTIME_EVENT_MAP_LOADING_FAILED && map != nullptr) {
+    runtime->map_loading_failures[map] = event.message;
+  }
+  runtime->events.push_back(std::move(event));
+}
+
+auto register_runtime_map_events(mln_runtime* runtime, const mln_map* map)
+  -> void {
+  if (runtime == nullptr || map == nullptr) {
+    return;
+  }
+
+  const std::scoped_lock lock(runtime->event_mutex);
+  runtime->event_maps.insert(map);
+}
+
+auto clear_runtime_map_loading_failure(mln_runtime* runtime, const mln_map* map)
+  -> void {
+  if (runtime == nullptr || map == nullptr) {
+    return;
+  }
+
+  const std::scoped_lock lock(runtime->event_mutex);
+  runtime->map_loading_failures.erase(map);
+}
+
+auto runtime_map_loading_failed(mln_runtime* runtime, const mln_map* map)
+  -> bool {
+  if (runtime == nullptr || map == nullptr) {
+    return false;
+  }
+
+  const std::scoped_lock lock(runtime->event_mutex);
+  return runtime->map_loading_failures.contains(map);
+}
+
+auto runtime_map_loading_failure_message(
+  mln_runtime* runtime, const mln_map* map
+) -> std::string {
+  if (runtime == nullptr || map == nullptr) {
+    return {};
+  }
+
+  const std::scoped_lock lock(runtime->event_mutex);
+  const auto found = runtime->map_loading_failures.find(map);
+  return found == runtime->map_loading_failures.end() ? std::string{}
+                                                      : found->second;
+}
+
+auto discard_runtime_map_events(mln_runtime* runtime, const mln_map* map)
+  -> void {
+  if (runtime == nullptr || map == nullptr) {
+    return;
+  }
+
+  const std::scoped_lock lock(runtime->event_mutex);
+  runtime->event_maps.erase(map);
+  std::erase_if(runtime->events, [map](const auto& event) -> bool {
+    return event.map == map;
+  });
+  runtime->map_loading_failures.erase(map);
 }
 
 }  // namespace mln::core

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -2,9 +2,14 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/util/run_loop.hpp>
@@ -16,6 +21,17 @@ namespace mln::core {
 struct ResourceProvider {
   mln_resource_provider_callback callback = nullptr;
   void* user_data = nullptr;
+};
+
+struct QueuedRuntimeEvent {
+  uint32_t type;
+  uint32_t source_type;
+  void* source;
+  mln_map* map;
+  int32_t code;
+  uint32_t payload_type;
+  std::vector<std::byte> payload;
+  std::string message;
 };
 
 }  // namespace mln::core
@@ -32,6 +48,12 @@ struct mln_runtime {
   mln_resource_transform_callback resource_transform_callback = nullptr;
   void* resource_transform_user_data = nullptr;
   std::size_t live_maps = 0;
+  mutable std::mutex event_mutex;
+  std::unordered_set<const mln_map*> event_maps;
+  std::deque<mln::core::QueuedRuntimeEvent> events;
+  std::vector<std::byte> last_polled_event_payload;
+  std::string last_polled_event_message;
+  std::unordered_map<const mln_map*, std::string> map_loading_failures;
 };
 
 namespace mln::core {
@@ -41,6 +63,9 @@ auto create_runtime(
 ) -> mln_status;
 auto destroy_runtime(mln_runtime* runtime) -> mln_status;
 auto run_runtime_once(mln_runtime* runtime) -> mln_status;
+auto poll_runtime_event(
+  mln_runtime* runtime, mln_runtime_event* out_event, bool* out_has_event
+) -> mln_status;
 auto set_resource_provider(
   mln_runtime* runtime, const mln_resource_provider* provider
 ) -> mln_status;
@@ -56,5 +81,20 @@ auto resource_options_for_runtime(mln_runtime* runtime)
   -> mbgl::ResourceOptions;
 auto find_runtime_for_platform_context(void* platform_context) noexcept
   -> mln_runtime*;
+auto push_runtime_map_event(
+  mln_runtime* runtime, mln_map* map, uint32_t type, int32_t code = 0,
+  const char* message = nullptr
+) -> void;
+auto register_runtime_map_events(mln_runtime* runtime, const mln_map* map)
+  -> void;
+auto clear_runtime_map_loading_failure(mln_runtime* runtime, const mln_map* map)
+  -> void;
+auto runtime_map_loading_failed(mln_runtime* runtime, const mln_map* map)
+  -> bool;
+auto runtime_map_loading_failure_message(
+  mln_runtime* runtime, const mln_map* map
+) -> std::string;
+auto discard_runtime_map_events(mln_runtime* runtime, const mln_map* map)
+  -> void;
 
 }  // namespace mln::core

--- a/tests/c/events.zig
+++ b/tests/c/events.zig
@@ -5,36 +5,33 @@ const c = support.c;
 
 extern fn usleep(useconds: c_uint) c_int;
 
-test "event polling reports empty queues" {
+test "runtime event polling reports empty queues" {
     const runtime = try support.createRuntime();
     defer support.destroyRuntime(runtime);
 
     const map = try support.createMap(runtime);
     defer support.destroyMap(map);
 
-    _ = try support.drainEvents(map);
+    _ = try support.drainEvents(runtime);
 
     var event = support.emptyEvent();
     var has_event = true;
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_poll_event(map, &event, &has_event));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_poll_event(runtime, &event, &has_event));
     try testing.expect(!has_event);
 }
 
-test "event polling rejects invalid outputs" {
+test "runtime event polling rejects invalid outputs" {
     const runtime = try support.createRuntime();
     defer support.destroyRuntime(runtime);
 
-    const map = try support.createMap(runtime);
-    defer support.destroyMap(map);
-
     var has_event = false;
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_poll_event(map, null, &has_event));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_poll_event(runtime, null, &has_event));
 
     var event = support.emptyEvent();
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_poll_event(map, &event, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_poll_event(runtime, &event, null));
 
-    event.size = @sizeOf(c.mln_map_event) - 1;
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_poll_event(map, &event, &has_event));
+    event.size = @sizeOf(c.mln_runtime_event) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_poll_event(runtime, &event, &has_event));
 }
 
 test "event message storage is copied into caller output" {
@@ -53,11 +50,19 @@ test "event message storage is copied into caller output" {
     for (0..1000) |_| {
         try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_once(runtime));
         var has_event = false;
-        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_poll_event(map, &event, &has_event));
-        if (has_event and event.type == c.MLN_MAP_EVENT_MAP_LOADING_FAILED) break;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_poll_event(runtime, &event, &has_event));
+        if (has_event and
+            event.type == c.MLN_RUNTIME_EVENT_MAP_LOADING_FAILED and
+            event.source_type == c.MLN_RUNTIME_EVENT_SOURCE_MAP and
+            event.source == @as(?*anyopaque, @ptrCast(map))) break;
         _ = usleep(1000);
     } else return error.EventNotFound;
 
+    try testing.expectEqual(c.MLN_RUNTIME_EVENT_SOURCE_MAP, event.source_type);
+    try testing.expect(event.source == @as(?*anyopaque, @ptrCast(map)));
+    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_NONE, event.payload_type);
+    try testing.expectEqual(@as(?*const anyopaque, null), event.payload);
+    try testing.expectEqual(@as(usize, 0), event.payload_size);
     try testing.expect(event.message != null);
     const message = event.message[0..event.message_size];
     try testing.expect(message.len > 0);
@@ -67,4 +72,26 @@ test "event message storage is copied into caller output" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_once(runtime));
     try testing.expect(event.message != null);
     try testing.expectEqualSlices(u8, copied_message, event.message[0..event.message_size]);
+}
+
+test "destroying a map discards its queued runtime events" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    var map_live = true;
+    errdefer if (map_live) support.destroyMap(map);
+    _ = try support.drainEvents(runtime);
+
+    try testing.expectEqual(c.MLN_STATUS_NATIVE_ERROR, c.mln_map_set_style_json(map, "{"));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_destroy(map));
+    map_live = false;
+
+    var event = support.emptyEvent();
+    var has_event = true;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_poll_event(runtime, &event, &has_event));
+    try testing.expect(!has_event);
 }

--- a/tests/c/map_lifecycle.zig
+++ b/tests/c/map_lifecycle.zig
@@ -3,12 +3,6 @@ const testing = std.testing;
 const support = @import("support.zig");
 const c = support.c;
 
-fn pollMapOnThread(map: *c.mln_map, out_status: *c.mln_status) void {
-    var event = support.emptyEvent();
-    var has_event = false;
-    out_status.* = c.mln_map_poll_event(map, &event, &has_event);
-}
-
 fn requestRepaintOnThread(map: *c.mln_map, out_status: *c.mln_status) void {
     out_status.* = c.mln_map_request_repaint(map);
 }
@@ -74,10 +68,6 @@ test "map lifecycle rejects invalid state and stale handles" {
     var camera = c.mln_camera_options_default();
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_camera(map, &camera));
 
-    var event = support.emptyEvent();
-    var has_event = true;
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_poll_event(map, &event, &has_event));
-
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_destroy(runtime));
 }
 
@@ -88,10 +78,10 @@ test "continuous repaint request makes render update available" {
     const map = try support.createMap(runtime);
     defer support.destroyMap(map);
 
-    _ = try support.drainEvents(map);
+    _ = try support.drainEvents(runtime);
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_map_request_still_image(map));
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_request_repaint(map));
-    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE));
+    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE));
 }
 
 test "runtime supports multiple maps" {
@@ -115,11 +105,6 @@ test "map rejects wrong-thread calls" {
     defer support.destroyMap(map);
 
     var status: c.mln_status = c.MLN_STATUS_OK;
-    const thread = try std.Thread.spawn(.{}, pollMapOnThread, .{ map, &status });
-    thread.join();
-
-    try testing.expectEqual(c.MLN_STATUS_WRONG_THREAD, status);
-
     const request_thread = try std.Thread.spawn(.{}, requestRepaintOnThread, .{ map, &status });
     request_thread.join();
 

--- a/tests/c/resources.zig
+++ b/tests/c/resources.zig
@@ -150,7 +150,7 @@ fn freeTempStyle(fixture: *const TempStyle) void {
 }
 
 fn pumpAndExpectStyleLoaded(runtime: *c.mln_runtime, map: *c.mln_map) !void {
-    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_STYLE_LOADED));
+    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED));
 }
 
 fn serveOneHttpStyleInner(state: *HttpServerState) !void {
@@ -538,7 +538,7 @@ test "custom provider error response fails style load" {
     defer support.destroyMap(map);
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_url(map, "custom://style.json"));
-    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_MAP_LOADING_FAILED));
+    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_LOADING_FAILED));
 }
 
 test "network provider pass-through delegates to native HTTP" {
@@ -801,7 +801,7 @@ test "missing file URL reports map loading failure" {
     defer support.destroyMap(map);
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_url(map, missing_url));
-    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_MAP_LOADING_FAILED));
+    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_LOADING_FAILED));
 }
 
 test "invalid resource provider settings are rejected" {

--- a/tests/c/runtime.zig
+++ b/tests/c/runtime.zig
@@ -7,6 +7,12 @@ fn destroyRuntimeOnThread(runtime: *c.mln_runtime, out_status: *c.mln_status) vo
     out_status.* = c.mln_runtime_destroy(runtime);
 }
 
+fn pollRuntimeOnThread(runtime: *c.mln_runtime, out_status: *c.mln_status) void {
+    var event = support.emptyEvent();
+    var has_event = false;
+    out_status.* = c.mln_runtime_poll_event(runtime, &event, &has_event);
+}
+
 fn createRuntimeOnThread(out_status: *c.mln_status) void {
     var runtime: ?*c.mln_runtime = null;
     var options = c.mln_runtime_options_default();
@@ -62,12 +68,29 @@ test "runtime run once rejects null runtime" {
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_run_once(null));
 }
 
+test "runtime event polling rejects null runtime" {
+    var event = support.emptyEvent();
+    var has_event = false;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_poll_event(null, &event, &has_event));
+}
+
 test "runtime rejects wrong-thread destroy" {
     const runtime = try support.createRuntime();
     defer support.destroyRuntime(runtime);
 
     var status: c.mln_status = c.MLN_STATUS_OK;
     const thread = try std.Thread.spawn(.{}, destroyRuntimeOnThread, .{ runtime, &status });
+    thread.join();
+
+    try testing.expectEqual(c.MLN_STATUS_WRONG_THREAD, status);
+}
+
+test "runtime rejects wrong-thread event polling" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    var status: c.mln_status = c.MLN_STATUS_OK;
+    const thread = try std.Thread.spawn(.{}, pollRuntimeOnThread, .{ runtime, &status });
     thread.join();
 
     try testing.expectEqual(c.MLN_STATUS_WRONG_THREAD, status);

--- a/tests/c/style.zig
+++ b/tests/c/style.zig
@@ -19,7 +19,7 @@ test "map loads inline style and emits events" {
         try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_once(runtime));
     }
 
-    try testing.expect(try support.drainEvents(map) > 0);
+    try testing.expect(try support.drainEvents(runtime) > 0);
 }
 
 test "malformed style returns failure status and event" {
@@ -39,10 +39,13 @@ test "malformed style returns failure status and event" {
     while (true) {
         var event = support.emptyEvent();
         var has_event = false;
-        const status = c.mln_map_poll_event(map, &event, &has_event);
+        const status = c.mln_runtime_poll_event(runtime, &event, &has_event);
         try testing.expectEqual(c.MLN_STATUS_OK, status);
         if (!has_event) break;
-        if (event.type == c.MLN_MAP_EVENT_MAP_LOADING_FAILED) {
+        if (event.type == c.MLN_RUNTIME_EVENT_MAP_LOADING_FAILED and
+            event.source_type == c.MLN_RUNTIME_EVENT_SOURCE_MAP and
+            event.source == @as(?*anyopaque, @ptrCast(map)))
+        {
             saw_failed_event = true;
             break;
         }
@@ -75,5 +78,5 @@ test "unsupported style URL is accepted then emits failure event" {
     defer support.destroyMap(map);
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_url(map, "unsupported://style.json"));
-    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_MAP_LOADING_FAILED));
+    try testing.expect(try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_LOADING_FAILED));
 }

--- a/tests/c/support.zig
+++ b/tests/c/support.zig
@@ -73,12 +73,12 @@ pub fn restoreLogs() void {
     testing.expectEqual(c.MLN_STATUS_OK, c.mln_log_set_async_severity_mask(c.MLN_LOG_SEVERITY_MASK_DEFAULT)) catch @panic("log async mask restore failed");
 }
 
-pub fn drainEvents(map: *c.mln_map) !usize {
+pub fn drainEvents(runtime: *c.mln_runtime) !usize {
     var count: usize = 0;
     while (true) {
         var event = emptyEvent();
         var has_event = false;
-        const status = c.mln_map_poll_event(map, &event, &has_event);
+        const status = c.mln_runtime_poll_event(runtime, &event, &has_event);
         try testing.expectEqual(c.MLN_STATUS_OK, status);
         if (!has_event) break;
         count += 1;
@@ -92,17 +92,30 @@ pub fn waitForEvent(runtime: *c.mln_runtime, map: *c.mln_map, event_type: u32) !
         while (true) {
             var event = emptyEvent();
             var has_event = false;
-            try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_poll_event(map, &event, &has_event));
+            try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_poll_event(runtime, &event, &has_event));
             if (!has_event) break;
-            if (event.type == event_type) return true;
+            if (event.type == event_type and
+                event.source_type == c.MLN_RUNTIME_EVENT_SOURCE_MAP and
+                event.source == @as(?*anyopaque, @ptrCast(map))) return true;
         }
         _ = usleep(1000);
     }
     return false;
 }
 
-pub fn emptyEvent() c.mln_map_event {
-    return .{ .size = @sizeOf(c.mln_map_event), .type = 0, .code = 0, .message = null, .message_size = 0 };
+pub fn emptyEvent() c.mln_runtime_event {
+    return .{
+        .size = @sizeOf(c.mln_runtime_event),
+        .type = 0,
+        .source_type = c.MLN_RUNTIME_EVENT_SOURCE_RUNTIME,
+        .source = null,
+        .code = 0,
+        .payload_type = c.MLN_RUNTIME_EVENT_PAYLOAD_NONE,
+        .payload = null,
+        .payload_size = 0,
+        .message = null,
+        .message_size = 0,
+    };
 }
 
 pub fn testCamera() c.mln_camera_options {

--- a/tests/c/texture.zig
+++ b/tests/c/texture.zig
@@ -155,7 +155,7 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, fixture.acquire(&frame));
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
-    _ = try support.waitForEvent(runtime, map, c.MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE);
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(fixture.texture));
     try testing.expectEqual(c.MLN_STATUS_OK, fixture.acquire(&frame));
@@ -219,11 +219,12 @@ pub fn expectStillModeStillImageRequest(comptime Backend: type, map_mode: u32) !
         while (true) {
             var event = support.emptyEvent();
             var has_event = false;
-            try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_poll_event(map, &event, &has_event));
+            try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_poll_event(runtime, &event, &has_event));
             if (!has_event) break;
+            if (event.source_type != c.MLN_RUNTIME_EVENT_SOURCE_MAP or event.source != @as(?*anyopaque, @ptrCast(map))) continue;
 
             switch (event.type) {
-                c.MLN_MAP_EVENT_RENDER_UPDATE_AVAILABLE => {
+                c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE => {
                     const render_status = c.mln_texture_render_update(fixture.texture);
                     if (render_status == c.MLN_STATUS_OK) {
                         rendered_frame = true;
@@ -231,7 +232,7 @@ pub fn expectStillModeStillImageRequest(comptime Backend: type, map_mode: u32) !
                         try testing.expectEqual(c.MLN_STATUS_OK, render_status);
                     }
                 },
-                c.MLN_MAP_EVENT_STILL_IMAGE_FINISHED => {
+                c.MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED => {
                     try testing.expect(rendered_frame);
                     var frame = Backend.Frame.empty(fixture.texture);
                     try testing.expectEqual(c.MLN_STATUS_OK, fixture.acquire(&frame));
@@ -239,7 +240,7 @@ pub fn expectStillModeStillImageRequest(comptime Backend: type, map_mode: u32) !
                     try testing.expectEqual(c.MLN_STATUS_OK, fixture.release(&frame));
                     return;
                 },
-                c.MLN_MAP_EVENT_STILL_IMAGE_FAILED => return error.StillImageFailed,
+                c.MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FAILED => return error.StillImageFailed,
                 else => {},
             }
         }


### PR DESCRIPTION
## Summary
- Move event ownership and draining from maps to the runtime with `mln_runtime_event` and `mln_runtime_poll_event`.
- Add runtime event source/payload metadata so future runtime-level and typed events can use the same drain path.
- Update tests, docs, and Zig/Swift examples while removing the map-event ABI without compatibility shims.

Closes #14

## Testing
- `mise run test`
- `mise run //examples/zig-map:build`
- `mise run //examples/swift-map:build`