### PR TITLE
Add map and render observer events

### DIFF
--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -755,10 +755,10 @@ MLN_API mln_status mln_runtime_run_once(mln_runtime* runtime) MLN_NOEXCEPT;
  * Runtime-originated events set out_event->source_type to
  * MLN_RUNTIME_EVENT_SOURCE_RUNTIME.
  *
- * The C API owns returned event storage. When an event is available,
- * out_event->payload points to a struct selected by out_event->payload_type, or
- * null when the payload type is MLN_RUNTIME_EVENT_PAYLOAD_NONE. String pointers
- * inside typed payloads and out_event->message remain valid until the next
+ * When an event is available, out_event->payload points to runtime-owned
+ * storage containing a struct selected by out_event->payload_type, or null when
+ * the payload type is MLN_RUNTIME_EVENT_PAYLOAD_NONE. String pointers inside
+ * typed payloads and out_event->message remain valid until the next
  * mln_runtime_poll_event() call for the same runtime or until the runtime is
  * destroyed. Copy those bytes before then when they must outlive that window.
  * For style-image-missing and tile-action events, out_event->message contains

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -233,6 +233,12 @@ typedef enum mln_runtime_event_type : uint32_t {
   MLN_RUNTIME_EVENT_MAP_RENDER_ERROR = 10,
   MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED = 11,
   MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FAILED = 12,
+  MLN_RUNTIME_EVENT_MAP_RENDER_FRAME_STARTED = 13,
+  MLN_RUNTIME_EVENT_MAP_RENDER_FRAME_FINISHED = 14,
+  MLN_RUNTIME_EVENT_MAP_RENDER_MAP_STARTED = 15,
+  MLN_RUNTIME_EVENT_MAP_RENDER_MAP_FINISHED = 16,
+  MLN_RUNTIME_EVENT_MAP_STYLE_IMAGE_MISSING = 17,
+  MLN_RUNTIME_EVENT_MAP_TILE_ACTION = 18,
 } mln_runtime_event_type;
 
 /** Source kinds used by mln_runtime_event.source_type. */
