### PR TITLE
Reshape CI around native artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,35 +9,49 @@ on:
 permissions:
   contents: read
 
+env:
+  MISE_ENV: ci
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  docs:
-    name: docs
+  hygiene:
+    name: hygiene
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-ci-deps
 
-      - run: mise run docs:c
+      - run: mise run ci:hygiene
 
-  build:
-    name: ${{ matrix.id }}
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-ci-deps
+
+      - run: mise run ci:docs
+
+  native:
+    name: native / ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         include:
-          - id: linux-x64
+          - target: linux-x64
             runner: ubuntu-latest
-          - id: linux-arm64
+          - target: linux-arm64
             runner: ubuntu-24.04-arm
-          - id: macos-arm64
+          - target: macos-arm64
             runner: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -50,23 +64,68 @@ jobs:
           path: third_party/maplibre-native
           key: mln-src-v1-${{ hashFiles('cmake/mln_version.cmake') }}
 
-      - run: mise run fix
-      - run: mise run _verify-clean-worktree
-      - run: mise run test
-      - run: mise run //examples/zig-map:build
-      - run: mise run //examples/zig-readback:run
-      - if: matrix.id == 'macos-arm64'
-        run: mise run //examples/swift-map:build
+      - run: mise run ci:native
 
-      - name: Upload diagnostics on failure
-        if: failure()
+      - run: mise run ci:native-artifact
+
+      - name: Upload native artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: diagnostics-${{ matrix.id }}-${{ github.run_id }}
-          path: |
-            build/CMakeCache.txt
-            build/compile_commands.json
-            build/CMakeFiles/CMakeOutput.log
-            build/CMakeFiles/CMakeError.log
-          if-no-files-found: ignore
+          name: native-${{ matrix.target }}
+          path: ci-artifact
+          if-no-files-found: error
           retention-days: 14
+
+  examples:
+    name: examples / ${{ matrix.example }} / ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    needs: native
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        example: [zig-map, zig-readback, swift-map]
+        target: [linux-x64, linux-arm64, macos-arm64]
+        exclude:
+          - example: swift-map
+            target: linux-x64
+          - example: swift-map
+            target: linux-arm64
+        include:
+          - target: linux-x64
+            runner: ubuntu-latest
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+          - target: macos-arm64
+            runner: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-ci-deps
+
+      - name: Download native artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: native-${{ matrix.target }}
+          path: .
+
+      - run: mise run ci:examples:${{ matrix.example }}
+
+  required:
+    name: ci-required
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs:
+      - hygiene
+      - docs
+      - native
+      - examples
+    steps:
+      - name: Fail if required jobs failed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo '${{ toJSON(needs) }}'
+          exit 1
+
+      - run: true

--- a/.mise/tasks/ensure-native-library
+++ b/.mise/tasks/ensure-native-library
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${CI:-}" != "true" ]]; then
+  exec mise run //:build
+fi
+
+if [[ ! -f build/pkgconfig/maplibre-native-c.pc ]]; then
+  echo "missing build/pkgconfig/maplibre-native-c.pc; native artifact was not downloaded" >&2
+  exit 1
+fi
+
+found=false
+for lib in build/libmaplibre-native-c.*; do
+  if [[ -f "$lib" ]]; then
+    found=true
+    break
+  fi
+done
+
+if [[ "$found" != "true" ]]; then
+  echo "missing build/libmaplibre-native-c.*; native artifact was not downloaded" >&2
+  exit 1
+fi

--- a/cmake/maplibre-native-c.ci-artifact.pc
+++ b/cmake/maplibre-native-c.ci-artifact.pc
@@ -1,0 +1,9 @@
+prefix=${pcfiledir}/../..
+includedir=${prefix}/include
+libdir=${prefix}/build
+
+Name: maplibre-native-c
+Description: C ABI for MapLibre Native
+Version: 0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmaplibre-native-c

--- a/examples/swift-map/mise.toml
+++ b/examples/swift-map/mise.toml
@@ -2,6 +2,7 @@
 PKG_CONFIG_PATH = "{{config_root}}/../../build/pkgconfig"
 
 [tasks.build]
+depends = ["//:ensure-native-library"]
 run = "swift build"
 
 [tasks.run]

--- a/examples/zig-map/mise.toml
+++ b/examples/zig-map/mise.toml
@@ -6,21 +6,21 @@ PKG_CONFIG_PATH = "{{config_root}}/../../build/pkgconfig"
 XDG_DATA_DIRS = "{{config_root}}/../../.pixi/envs/default/share:{{env.XDG_DATA_DIRS | default(value=\"/usr/local/share:/usr/share\")}}"
 
 [tasks.build]
