### PR TITLE
Preserve host XDG data dirs for zig-map

### DIFF
--- a/examples/zig-map/mise.toml
+++ b/examples/zig-map/mise.toml
@@ -3,7 +3,7 @@ DYLD_LIBRARY_PATH = "{{config_root}}/../../build"
 LD_LIBRARY_PATH = "{{config_root}}/../../build"
 PKG_CONFIG = "{{config_root}}/../../.pixi/envs/default/bin/pkg-config"
 PKG_CONFIG_PATH = "{{config_root}}/../../build/pkgconfig"
-XDG_DATA_DIRS = "{{config_root}}/../../.pixi/envs/default/share"
+XDG_DATA_DIRS = "{{config_root}}/../../.pixi/envs/default/share:{{env.XDG_DATA_DIRS | default(value=\"/usr/local/share:/usr/share\")}}"
 
 [tasks.build]
 depends = ["//:build", ":compile-shaders"]


### PR DESCRIPTION
## Summary
- Preserve the host XDG data directory search path when running the Zig map example.
- Keep the XDG spec fallback so system Vulkan ICD manifests remain discoverable when the host variable is unset.

## Testing
- `mise run test`
- `mise run check`
- `timeout 8s mise run //examples/zig-map:run` (window/map loop starts; command was intentionally timed out)