@@ -244,7 +250,30 @@ typedef enum mln_runtime_event_source_type : uint32_t {
 /** Payload kinds used by mln_runtime_event.payload_type. */
 typedef enum mln_runtime_event_payload_type : uint32_t {
   MLN_RUNTIME_EVENT_PAYLOAD_NONE = 0,
+  MLN_RUNTIME_EVENT_PAYLOAD_RENDER_FRAME = 1,
+  MLN_RUNTIME_EVENT_PAYLOAD_RENDER_MAP = 2,
+  MLN_RUNTIME_EVENT_PAYLOAD_STYLE_IMAGE_MISSING = 3,
+  MLN_RUNTIME_EVENT_PAYLOAD_TILE_ACTION = 4,
 } mln_runtime_event_payload_type;
+
+/** Render modes reported by render observer events. */
+typedef enum mln_render_mode : uint32_t {
+  MLN_RENDER_MODE_PARTIAL = 0,
+  MLN_RENDER_MODE_FULL = 1,
+} mln_render_mode;
+
+/** Tile operations reported by tile observer events. */
+typedef enum mln_tile_operation : uint32_t {
+  MLN_TILE_OPERATION_REQUESTED_FROM_CACHE = 0,
+  MLN_TILE_OPERATION_REQUESTED_FROM_NETWORK = 1,
+  MLN_TILE_OPERATION_LOAD_FROM_NETWORK = 2,
+  MLN_TILE_OPERATION_LOAD_FROM_CACHE = 3,
+  MLN_TILE_OPERATION_START_PARSE = 4,
+  MLN_TILE_OPERATION_END_PARSE = 5,
+  MLN_TILE_OPERATION_ERROR = 6,
+  MLN_TILE_OPERATION_CANCELLED = 7,
+  MLN_TILE_OPERATION_NULL = 8,
+} mln_tile_operation;
 
 typedef enum mln_resource_kind : uint32_t {
   MLN_RESOURCE_KIND_UNKNOWN = 0,
@@ -337,6 +366,76 @@ typedef struct mln_runtime_options {
   uint64_t maximum_cache_size;
 } mln_runtime_options;
 
+/** Rendering statistics reported in MLN_RUNTIME_EVENT_PAYLOAD_RENDER_FRAME. */
+typedef struct mln_rendering_stats {
+  uint32_t size;
+  /** Frame CPU encoding time in seconds. */
+  double encoding_time;
+  /** Frame CPU rendering time in seconds. */
+  double rendering_time;
+  /** Number of frames rendered by the native renderer. */
+  int64_t frame_count;
+  /** Draw calls executed during the most recent frame. */
+  int64_t draw_call_count;
+  /** Total draw calls executed by the native renderer. */
+  int64_t total_draw_call_count;
+} mln_rendering_stats;
+
+/** Payload for MLN_RUNTIME_EVENT_MAP_RENDER_FRAME_FINISHED. */
+typedef struct mln_runtime_event_render_frame {
+  uint32_t size;
+  /** One of mln_render_mode. */
+  uint32_t mode;
+  /** Whether MapLibre needs another frame after this one. */
+  bool needs_repaint;
+  /** Whether symbol placement changed during this frame. */
+  bool placement_changed;
+  mln_rendering_stats stats;
+} mln_runtime_event_render_frame;
+
+/** Payload for MLN_RUNTIME_EVENT_MAP_RENDER_MAP_FINISHED. */
+typedef struct mln_runtime_event_render_map {
+  uint32_t size;
+  /** One of mln_render_mode. */
+  uint32_t mode;
+} mln_runtime_event_render_map;
+
+/** Payload for MLN_RUNTIME_EVENT_MAP_STYLE_IMAGE_MISSING. */
+typedef struct mln_runtime_event_style_image_missing {
+  uint32_t size;
+  /**
+   * Borrowed image ID bytes. Valid until the next poll for this runtime or
+   * until the runtime is destroyed.
+   */
+  const char* image_id;
+  /** Number of bytes in image_id, excluding the trailing null terminator. */
+  size_t image_id_size;
+} mln_runtime_event_style_image_missing;
+
+/** Overscaled tile identity reported in tile observer events. */
+typedef struct mln_tile_id {
+  uint32_t overscaled_z;
+  int32_t wrap;
+  uint32_t canonical_z;
+  uint32_t canonical_x;
+  uint32_t canonical_y;
+} mln_tile_id;
+
+/** Payload for MLN_RUNTIME_EVENT_MAP_TILE_ACTION. */
+typedef struct mln_runtime_event_tile_action {
+  uint32_t size;
+  /** One of mln_tile_operation. */
+  uint32_t operation;
+  mln_tile_id tile_id;
+  /**
+   * Borrowed source ID bytes. Valid until the next poll for this runtime or
+   * until the runtime is destroyed.
+   */
+  const char* source_id;
+  /** Number of bytes in source_id, excluding the trailing null terminator. */
+  size_t source_id_size;
+} mln_runtime_event_tile_action;
+
 /** Event payload returned by mln_runtime_poll_event(). */
 typedef struct mln_runtime_event {
   uint32_t size;
@@ -352,7 +451,7 @@ typedef struct mln_runtime_event {
   int32_t code;
   /** One of mln_runtime_event_payload_type. */
   uint32_t payload_type;
-  /** Borrowed payload bytes. Null when payload_size is 0. */
+  /** Borrowed payload selected by payload_type. Null when payload_size is 0. */
   const void* payload;
   /** Number of bytes in payload. */
   size_t payload_size;
@@ -656,10 +755,14 @@ MLN_API mln_status mln_runtime_run_once(mln_runtime* runtime) MLN_NOEXCEPT;
  * Runtime-originated events set out_event->source_type to
  * MLN_RUNTIME_EVENT_SOURCE_RUNTIME.
  *
- * When an event is available, out_event->payload and out_event->message point
- * to runtime-owned storage that remains valid until the next
+ * The C API owns returned event storage. When an event is available,
+ * out_event->payload points to a struct selected by out_event->payload_type, or
+ * null when the payload type is MLN_RUNTIME_EVENT_PAYLOAD_NONE. String pointers
+ * inside typed payloads and out_event->message remain valid until the next
  * mln_runtime_poll_event() call for the same runtime or until the runtime is
  * destroyed. Copy those bytes before then when they must outlive that window.
+ * For style-image-missing and tile-action events, out_event->message contains
+ * the same ID string exposed by the typed payload.
  *
  * Returns:
  * - MLN_STATUS_OK when the poll completed; out_has_event indicates whether an

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <exception>
 #include <memory>
 #include <mutex>
@@ -13,6 +14,7 @@
 #include <vector>
 
 #include <mbgl/actor/scheduler.hpp>
+#include <mbgl/gfx/rendering_stats.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_observer.hpp>
@@ -24,6 +26,8 @@
 #include <mbgl/renderer/renderer_observer.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/style/style.hpp>
+#include <mbgl/tile/tile_id.hpp>
+#include <mbgl/tile/tile_operation.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/size.hpp>
@@ -61,6 +65,107 @@ auto map_projection_registry_mutex() -> std::mutex& {
 auto map_projection_registry() -> ProjectionRegistry& {
   static ProjectionRegistry value;
   return value;
+}
+
+template <typename Payload>
+auto payload_bytes(const Payload& payload) -> std::vector<std::byte> {
+  auto result = std::vector<std::byte>(sizeof(Payload));
+  std::memcpy(result.data(), &payload, sizeof(Payload));
+  return result;
+}
+
+auto to_c_render_mode(mbgl::MapObserver::RenderMode mode) -> uint32_t {
+  switch (mode) {
+    case mbgl::MapObserver::RenderMode::Partial:
+      return MLN_RENDER_MODE_PARTIAL;
+    case mbgl::MapObserver::RenderMode::Full:
+      return MLN_RENDER_MODE_FULL;
+  }
+  return MLN_RENDER_MODE_PARTIAL;
+}
+
+auto to_c_rendering_stats(const mbgl::gfx::RenderingStats& stats)
+  -> mln_rendering_stats {
+  return mln_rendering_stats{
+    .size = sizeof(mln_rendering_stats),
+    .encoding_time = stats.encodingTime,
+    .rendering_time = stats.renderingTime,
+    .frame_count = stats.numFrames,
+    .draw_call_count = stats.numDrawCalls,
+    .total_draw_call_count = stats.totalDrawCalls
+  };
+}
+
+auto render_frame_payload(const mbgl::MapObserver::RenderFrameStatus& status)
+  -> mln_runtime_event_render_frame {
+  return mln_runtime_event_render_frame{
+    .size = sizeof(mln_runtime_event_render_frame),
+    .mode = to_c_render_mode(status.mode),
+    .needs_repaint = status.needsRepaint,
+    .placement_changed = status.placementChanged,
+    .stats = to_c_rendering_stats(status.renderingStats)
+  };
+}
+
+auto render_map_payload(mbgl::MapObserver::RenderMode mode)
+  -> mln_runtime_event_render_map {
+  return mln_runtime_event_render_map{
+    .size = sizeof(mln_runtime_event_render_map), .mode = to_c_render_mode(mode)
+  };
+}
+
+auto style_image_missing_payload() -> mln_runtime_event_style_image_missing {
+  return mln_runtime_event_style_image_missing{
+    .size = sizeof(mln_runtime_event_style_image_missing),
+    .image_id = nullptr,
+    .image_id_size = 0
+  };
+}
+
+auto to_c_tile_operation(mbgl::TileOperation operation) -> uint32_t {
+  switch (operation) {
+    case mbgl::TileOperation::RequestedFromCache:
+      return MLN_TILE_OPERATION_REQUESTED_FROM_CACHE;
+    case mbgl::TileOperation::RequestedFromNetwork:
+      return MLN_TILE_OPERATION_REQUESTED_FROM_NETWORK;
+    case mbgl::TileOperation::LoadFromNetwork:
+      return MLN_TILE_OPERATION_LOAD_FROM_NETWORK;
+    case mbgl::TileOperation::LoadFromCache:
+      return MLN_TILE_OPERATION_LOAD_FROM_CACHE;
+    case mbgl::TileOperation::StartParse:
+      return MLN_TILE_OPERATION_START_PARSE;
+    case mbgl::TileOperation::EndParse:
+      return MLN_TILE_OPERATION_END_PARSE;
+    case mbgl::TileOperation::Error:
+      return MLN_TILE_OPERATION_ERROR;
+    case mbgl::TileOperation::Cancelled:
+      return MLN_TILE_OPERATION_CANCELLED;
+    case mbgl::TileOperation::NullOp:
+      return MLN_TILE_OPERATION_NULL;
+  }
+  return MLN_TILE_OPERATION_NULL;
+}
+
+auto to_c_tile_id(const mbgl::OverscaledTileID& tile_id) -> mln_tile_id {
+  return mln_tile_id{
+    .overscaled_z = tile_id.overscaledZ,
+    .wrap = tile_id.wrap,
+    .canonical_z = tile_id.canonical.z,
+    .canonical_x = tile_id.canonical.x,
+    .canonical_y = tile_id.canonical.y
+  };
+}
+
+auto tile_action_payload(
+  mbgl::TileOperation operation, const mbgl::OverscaledTileID& tile_id
+) -> mln_runtime_event_tile_action {
+  return mln_runtime_event_tile_action{
+    .size = sizeof(mln_runtime_event_tile_action),
+    .operation = to_c_tile_operation(operation),
+    .tile_id = to_c_tile_id(tile_id),
+    .source_id = nullptr,
+    .source_id_size = 0
+  };
 }
 
 class HeadlessObserver final : public mbgl::MapObserver {
@@ -101,7 +206,49 @@ class HeadlessObserver final : public mbgl::MapObserver {
     push(MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
   }
 
+  void onWillStartRenderingFrame() override {
+    push(MLN_RUNTIME_EVENT_MAP_RENDER_FRAME_STARTED);
+  }
+
+  void onDidFinishRenderingFrame(const RenderFrameStatus& status) override {
+    push_payload(
+      MLN_RUNTIME_EVENT_MAP_RENDER_FRAME_FINISHED,
+      MLN_RUNTIME_EVENT_PAYLOAD_RENDER_FRAME,
+      payload_bytes(render_frame_payload(status))
+    );
+  }
+
+  void onWillStartRenderingMap() override {
+    push(MLN_RUNTIME_EVENT_MAP_RENDER_MAP_STARTED);
+  }
+
+  void onDidFinishRenderingMap(RenderMode mode) override {
+    push_payload(
+      MLN_RUNTIME_EVENT_MAP_RENDER_MAP_FINISHED,
+      MLN_RUNTIME_EVENT_PAYLOAD_RENDER_MAP,
+      payload_bytes(render_map_payload(mode))
+    );
+  }
+
   void onDidBecomeIdle() override { push(MLN_RUNTIME_EVENT_MAP_IDLE); }
+
+  void onStyleImageMissing(const std::string& image_id) override {
+    push_payload(
+      MLN_RUNTIME_EVENT_MAP_STYLE_IMAGE_MISSING,
+      MLN_RUNTIME_EVENT_PAYLOAD_STYLE_IMAGE_MISSING,
+      payload_bytes(style_image_missing_payload()), 0, image_id
+    );
+  }
+
+  void onTileAction(
+    mbgl::TileOperation operation, const mbgl::OverscaledTileID& tile_id,
+    const std::string& source_id
+  ) override {
+    push_payload(
+      MLN_RUNTIME_EVENT_MAP_TILE_ACTION, MLN_RUNTIME_EVENT_PAYLOAD_TILE_ACTION,
+      payload_bytes(tile_action_payload(operation, tile_id)), 0, source_id
+    );
+  }
 
   void onRenderError(std::exception_ptr error) override {
     try {
@@ -120,6 +267,16 @@ class HeadlessObserver final : public mbgl::MapObserver {
   auto push(uint32_t type, int32_t code = 0, const char* message = nullptr)
     -> void {
     mln::core::push_runtime_map_event(runtime_, map_, type, code, message);
+  }
+
+  auto push_payload(
+    uint32_t type, uint32_t payload_type, std::vector<std::byte> payload,
+    int32_t code = 0, std::string message = {}
+  ) -> void {
+    mln::core::push_runtime_map_event_payload(
+      runtime_, map_, type, payload_type, std::move(payload), code,
+      std::move(message)
+    );
   }
 
   mln_runtime* runtime_;

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <exception>
 #include <functional>
 #include <memory>
@@ -9,6 +11,7 @@
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/storage/database_file_source.hpp>
@@ -117,6 +120,51 @@ auto wait_for_database_operation(
     return MLN_STATUS_NATIVE_ERROR;
   }
   return MLN_STATUS_OK;
+}
+
+auto patch_polled_payload_strings(mln_runtime* runtime, uint32_t payload_type)
+  -> void {
+  const auto* const text = runtime->last_polled_event_message.empty()
+                             ? nullptr
+                             : runtime->last_polled_event_message.c_str();
+  const auto text_size = runtime->last_polled_event_message.size();
+
+  switch (payload_type) {
+    case MLN_RUNTIME_EVENT_PAYLOAD_STYLE_IMAGE_MISSING:
+      if (
+        runtime->last_polled_event_payload.size() >=
+        sizeof(mln_runtime_event_style_image_missing)
+      ) {
+        auto payload = mln_runtime_event_style_image_missing{};
+        std::memcpy(
+          &payload, runtime->last_polled_event_payload.data(), sizeof(payload)
+        );
+        payload.image_id = text;
+        payload.image_id_size = text_size;
+        std::memcpy(
+          runtime->last_polled_event_payload.data(), &payload, sizeof(payload)
+        );
+      }
+      break;
+    case MLN_RUNTIME_EVENT_PAYLOAD_TILE_ACTION:
+      if (
+        runtime->last_polled_event_payload.size() >=
+        sizeof(mln_runtime_event_tile_action)
+      ) {
+        auto payload = mln_runtime_event_tile_action{};
+        std::memcpy(
+          &payload, runtime->last_polled_event_payload.data(), sizeof(payload)
+        );
+        payload.source_id = text;
+        payload.source_id_size = text_size;
+        std::memcpy(
+          runtime->last_polled_event_payload.data(), &payload, sizeof(payload)
+        );
+      }
+      break;
+    default:
+      break;
+  }
 }
 
 }  // namespace
@@ -395,6 +443,7 @@ auto poll_runtime_event(
   runtime->events.pop_front();
   runtime->last_polled_event_payload = std::move(event.payload);
   runtime->last_polled_event_message = std::move(event.message);
+  patch_polled_payload_strings(runtime, event.payload_type);
 
   out_event->type = event.type;
   out_event->source_type = event.source_type;
@@ -468,6 +517,16 @@ auto push_runtime_map_event(
   mln_runtime* runtime, mln_map* map, uint32_t type, int32_t code,
   const char* message
 ) -> void {
+  push_runtime_map_event_payload(
+    runtime, map, type, MLN_RUNTIME_EVENT_PAYLOAD_NONE, {}, code,
+    message == nullptr ? std::string{} : std::string{message}
+  );
+}
+
+auto push_runtime_map_event_payload(
+  mln_runtime* runtime, mln_map* map, uint32_t type, uint32_t payload_type,
+  std::vector<std::byte> payload, int32_t code, std::string message
+) -> void {
   if (runtime == nullptr) {
     return;
   }
@@ -478,9 +537,9 @@ auto push_runtime_map_event(
     .source = map,
     .map = map,
     .code = code,
-    .payload_type = MLN_RUNTIME_EVENT_PAYLOAD_NONE,
-    .payload = {},
-    .message = message == nullptr ? std::string{} : std::string{message}
+    .payload_type = payload_type,
+    .payload = std::move(payload),
+    .message = std::move(message)
   };
 
   const std::scoped_lock lock(runtime->event_mutex);

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -85,6 +85,10 @@ auto push_runtime_map_event(
   mln_runtime* runtime, mln_map* map, uint32_t type, int32_t code = 0,
   const char* message = nullptr
 ) -> void;
+auto push_runtime_map_event_payload(
+  mln_runtime* runtime, mln_map* map, uint32_t type, uint32_t payload_type,
+  std::vector<std::byte> payload, int32_t code = 0, std::string message = {}
+) -> void;
 auto register_runtime_map_events(mln_runtime* runtime, const mln_map* map)
   -> void;
 auto clear_runtime_map_loading_failure(mln_runtime* runtime, const mln_map* map)

--- a/tests/c/events.zig
+++ b/tests/c/events.zig
@@ -34,6 +34,54 @@ test "runtime event polling rejects invalid outputs" {
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_poll_event(runtime, &event, &has_event));
 }
 
+test "observer event payload ABI is visible to C import" {
+    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_RENDER_FRAME, @as(u32, 1));
+    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_RENDER_MAP, @as(u32, 2));
+    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_STYLE_IMAGE_MISSING, @as(u32, 3));
+    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_TILE_ACTION, @as(u32, 4));
+
+    try testing.expectEqual(c.MLN_RENDER_MODE_PARTIAL, @as(u32, 0));
+    try testing.expectEqual(c.MLN_RENDER_MODE_FULL, @as(u32, 1));
+    try testing.expectEqual(c.MLN_TILE_OPERATION_REQUESTED_FROM_CACHE, @as(u32, 0));
+    try testing.expectEqual(c.MLN_TILE_OPERATION_NULL, @as(u32, 8));
+
+    const stats = c.mln_rendering_stats{
+        .size = @sizeOf(c.mln_rendering_stats),
+        .encoding_time = 0,
+        .rendering_time = 0,
+        .frame_count = 0,
+        .draw_call_count = 0,
+        .total_draw_call_count = 0,
+    };
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_rendering_stats)), stats.size);
+
+    const frame = c.mln_runtime_event_render_frame{
+        .size = @sizeOf(c.mln_runtime_event_render_frame),
+        .mode = c.MLN_RENDER_MODE_FULL,
+        .needs_repaint = false,
+        .placement_changed = false,
+        .stats = stats,
+    };
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_runtime_event_render_frame)), frame.size);
+    try testing.expectEqual(c.MLN_RENDER_MODE_FULL, frame.mode);
+
+    const tile = c.mln_runtime_event_tile_action{
+        .size = @sizeOf(c.mln_runtime_event_tile_action),
+        .operation = c.MLN_TILE_OPERATION_START_PARSE,
+        .tile_id = .{
+            .overscaled_z = 1,
+            .wrap = 0,
+            .canonical_z = 1,
+            .canonical_x = 0,
+            .canonical_y = 0,
+        },
+        .source_id = null,
+        .source_id_size = 0,
+    };
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_runtime_event_tile_action)), tile.size);
+    try testing.expectEqual(c.MLN_TILE_OPERATION_START_PARSE, tile.operation);
+}
+
 test "event message storage is copied into caller output" {
     try support.suppressLogs();
     defer support.restoreLogs();

--- a/tests/c/texture.zig
+++ b/tests/c/texture.zig
@@ -194,6 +194,93 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     frame_acquired = false;
 }
 