-depends = ["//:build", ":compile-shaders"]
+depends = ["//:ensure-native-library", ":compile-shaders"]
 run = "zig build"
 
 [tasks.run]
-depends = ["//:build", ":compile-shaders"]
+depends = ["//:ensure-native-library", ":compile-shaders"]
 run = "zig build run -- --render-target=owned-texture"
 
 [tasks."run:owned-texture"]
-depends = ["//:build", ":compile-shaders"]
+depends = ["//:ensure-native-library", ":compile-shaders"]
 run = "zig build run -- --render-target=owned-texture"
 
 [tasks."run:borrowed-texture"]
-depends = ["//:build", ":compile-shaders"]
+depends = ["//:ensure-native-library", ":compile-shaders"]
 run = "zig build run -- --render-target=borrowed-texture"
 
 [tasks."run:native-surface"]
-depends = ["//:build", ":compile-shaders"]
+depends = ["//:ensure-native-library", ":compile-shaders"]
 run = "zig build run -- --render-target=native-surface"

--- a/examples/zig-readback/mise.toml
+++ b/examples/zig-readback/mise.toml
@@ -6,9 +6,9 @@ PKG_CONFIG_PATH = "{{config_root}}/../../build/pkgconfig"
 XDG_DATA_DIRS = "{{config_root}}/../../.pixi/envs/default/share:{{env.XDG_DATA_DIRS | default(value=\"/usr/local/share:/usr/share\")}}"
 
 [tasks.build]
-depends = ["//:build"]
+depends = ["//:ensure-native-library"]
 run = "zig build"
 
 [tasks.run]
-depends = ["//:build"]
+depends = ["//:ensure-native-library"]
 run = "mkdir -p zig-out && zig build run -- zig-out/zig-readback.ppm"

--- a/hk.pkl
+++ b/hk.pkl
@@ -2,32 +2,48 @@ amends "package://github.com/jdx/hk/releases/download/v1.40.0/hk@1.40.0#/Config.
 
 import "package://github.com/jdx/hk/releases/download/v1.40.0/hk@1.40.0#/Builtins.pkl"
 