+pub fn expectRenderObserverEvents(comptime Backend: type) !void {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+    var fixture = try Backend.Fixture.create(map);
+    defer fixture.destroy();
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+
+    var rendered_update = false;
+    var pending_render_update = false;
+    var saw_frame_started = false;
+    var saw_frame_finished = false;
+    var saw_map_started = false;
+    var saw_map_finished = false;
+    for (0..1000) |_| {
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_once(runtime));
+
+        if (pending_render_update) {
+            pending_render_update = false;
+            const render_status = c.mln_texture_render_update(fixture.texture);
+            if (render_status == c.MLN_STATUS_OK) {
+                rendered_update = true;
+            } else if (render_status != c.MLN_STATUS_INVALID_STATE) {
+                try testing.expectEqual(c.MLN_STATUS_OK, render_status);
+            }
+        }
+
+        while (true) {
+            var event = support.emptyEvent();
+            var has_event = false;
+            try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_poll_event(runtime, &event, &has_event));
+            if (!has_event) break;
+            if (event.source_type != c.MLN_RUNTIME_EVENT_SOURCE_MAP or event.source != @as(?*anyopaque, @ptrCast(map))) continue;
+
+            switch (event.type) {
+                c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE => {
+                    pending_render_update = true;
+                },
+                c.MLN_RUNTIME_EVENT_MAP_RENDER_FRAME_STARTED => {
+                    saw_frame_started = true;
+                    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_NONE, event.payload_type);
+                    try testing.expectEqual(@as(?*const anyopaque, null), event.payload);
+                },
+                c.MLN_RUNTIME_EVENT_MAP_RENDER_FRAME_FINISHED => {
+                    saw_frame_finished = true;
+                    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_RENDER_FRAME, event.payload_type);
+                    try testing.expectEqual(@as(usize, @sizeOf(c.mln_runtime_event_render_frame)), event.payload_size);
+                    const payload: *const c.mln_runtime_event_render_frame = @ptrCast(@alignCast(event.payload.?));
+                    try testing.expectEqual(@as(u32, @sizeOf(c.mln_runtime_event_render_frame)), payload.size);
+                    try testing.expect(payload.mode == c.MLN_RENDER_MODE_PARTIAL or payload.mode == c.MLN_RENDER_MODE_FULL);
+                    try testing.expectEqual(@as(u32, @sizeOf(c.mln_rendering_stats)), payload.stats.size);
+                    try testing.expect(payload.stats.encoding_time >= 0);
+                    try testing.expect(payload.stats.rendering_time >= 0);
+                },
+                c.MLN_RUNTIME_EVENT_MAP_RENDER_MAP_STARTED => {
+                    saw_map_started = true;
+                    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_NONE, event.payload_type);
+                    try testing.expectEqual(@as(?*const anyopaque, null), event.payload);
+                },
+                c.MLN_RUNTIME_EVENT_MAP_RENDER_MAP_FINISHED => {
+                    saw_map_finished = true;
+                    try testing.expectEqual(c.MLN_RUNTIME_EVENT_PAYLOAD_RENDER_MAP, event.payload_type);
+                    try testing.expectEqual(@as(usize, @sizeOf(c.mln_runtime_event_render_map)), event.payload_size);
+                    const payload: *const c.mln_runtime_event_render_map = @ptrCast(@alignCast(event.payload.?));
+                    try testing.expectEqual(@as(u32, @sizeOf(c.mln_runtime_event_render_map)), payload.size);
+                    try testing.expect(payload.mode == c.MLN_RENDER_MODE_PARTIAL or payload.mode == c.MLN_RENDER_MODE_FULL);
+                },
+                else => {},
+            }
+        }
+
+        if (saw_frame_started and saw_frame_finished and saw_map_started and saw_map_finished) break;
+        _ = usleep(1000);
+    }
+
+    try testing.expect(rendered_update);
+    try testing.expect(saw_frame_started);
+    try testing.expect(saw_frame_finished);
+    try testing.expect(saw_map_started);
+    try testing.expect(saw_map_finished);
+}
+
 pub fn expectStillModeStillImageRequest(comptime Backend: type, map_mode: u32) !void {
     try support.suppressLogs();
     defer support.restoreLogs();

--- a/tests/c/texture_metal.zig
+++ b/tests/c/texture_metal.zig
@@ -170,6 +170,11 @@ test "Metal texture render acquire release and resize generation" {
     try common.expectRenderAcquireReleaseAndResizeGeneration(Backend);
 }
 
+test "Metal texture render emits observer events" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try common.expectRenderObserverEvents(Backend);
+}
+
 test "Metal texture supports static still-image requests" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
     try common.expectStillModeStillImageRequest(Backend, c.MLN_MAP_MODE_STATIC);

--- a/tests/c/texture_vulkan.zig
+++ b/tests/c/texture_vulkan.zig
@@ -267,6 +267,11 @@ test "Vulkan texture render acquire release and resize generation" {
     try common.expectRenderAcquireReleaseAndResizeGeneration(Backend);
 }
 
+test "Vulkan texture render emits observer events" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    try common.expectRenderObserverEvents(Backend);
+}
+
 test "Vulkan texture supports static still-image requests" {
     if (builtin.os.tag != .linux) return error.SkipZigTest;
     try common.expectStillModeStillImageRequest(Backend, c.MLN_MAP_MODE_STATIC);


### PR DESCRIPTION
## Summary
- Expose render lifecycle, style-image-missing, and tile-action observer events through runtime polling.
- Add typed C ABI payloads for render stats, render modes, image IDs, tile IDs, source IDs, and tile operations.
- Add C ABI shape coverage plus Metal and Vulkan render observer event tests.

## Tests
- `mise run test` (73 passed, 9 skipped, 82 total)

Closes #39