-local allSteps = new Mapping<String, Step> {
-  ["dprint"] = Builtins.dprint
-  ["cmake-configure"] {
-    glob = List("CMakeLists.txt", "**/*.cmake", "**/*.cmake.in")
-    check = "mise run configure"
+local commonProfiles = List("!ci-native")
+local nativeProfiles = List("!ci-common")
+
+local commonSteps = new Mapping<String, Step> {
+  ["dprint"] = (Builtins.dprint) {
+    profiles = commonProfiles
   }
-  ["clang-tidy"] {
-    glob = List("include/**/*.h", "include/**/*.hpp", "src/**/*.cpp", "src/**/*.cc", "src/**/*.cxx", "src/**/*.hpp")
-    exclude = List("src/render/vulkan/**")
-    depends = List("cmake-configure")
-    check = "pixi run clang-tidy --quiet --config-file=.clang-tidy -p build {{files}}"
-  }
-  ["clang-tidy-vulkan"] {
-    glob = List("src/render/vulkan/**/*.cpp", "src/render/vulkan/**/*.hpp")
-    depends = List("cmake-configure")
-    step_condition = "exec('uname -s') == 'Linux'"
-    check = "pixi run clang-tidy --quiet --config-file=.clang-tidy -p build {{files}}"
+  ["actionlint"] {
+    glob = List(".github/workflows/*.yml", ".github/workflows/*.yaml")
+    profiles = commonProfiles
+    check = "actionlint {{files}}"
   }
   ["jvl"] {
     glob = List("**/*.json", "**/*.jsonc")
+    profiles = commonProfiles
     check = "jvl check {{files}}"
   }
   ["zig-ast-check"] {
     glob = List("**/*.zig")
+    profiles = commonProfiles
     check = "for file in {{files}}; do zig ast-check \"$file\"; done"
   }
+}
+
+local nativeSteps = new Mapping<String, Step> {
+  ["clang-tidy"] {
+    glob = List("include/**/*.h", "include/**/*.hpp", "src/**/*.cpp", "src/**/*.cc", "src/**/*.cxx", "src/**/*.hpp")
+    exclude = List("src/render/vulkan/**")
+    profiles = nativeProfiles
+    check = "pixi run clang-tidy --quiet --config-file=.clang-tidy -p build {{files}}"
+  }
+  ["clang-tidy-vulkan"] {
+    glob = List("src/render/vulkan/**/*.cpp", "src/render/vulkan/**/*.hpp")
+    profiles = nativeProfiles
+    step_condition = "exec('uname -s') == 'Linux'"
+    check = "pixi run clang-tidy --quiet --config-file=.clang-tidy -p build {{files}}"
+  }
+}
+
+local allSteps = new Mapping<String, Step> {
+  ...commonSteps
+  ...nativeSteps
 }
 
 hooks {

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -1,0 +1,40 @@
+[tasks."ci:hygiene"]
+run = [
+  "hk fix --all --profile ci-common",
+  "mise run _verify-clean-worktree",
+]
+
+[tasks."ci:native-lint"]
+run = [
+  "mise run configure",
+  "hk fix --all --profile ci-native",
+  "mise run _verify-clean-worktree",
+]
+
+[tasks."ci:native"]
+run = [
+  "mise run ci:native-lint",
+  "mise run test",
+]
+
+[tasks."ci:native-artifact"]
+run = [
+  "pixi run cmake -E rm -rf ci-artifact",
+  "pixi run cmake -E make_directory ci-artifact/build/pkgconfig",
+  "pixi run cmake -E make_directory ci-artifact/third_party/maplibre-native/vendor/Vulkan-Headers",
+  "pixi run cmake -E copy build/libmaplibre-native-c.* ci-artifact/build",
+  "pixi run cmake -E copy cmake/maplibre-native-c.ci-artifact.pc ci-artifact/build/pkgconfig/maplibre-native-c.pc",
+  "pixi run cmake -E copy_directory third_party/maplibre-native/vendor/Vulkan-Headers/include ci-artifact/third_party/maplibre-native/vendor/Vulkan-Headers/include",
+]
+
+[tasks."ci:docs"]
+run = "mise run docs:c"
+
+[tasks."ci:examples:zig-map"]
+run = "mise run --skip-deps //examples/zig-map:build"
+
+[tasks."ci:examples:zig-readback"]
+run = "mise run --skip-deps //examples/zig-readback:run"
+
+[tasks."ci:examples:swift-map"]
+run = "mise run --skip-deps //examples/swift-map:build"

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -31,7 +31,10 @@ run = [
 run = "mise run docs:c"
 
 [tasks."ci:examples:zig-map"]
-run = "mise run --skip-deps //examples/zig-map:build"
+run = [
+  "mise run //examples/zig-map:compile-shaders",
+  "mise run --skip-deps //examples/zig-map:build",
+]
 
 [tasks."ci:examples:zig-readback"]
 run = "mise run --skip-deps //examples/zig-readback:run"

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -31,13 +31,10 @@ run = [
 run = "mise run docs:c"
 
 [tasks."ci:examples:zig-map"]
-run = [
-  "mise run //examples/zig-map:compile-shaders",
-  "mise run --skip-deps //examples/zig-map:build",
-]
+run = "mise run //examples/zig-map:build"
 
 [tasks."ci:examples:zig-readback"]
-run = "mise run --skip-deps //examples/zig-readback:run"
+run = "mise run //examples/zig-readback:run"
 
 [tasks."ci:examples:swift-map"]
-run = "mise run --skip-deps //examples/swift-map:build"
+run = "mise run //examples/swift-map:build"

--- a/mise.toml
+++ b/mise.toml
@@ -16,6 +16,7 @@ pixi = "0.67.2"
 "github:cmakefmt/cmakefmt" = "1.3.0"
 zig = "0.16.0"
 "conda:doxygen" = "1.13.2"
+actionlint = "1.7.8"
 
 [hooks]
 postinstall = [
@@ -28,14 +29,14 @@ env = { CC = "clang", CXX = "clang++" }
 run = "pixi run cmake -S . -B build -G Ninja"
 
 [tasks.build]
-depends = ["configure"]
+depends = ["//:configure"]
 run = "pixi run cmake --build build --parallel"
 
 [tasks.clean]
 run = "rm -rf build"
 
 [tasks.test]
-depends = ["build"]
+depends = ["//:build"]
 env = { XDG_DATA_DIRS = "{{config_root}}/.pixi/envs/default/share" }
 run = "zig build test --summary all"
 


### PR DESCRIPTION
## Summary
- Split CI into hygiene, docs, native, examples, and a stable `ci-required` aggregate check.
- Move CI-only task entrypoints into `mise.ci.toml` and split hk lint profiles into common and native groups.
- Reuse native C API build outputs in examples via a platform artifact and relocatable CI pkg-config file.

## Validation
- Pre-commit hook during commit: dprint and actionlint
- `MISE_ENV=ci mise tasks validate`
- `mise exec -- hk fix --profile ci-common --step actionlint .github/workflows/ci.yml`