### PR TITLE
Unify render session API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ add_library(
     src/diagnostics/diagnostics.cpp
     src/logging/logging.cpp
     src/map/map.cpp
+    src/render/render_session_common.cpp
     src/render/surface_session.cpp
     src/render/texture_session.cpp
     src/resources/custom_resource_provider.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ add_library(
     src/c_api/logging.cpp
     src/c_api/map.cpp
     src/c_api/network.cpp
+    src/c_api/render_session.cpp
     src/c_api/runtime.cpp
     src/c_api/surface.cpp
     src/c_api/texture.cpp

--- a/examples/swift-map/Sources/SwiftMap/MapState.swift
+++ b/examples/swift-map/Sources/SwiftMap/MapState.swift
@@ -14,21 +14,21 @@ struct Viewport: Equatable {
 final class MapState {
   nonisolated(unsafe) private(set) var runtime: OpaquePointer? = nil
   nonisolated(unsafe) private(set) var map: OpaquePointer? = nil
-  nonisolated(unsafe) private(set) var surface: OpaquePointer? = nil
+  nonisolated(unsafe) private(set) var renderSession: OpaquePointer? = nil
 
   init(viewport: Viewport, layer: CAMetalLayer) throws {
     var createdRuntime: OpaquePointer?
     var createdMap: OpaquePointer?
-    var createdSurface: OpaquePointer?
+    var createdRenderSession: OpaquePointer?
 
     do {
       try Self.createRuntime(&createdRuntime)
       try Self.createMap(runtime: createdRuntime, viewport: viewport, outMap: &createdMap)
       try Self.loadStyle(map: createdMap)
       try Self.setInitialCamera(map: createdMap)
-      try Self.attachSurface(map: createdMap, viewport: viewport, layer: layer, outSurface: &createdSurface)
+      try Self.attachSurface(map: createdMap, viewport: viewport, layer: layer, outSession: &createdRenderSession)
     } catch {
-      if let createdSurface { _ = mln_surface_destroy(createdSurface) }
+      if let createdRenderSession { _ = mln_render_session_destroy(createdRenderSession) }
       if let createdMap { _ = mln_map_destroy(createdMap) }
       if let createdRuntime { _ = mln_runtime_destroy(createdRuntime) }
       throw error
@@ -36,19 +36,19 @@ final class MapState {
 
     runtime = createdRuntime
     map = createdMap
-    surface = createdSurface
+    renderSession = createdRenderSession
   }
 
   deinit {
-    if let surface { _ = mln_surface_destroy(surface) }
+    if let renderSession { _ = mln_render_session_destroy(renderSession) }
     if let map { _ = mln_map_destroy(map) }
     if let runtime { _ = mln_runtime_destroy(runtime) }
   }
 
   func resize(_ viewport: Viewport) throws {
     try checkCAPI(
-      mln_surface_resize(surface, viewport.logicalWidth, viewport.logicalHeight, viewport.scaleFactor),
-      "surface resize failed"
+      mln_render_session_resize(renderSession, viewport.logicalWidth, viewport.logicalHeight, viewport.scaleFactor),
+      "render session resize failed"
     )
   }
 
@@ -74,10 +74,10 @@ final class MapState {
   }
 
   func render() throws -> Bool {
-    let status = mln_surface_render_update(surface)
+    let status = mln_render_session_render_update(renderSession)
     if status == MLN_STATUS_OK { return true }
     if status == MLN_STATUS_INVALID_STATE { return false }
-    try checkCAPI(status, "surface render failed")
+    try checkCAPI(status, "render session render failed")
     return false
   }
 
@@ -126,13 +126,13 @@ final class MapState {
     map: OpaquePointer?,
     viewport: Viewport,
     layer: CAMetalLayer,
-    outSurface: inout OpaquePointer?
+    outSession: inout OpaquePointer?
   ) throws {
     var descriptor = mln_metal_surface_descriptor_default()
     descriptor.width = viewport.logicalWidth
     descriptor.height = viewport.logicalHeight
     descriptor.scale_factor = viewport.scaleFactor
     descriptor.layer = Unmanaged.passUnretained(layer).toOpaque()
-    try checkCAPI(mln_metal_surface_attach(map, &descriptor, &outSurface), "Metal surface attach failed")
+    try checkCAPI(mln_metal_surface_attach(map, &descriptor, &outSession), "Metal surface attach failed")
   }
 }

--- a/examples/zig-map/render/metal/mod.zig
+++ b/examples/zig-map/render/metal/mod.zig
@@ -84,7 +84,7 @@ pub const MetalBackend = union(enum) {
 
     pub fn drawTexture(
         self: *MetalBackend,
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         viewport: types.Viewport,
     ) !bool {
         return switch (self.*) {
@@ -229,7 +229,7 @@ const MetalOwnedTextureBackend = struct {
         descriptor.height = viewport.logical_height;
         descriptor.scale_factor = viewport.scale_factor;
         descriptor.device = self.compositor.view.device.value.?;
-        var texture: ?*c.mln_texture_session = null;
+        var texture: ?*c.mln_render_session = null;
         if (c.mln_metal_owned_texture_attach(map, &descriptor, &texture) !=
             c.MLN_STATUS_OK or texture == null)
         {
@@ -241,7 +241,7 @@ const MetalOwnedTextureBackend = struct {
 
     fn drawTexture(
         self: *MetalOwnedTextureBackend,
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         _: types.Viewport,
     ) !bool {
         var frame: c.mln_metal_owned_texture_frame = .{
@@ -302,7 +302,7 @@ const MetalBorrowedTextureBackend = struct {
         descriptor.height = viewport.logical_height;
         descriptor.scale_factor = viewport.scale_factor;
         descriptor.texture = self.borrowed_texture.value.?;
-        var texture: ?*c.mln_texture_session = null;
+        var texture: ?*c.mln_render_session = null;
         if (c.mln_metal_borrowed_texture_attach(map, &descriptor, &texture) !=
             c.MLN_STATUS_OK or texture == null)
         {
@@ -314,7 +314,7 @@ const MetalBorrowedTextureBackend = struct {
 
     fn drawTexture(
         self: *MetalBorrowedTextureBackend,
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         _: types.Viewport,
     ) !bool {
         _ = texture;
@@ -346,7 +346,7 @@ const MetalSurfaceBackend = struct {
         descriptor.scale_factor = viewport.scale_factor;
         descriptor.layer = self.view.layer.value.?;
         descriptor.device = self.view.device.value.?;
-        var surface: ?*c.mln_surface_session = null;
+        var surface: ?*c.mln_render_session = null;
         if (c.mln_metal_surface_attach(map, &descriptor, &surface) !=
             c.MLN_STATUS_OK or surface == null)
         {
@@ -358,7 +358,7 @@ const MetalSurfaceBackend = struct {
 };
 
 fn releaseMetalFrame(
-    texture: *c.mln_texture_session,
+    texture: *c.mln_render_session,
     frame: *const c.mln_metal_owned_texture_frame,
 ) void {
     if (c.mln_metal_owned_texture_release_frame(texture, frame) != c.MLN_STATUS_OK) {

--- a/examples/zig-map/render/vulkan/mod.zig
+++ b/examples/zig-map/render/vulkan/mod.zig
@@ -75,7 +75,7 @@ pub const VulkanBackend = union(enum) {
 
     pub fn drawTexture(
         self: *VulkanBackend,
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         viewport: types.Viewport,
     ) !bool {
         return switch (self.*) {
@@ -210,7 +210,7 @@ const VulkanTextureCompositor = struct {
 
 const VulkanOwnedTextureBackend = struct {
     compositor: VulkanTextureCompositor,
-    pending_texture: ?*c.mln_texture_session,
+    pending_texture: ?*c.mln_render_session,
     pending_frame: ?c.mln_vulkan_owned_texture_frame,
 
     fn init(
@@ -258,7 +258,7 @@ const VulkanOwnedTextureBackend = struct {
         descriptor.graphics_queue = self.compositor.context.queue;
         descriptor.graphics_queue_family_index = self.compositor.context.queue_family_index;
 
-        var texture: ?*c.mln_texture_session = null;
+        var texture: ?*c.mln_render_session = null;
         if (c.mln_vulkan_owned_texture_attach(map, &descriptor, &texture) !=
             c.MLN_STATUS_OK or texture == null)
         {
@@ -270,7 +270,7 @@ const VulkanOwnedTextureBackend = struct {
 
     fn drawTexture(
         self: *VulkanOwnedTextureBackend,
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         _: types.Viewport,
     ) !bool {
         var frame: c.mln_vulkan_owned_texture_frame = .{
@@ -452,7 +452,7 @@ const VulkanBorrowedTextureBackend = struct {
         descriptor.initial_layout = c.VK_IMAGE_LAYOUT_UNDEFINED;
         descriptor.final_layout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-        var texture: ?*c.mln_texture_session = null;
+        var texture: ?*c.mln_render_session = null;
         if (c.mln_vulkan_borrowed_texture_attach(map, &descriptor, &texture) !=
             c.MLN_STATUS_OK or texture == null)
         {
@@ -464,7 +464,7 @@ const VulkanBorrowedTextureBackend = struct {
 
     fn drawTexture(
         self: *VulkanBorrowedTextureBackend,
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         _: types.Viewport,
     ) !bool {
         _ = texture;
@@ -504,7 +504,7 @@ const VulkanSurfaceBackend = struct {
         descriptor.graphics_queue_family_index = self.context.queue_family_index;
         descriptor.surface = self.context.surface;
 
-        var surface: ?*c.mln_surface_session = null;
+        var surface: ?*c.mln_render_session = null;
         if (c.mln_vulkan_surface_attach(map, &descriptor, &surface) !=
             c.MLN_STATUS_OK or surface == null)
         {
@@ -516,7 +516,7 @@ const VulkanSurfaceBackend = struct {
 };
 
 fn releaseVulkanFrame(
-    texture: *c.mln_texture_session,
+    texture: *c.mln_render_session,
     frame: *const c.mln_vulkan_owned_texture_frame,
 ) void {
     if (c.mln_vulkan_owned_texture_release_frame(texture, frame) != c.MLN_STATUS_OK) {

--- a/examples/zig-map/render_target.zig
+++ b/examples/zig-map/render_target.zig
@@ -4,14 +4,14 @@ const types = @import("types.zig");
 
 pub const Session = union(enum) {
     none,
-    texture: *c.mln_texture_session,
-    surface: *c.mln_surface_session,
+    texture: *c.mln_render_session,
+    surface: *c.mln_render_session,
 
     pub fn deinit(self: *Session) void {
         switch (self.*) {
             .none => {},
-            .texture => |texture| _ = c.mln_texture_destroy(texture),
-            .surface => |surface| _ = c.mln_surface_destroy(surface),
+            .texture => |texture| _ = c.mln_render_session_destroy(texture),
+            .surface => |surface| _ = c.mln_render_session_destroy(surface),
         }
         self.* = .none;
     }
@@ -19,13 +19,13 @@ pub const Session = union(enum) {
     pub fn resize(self: *Session, viewport: types.Viewport) !void {
         const status = switch (self.*) {
             .none => c.MLN_STATUS_INVALID_STATE,
-            .texture => |texture| c.mln_texture_resize(
+            .texture => |texture| c.mln_render_session_resize(
                 texture,
                 viewport.logical_width,
                 viewport.logical_height,
                 viewport.scale_factor,
             ),
-            .surface => |surface| c.mln_surface_resize(
+            .surface => |surface| c.mln_render_session_resize(
                 surface,
                 viewport.logical_width,
                 viewport.logical_height,
@@ -48,8 +48,8 @@ pub const Session = union(enum) {
     pub fn renderUpdate(self: *Session) !bool {
         const status = switch (self.*) {
             .none => c.MLN_STATUS_INVALID_STATE,
-            .texture => |texture| c.mln_texture_render_update(texture),
-            .surface => |surface| c.mln_surface_render_update(surface),
+            .texture => |texture| c.mln_render_session_render_update(texture),
+            .surface => |surface| c.mln_render_session_render_update(surface),
         };
         if (status == c.MLN_STATUS_OK) return true;
         if (status == c.MLN_STATUS_INVALID_STATE) return false;

--- a/examples/zig-readback/main.zig
+++ b/examples/zig-readback/main.zig
@@ -31,13 +31,13 @@ pub fn main(init_args: std.process.Init) !void {
     try check(c.mln_map_create(runtime.?, &map_options, &map), "map create failed");
     defer _ = c.mln_map_destroy(map.?);
 
-    var texture: ?*c.mln_texture_session = null;
+    var texture: ?*c.mln_render_session = null;
     var texture_descriptor = c.mln_owned_texture_descriptor_default();
     texture_descriptor.width = width;
     texture_descriptor.height = height;
     texture_descriptor.scale_factor = 1.0;
     try check(c.mln_owned_texture_attach(map.?, &texture_descriptor, &texture), "owned texture attach failed");
-    defer _ = c.mln_texture_destroy(texture.?);
+    defer _ = c.mln_render_session_destroy(texture.?);
 
     try setInitialCamera(map.?);
     try check(c.mln_map_set_style_url(map.?, style_url), "style load failed");
@@ -71,7 +71,7 @@ fn setInitialCamera(map: *c.mln_map) !void {
     try check(c.mln_map_jump_to(map, &camera), "camera jump failed");
 }
 
-fn renderTexture(runtime: *c.mln_runtime, map: *c.mln_map, texture: *c.mln_texture_session) !void {
+fn renderTexture(runtime: *c.mln_runtime, map: *c.mln_map, texture: *c.mln_render_session) !void {
     var rendered_frame = false;
     while (true) {
         try check(c.mln_runtime_run_once(runtime), "runtime pump failed");
@@ -86,7 +86,7 @@ fn renderTexture(runtime: *c.mln_runtime, map: *c.mln_map, texture: *c.mln_textu
 
             switch (event.type) {
                 c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE => {
-                    const status = c.mln_texture_render_update(texture);
+                    const status = c.mln_render_session_render_update(texture);
                     if (status == c.MLN_STATUS_OK) {
                         rendered_frame = true;
                     } else if (status != c.MLN_STATUS_INVALID_STATE) {

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -72,8 +72,7 @@ typedef struct mln_runtime mln_runtime;
 typedef struct mln_map mln_map;
 typedef struct mln_map_projection mln_map_projection;
 typedef struct mln_resource_request_handle mln_resource_request_handle;
-typedef struct mln_surface_session mln_surface_session;
-typedef struct mln_texture_session mln_texture_session;
+typedef struct mln_render_session mln_render_session;
 
 /**
  * Reports the C ABI contract version.
@@ -929,8 +928,8 @@ MLN_API mln_status mln_map_request_repaint(mln_map* map) MLN_NOEXCEPT;
  * MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED or
  * MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FAILED is reported. While the request is
  * pending, process each MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE event
- * from this map. Texture targets use mln_texture_render_update(). Surface
- * targets use mln_surface_render_update() and present directly. A render-update
+ * from this map. Render targets use mln_render_session_render_update(). Surface
+ * targets present directly. A render-update
  * call can return MLN_STATUS_INVALID_STATE before the next update is available;
  * keep pumping and polling in that case. After
  * MLN_RUNTIME_EVENT_MAP_STILL_IMAGE_FINISHED, use the latest successful texture
@@ -1447,13 +1446,13 @@ mln_vulkan_surface_descriptor_default(void) MLN_NOEXCEPT;
  * The map may have at most one live render target session. The session and
  * every surface-session call are owner-thread affine to the map owner thread.
  * The session retains descriptor->layer and optional descriptor->device. It
- * renders into the layer and presents through it. On success, *out_surface
- * receives a handle the caller destroys with mln_surface_destroy().
+ * renders into the layer and presents through it. On success, *out_session
+ * receives a handle the caller destroys with mln_render_session_destroy().
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, descriptor is
- *   null or invalid, out_surface is null, or *out_surface is not null.
+ *   null or invalid, out_session is null, or *out_session is not null.
  * - MLN_STATUS_INVALID_STATE when the map already has a render target session.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
@@ -1463,7 +1462,7 @@ mln_vulkan_surface_descriptor_default(void) MLN_NOEXCEPT;
  */
 MLN_API mln_status mln_metal_surface_attach(
   mln_map* map, const mln_metal_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_session
 ) MLN_NOEXCEPT;
 
 /**
@@ -1473,13 +1472,13 @@ MLN_API mln_status mln_metal_surface_attach(
  * every surface-session call are owner-thread affine to the map owner thread.
  * The session renders to descriptor->surface and presents through it. Vulkan
  * handles are borrowed and must remain valid until the session is detached or
- * destroyed. On success, *out_surface receives a handle the caller destroys
- * with mln_surface_destroy().
+ * destroyed. On success, *out_session receives a handle the caller destroys
+ * with mln_render_session_destroy().
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, descriptor is
- *   null or invalid, out_surface is null, or *out_surface is not null.
+ *   null or invalid, out_session is null, or *out_session is not null.
  * - MLN_STATUS_INVALID_STATE when the map already has a render target session.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
@@ -1489,78 +1488,130 @@ MLN_API mln_status mln_metal_surface_attach(
  */
 MLN_API mln_status mln_vulkan_surface_attach(
   mln_map* map, const mln_vulkan_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_session
 ) MLN_NOEXCEPT;
 
 /**
- * Resizes a surface session.
+ * Resizes an attached render session.
  *
  * Width and height are logical map dimensions. The scale_factor value maps
- * them to physical backend surface pixels.
+ * them to physical backend pixels.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when surface is null or not live, dimensions
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, dimensions
  *   are zero, scale_factor is non-positive or non-finite, or scaled dimensions
  *   are too large.
- * - MLN_STATUS_INVALID_STATE when the session is detached.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or a texture frame is
+ *   currently acquired.
+ * - MLN_STATUS_UNSUPPORTED when resizing is not supported by the session kind
+ *   or mode, such as a caller-owned borrowed texture target.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
-MLN_API mln_status mln_surface_resize(
-  mln_surface_session* surface, uint32_t width, uint32_t height,
+MLN_API mln_status mln_render_session_resize(
+  mln_render_session* session, uint32_t width, uint32_t height,
   double scale_factor
 ) MLN_NOEXCEPT;
 
 /**
- * Processes the latest map render update for a native surface session.
+ * Processes the latest map render update for an attached render session.
  *
- * This renders and presents through the session's native surface.
+ * Surface sessions render and present through their native surface. Texture
+ * sessions render into their texture target.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when surface is null or not live.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live.
  * - MLN_STATUS_INVALID_STATE when no render update is available or the session
- *   is detached.
+ *   is detached, or a texture frame is currently acquired.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status
-mln_surface_render_update(mln_surface_session* surface) MLN_NOEXCEPT;
+mln_render_session_render_update(mln_render_session* session) MLN_NOEXCEPT;
 
 /**
- * Detaches backend-bound surface resources from the map while keeping the
+ * Detaches backend-bound render resources from the map while keeping the
  * session handle live for destruction.
  *
- * After detach, resize and render operations return MLN_STATUS_INVALID_STATE.
+ * After detach, resize, render, readback, acquire, and renderer maintenance
+ * operations return MLN_STATUS_INVALID_STATE.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when surface is null or not live.
- * - MLN_STATUS_INVALID_STATE when already detached.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live.
+ * - MLN_STATUS_INVALID_STATE when already detached or a texture frame is
+ *   acquired.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status
-mln_surface_detach(mln_surface_session* surface) MLN_NOEXCEPT;
+mln_render_session_detach(mln_render_session* session) MLN_NOEXCEPT;
 
 /**
- * Destroys a surface session handle.
+ * Destroys a render session handle.
  *
  * If the session is still attached, this function detaches it first.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when surface is null or not live.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live.
+ * - MLN_STATUS_INVALID_STATE when a texture frame is acquired.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status
-mln_surface_destroy(mln_surface_session* surface) MLN_NOEXCEPT;
+mln_render_session_destroy(mln_render_session* session) MLN_NOEXCEPT;
+
+/**
+ * Asks the session renderer to release cached resources where possible.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_render_session_reduce_memory_use(mln_render_session* session) MLN_NOEXCEPT;
+
+/**
+ * Clears renderer data for the session.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_render_session_clear_data(mln_render_session* session) MLN_NOEXCEPT;
+
+/**
+ * Dumps renderer debug logs for the session through MapLibre Native logging.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_render_session_dump_debug_logs(mln_render_session* session) MLN_NOEXCEPT;
 
 #pragma endregion
 
@@ -1779,8 +1830,8 @@ mln_texture_image_info_default(void) MLN_NOEXCEPT;
  * The map may have at most one live render target session. The session and
  * every texture-session call are owner-thread affine to the map owner thread.
  * The session creates a backend-native offscreen target using the default
- * headless backend for this build. On success, *out_texture receives a handle
- * the caller destroys with mln_texture_destroy().
+ * headless backend for this build. On success, *out_session receives a handle
+ * the caller destroys with mln_render_session_destroy().
  *
  * Use this target for still-image and CPU-readback workflows. Use
  * backend-specific borrowed texture attach functions when a UI framework
@@ -1789,7 +1840,7 @@ mln_texture_image_info_default(void) MLN_NOEXCEPT;
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, descriptor is
- *   null or invalid, out_texture is null, or *out_texture is not null.
+ *   null or invalid, out_session is null, or *out_session is not null.
  * - MLN_STATUS_INVALID_STATE when the map already has a render target session.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
@@ -1797,7 +1848,7 @@ mln_texture_image_info_default(void) MLN_NOEXCEPT;
  */
 MLN_API mln_status mln_owned_texture_attach(
   mln_map* map, const mln_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) MLN_NOEXCEPT;
 
 /**
@@ -1806,13 +1857,13 @@ MLN_API mln_status mln_owned_texture_attach(
  * The map may have at most one live render target session. The session and
  * every texture-session call are owner-thread affine to the map owner thread.
  * The session renders into a session-owned texture created on
- * descriptor->device. On success, *out_texture receives a handle the caller
- * destroys with mln_texture_destroy().
+ * descriptor->device. On success, *out_session receives a handle the caller
+ * destroys with mln_render_session_destroy().
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, descriptor is
- *   null or invalid, out_texture is null, or *out_texture is not null.
+ *   null or invalid, out_session is null, or *out_session is not null.
  * - MLN_STATUS_INVALID_STATE when the map already has a render target session.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
@@ -1822,7 +1873,7 @@ MLN_API mln_status mln_owned_texture_attach(
  */
 MLN_API mln_status mln_metal_owned_texture_attach(
   mln_map* map, const mln_metal_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) MLN_NOEXCEPT;
 
 /**
@@ -1832,13 +1883,13 @@ MLN_API mln_status mln_metal_owned_texture_attach(
  * every texture-session call are owner-thread affine to the map owner thread.
  * The session renders into descriptor->texture. The caller owns the texture,
  * keeps it valid until detach or destroy, and synchronizes any use outside this
- * session. On success, *out_texture receives a handle the caller destroys with
- * mln_texture_destroy().
+ * session. On success, *out_session receives a handle the caller destroys with
+ * mln_render_session_destroy().
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, descriptor is
- *   null or invalid, out_texture is null, or *out_texture is not null.
+ *   null or invalid, out_session is null, or *out_session is not null.
  * - MLN_STATUS_INVALID_STATE when the map already has a render target session.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
@@ -1848,7 +1899,7 @@ MLN_API mln_status mln_metal_owned_texture_attach(
  */
 MLN_API mln_status mln_metal_borrowed_texture_attach(
   mln_map* map, const mln_metal_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) MLN_NOEXCEPT;
 
 /**
@@ -1858,13 +1909,13 @@ MLN_API mln_status mln_metal_borrowed_texture_attach(
  * every texture-session call are owner-thread affine to the map owner thread.
  * The session renders into a session-owned image created on descriptor->device.
  * Vulkan handles are borrowed and must remain valid until detach or destroy. On
- * success, *out_texture receives a handle the caller destroys with
- * mln_texture_destroy().
+ * success, *out_session receives a handle the caller destroys with
+ * mln_render_session_destroy().
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, descriptor is
- *   null or invalid, out_texture is null, or *out_texture is not null.
+ *   null or invalid, out_session is null, or *out_session is not null.
  * - MLN_STATUS_INVALID_STATE when the map already has a render target session.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
@@ -1874,7 +1925,7 @@ MLN_API mln_status mln_metal_borrowed_texture_attach(
  */
 MLN_API mln_status mln_vulkan_owned_texture_attach(
   mln_map* map, const mln_vulkan_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) MLN_NOEXCEPT;
 
 /**
@@ -1885,19 +1936,19 @@ MLN_API mln_status mln_vulkan_owned_texture_attach(
  * The session renders into descriptor->image through descriptor->image_view.
  * The caller owns the image and view, keeps them valid until detach or destroy,
  * and handles queue-family ownership and synchronization outside this session.
- * On success, *out_texture receives a handle the caller destroys with
- * mln_texture_destroy().
+ * On success, *out_session receives a handle the caller destroys with
+ * mln_render_session_destroy().
  *
- * Before each mln_texture_render_update(), make the image available on
+ * Before each mln_render_session_render_update(), make the image available on
  * descriptor->graphics_queue in descriptor->initial_layout and keep it out of
  * concurrent use. The session submits rendering on that queue, waits for the
  * submitted work to finish, and leaves the image in
- * descriptor->final_layout before mln_texture_render_update() returns.
+ * descriptor->final_layout before mln_render_session_render_update() returns.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, descriptor is
- *   null or invalid, out_texture is null, or *out_texture is not null.
+ *   null or invalid, out_session is null, or *out_session is not null.
  * - MLN_STATUS_INVALID_STATE when the map already has a render target session.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
@@ -1907,7 +1958,7 @@ MLN_API mln_status mln_vulkan_owned_texture_attach(
  */
 MLN_API mln_status mln_vulkan_borrowed_texture_attach(
   mln_map* map, const mln_vulkan_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) MLN_NOEXCEPT;
 
 /**
@@ -1930,31 +1981,6 @@ MLN_API mln_status mln_vulkan_borrowed_texture_attach(
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
-MLN_API mln_status mln_texture_resize(
-  mln_texture_session* texture, uint32_t width, uint32_t height,
-  double scale_factor
-) MLN_NOEXCEPT;
-
-/**
- * Processes the latest map render update for an offscreen texture session.
- *
- * This renders into the texture. For session-owned backend textures, the
- * backend-specific owned-frame acquire function can expose a frame for the same
- * session generation. Borrowed textures need no acquire step because the caller
- * owns the target.
- *
- * Returns:
- * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when texture is null or not live.
- * - MLN_STATUS_INVALID_STATE when no render update is available, the session is
- *   detached, or a frame is currently acquired.
- * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
- *   owner thread.
- * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
- */
-MLN_API mln_status
-mln_texture_render_update(mln_texture_session* texture) MLN_NOEXCEPT;
-
 /**
  * Reads the most recently rendered session-owned texture frame into
  * caller-owned storage.
@@ -1977,7 +2003,7 @@ mln_texture_render_update(mln_texture_session* texture) MLN_NOEXCEPT;
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_texture_read_premultiplied_rgba8(
-  mln_texture_session* texture, uint8_t* out_data, size_t out_data_capacity,
+  mln_render_session* session, uint8_t* out_data, size_t out_data_capacity,
   mln_texture_image_info* out_info
 ) MLN_NOEXCEPT;
 
@@ -1988,7 +2014,7 @@ MLN_API mln_status mln_texture_read_premultiplied_rgba8(
  *
  * The returned texture and device pointers are borrowed and remain valid only
  * until mln_metal_owned_texture_release_frame() is called for the same frame.
- * While acquired, resize, mln_texture_render_update(), detach, destroy, and a
+ * While acquired, resize, render update, detach, destroy, and a
  * second acquire return MLN_STATUS_INVALID_STATE.
  *
  * Returns:
@@ -2004,7 +2030,7 @@ MLN_API mln_status mln_texture_read_premultiplied_rgba8(
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_metal_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_metal_owned_texture_frame* out_frame
+  mln_render_session* session, mln_metal_owned_texture_frame* out_frame
 ) MLN_NOEXCEPT;
 
 /**
@@ -2014,7 +2040,7 @@ MLN_API mln_status mln_metal_owned_texture_acquire_frame(
  *
  * The returned image, image view, and device pointers are borrowed and remain
  * valid only until mln_vulkan_owned_texture_release_frame() is called for the
- * same frame. While acquired, resize, mln_texture_render_update(), detach,
+ * same frame. While acquired, resize, render update, detach,
  * destroy, and a second acquire return MLN_STATUS_INVALID_STATE.
  *
  * On success, the image has been rendered and made available in the returned
@@ -2033,7 +2059,7 @@ MLN_API mln_status mln_metal_owned_texture_acquire_frame(
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_vulkan_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_vulkan_owned_texture_frame* out_frame
+  mln_render_session* session, mln_vulkan_owned_texture_frame* out_frame
 ) MLN_NOEXCEPT;
 
 /**
@@ -2056,7 +2082,7 @@ MLN_API mln_status mln_vulkan_owned_texture_acquire_frame(
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_metal_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_metal_owned_texture_frame* frame
+  mln_render_session* session, const mln_metal_owned_texture_frame* frame
 ) MLN_NOEXCEPT;
 
 /**
@@ -2080,44 +2106,8 @@ MLN_API mln_status mln_metal_owned_texture_release_frame(
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_vulkan_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_vulkan_owned_texture_frame* frame
+  mln_render_session* session, const mln_vulkan_owned_texture_frame* frame
 ) MLN_NOEXCEPT;
-
-/**
- * Detaches backend-bound resources from the map while keeping the session
- * handle live for destruction.
- *
- * Detach advances the session generation. After detach, resize, render,
- * readback, and acquire operations return MLN_STATUS_INVALID_STATE.
- *
- * Returns:
- * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when texture is null or not live.
- * - MLN_STATUS_INVALID_STATE when already detached or a frame is acquired.
- * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
- *   owner thread.
- * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
- */
-MLN_API mln_status
-mln_texture_detach(mln_texture_session* texture) MLN_NOEXCEPT;
-
-/**
- * Destroys a texture session handle.
- *
- * If the session is still attached, this function detaches it first.
- * Destruction is rejected while a frame is acquired so borrowed texture
- * pointers cannot outlive their session.
- *
- * Returns:
- * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when texture is null or not live.
- * - MLN_STATUS_INVALID_STATE when a frame is acquired.
- * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
- *   owner thread.
- * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
- */
-MLN_API mln_status
-mln_texture_destroy(mln_texture_session* texture) MLN_NOEXCEPT;
 
 #pragma endregion
 

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -1491,6 +1491,10 @@ MLN_API mln_status mln_vulkan_surface_attach(
   mln_render_session** out_session
 ) MLN_NOEXCEPT;
 
+#pragma endregion
+
+#pragma region Render sessions
+
 /**
  * Resizes an attached render session.
  *

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -1962,26 +1962,6 @@ MLN_API mln_status mln_vulkan_borrowed_texture_attach(
 ) MLN_NOEXCEPT;
 
 /**
- * Resizes a texture session and advances its generation.
- *
- * Width and height are logical map dimensions. The scale_factor value maps
- * them to physical backend texture or image pixels. Resize clears the last
- * rendered frame.
- *
- * Returns:
- * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when texture is null or not live, dimensions
- *   are zero, scale_factor is non-positive or non-finite, or scaled dimensions
- *   are too large.
- * - MLN_STATUS_INVALID_STATE when the session is detached or a frame is
- *   currently acquired.
- * - MLN_STATUS_UNSUPPORTED when the session uses a caller-owned borrowed
- *   texture; attach a new borrowed texture session instead.
- * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
- *   owner thread.
- * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
- */
-/**
  * Reads the most recently rendered session-owned texture frame into
  * caller-owned storage.
  *
@@ -1999,7 +1979,8 @@ MLN_API mln_status mln_vulkan_borrowed_texture_attach(
  *   is detached, a frame is currently acquired, or readback produces no image.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
- * - MLN_STATUS_UNSUPPORTED when the texture session uses a caller-owned target.
+ * - MLN_STATUS_UNSUPPORTED when session is not a texture session or when the
+ *   texture session uses a caller-owned target.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_texture_read_premultiplied_rgba8(
@@ -2077,8 +2058,8 @@ MLN_API mln_status mln_vulkan_owned_texture_acquire_frame(
  *   acquired.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
- * - MLN_STATUS_UNSUPPORTED when Metal texture sessions are not supported by
- *   this build.
+ * - MLN_STATUS_UNSUPPORTED when session is not a texture session or when Metal
+ *   texture sessions are not supported by this build.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_metal_owned_texture_release_frame(
@@ -2101,8 +2082,8 @@ MLN_API mln_status mln_metal_owned_texture_release_frame(
  *   acquired.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
  *   owner thread.
- * - MLN_STATUS_UNSUPPORTED when Vulkan texture sessions are not supported by
- *   this build.
+ * - MLN_STATUS_UNSUPPORTED when session is not a texture session or when Vulkan
+ *   texture sessions are not supported by this build.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_vulkan_owned_texture_release_frame(

--- a/src/c_api/render_session.cpp
+++ b/src/c_api/render_session.cpp
@@ -1,0 +1,60 @@
+#define MLN_BUILDING_C
+
+#include <cstdint>
+
+#include "c_api/boundary.hpp"
+#include "maplibre_native_c.h"
+#include "render/render_session_common.hpp"
+
+auto mln_render_session_resize(
+  mln_render_session* session, uint32_t width, uint32_t height,
+  double scale_factor
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_resize(
+      session, width, height, scale_factor
+    );
+  });
+}
+
+auto mln_render_session_render_update(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_render_update(session);
+  });
+}
+
+auto mln_render_session_detach(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_detach(session);
+  });
+}
+
+auto mln_render_session_destroy(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_destroy(session);
+  });
+}
+
+auto mln_render_session_reduce_memory_use(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_reduce_memory_use(session);
+  });
+}
+
+auto mln_render_session_clear_data(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_clear_data(session);
+  });
+}
+
+auto mln_render_session_dump_debug_logs(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_dump_debug_logs(session);
+  });
+}

--- a/src/c_api/surface.cpp
+++ b/src/c_api/surface.cpp
@@ -3,8 +3,63 @@
 #include <cstdint>
 
 #include "c_api/boundary.hpp"
+#include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
+#include "render/render_session_common.hpp"
 #include "render/surface_session.hpp"
+#include "render/texture_session.hpp"
+
+namespace {
+
+auto as_render_session(mln_surface_session* surface) -> mln_render_session* {
+  return static_cast<mln_render_session*>(surface);
+}
+
+auto as_surface_session(mln_render_session* session) -> mln_surface_session* {
+  return static_cast<mln_surface_session*>(session->concrete);
+}
+
+auto as_texture_session(mln_render_session* session) -> mln_texture_session* {
+  return static_cast<mln_texture_session*>(session->concrete);
+}
+
+template <typename Operation>
+auto with_renderer(mln_render_session* session, Operation operation)
+  -> mln_status {
+  auto kind = mln::core::RenderSessionKind::Surface;
+  auto status = mln::core::render_session_kind(session, &kind);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  if (kind == mln::core::RenderSessionKind::Surface) {
+    auto* surface = as_surface_session(session);
+    status = mln::core::validate_live_attached_surface(surface);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    if (surface->renderer == nullptr) {
+      mln::core::set_thread_error("render session renderer is not available");
+      return MLN_STATUS_INVALID_STATE;
+    }
+    operation(*surface->renderer);
+    return MLN_STATUS_OK;
+  }
+
+  auto* texture = as_texture_session(session);
+  status = mln::core::validate_live_attached_texture(texture);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (texture->renderer == nullptr) {
+    mln::core::set_thread_error("render session renderer is not available");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  operation(*texture->renderer);
+  return MLN_STATUS_OK;
+}
+
+}  // namespace
 
 auto mln_metal_surface_descriptor_default(void) noexcept
   -> mln_metal_surface_descriptor {
@@ -18,46 +73,140 @@ auto mln_vulkan_surface_descriptor_default(void) noexcept
 
 auto mln_metal_surface_attach(
   mln_map* map, const mln_metal_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::metal_surface_attach(map, descriptor, out_surface);
+    auto output_status = mln::core::validate_render_session_attach_output(
+      out_session, "out_session must not be null",
+      "out_session must point to a null handle"
+    );
+    if (output_status != MLN_STATUS_OK) {
+      return output_status;
+    }
+    auto* surface = static_cast<mln_surface_session*>(nullptr);
+    auto status = mln::core::metal_surface_attach(map, descriptor, &surface);
+    if (status == MLN_STATUS_OK) {
+      *out_session = as_render_session(surface);
+    }
+    return status;
   });
 }
 
 auto mln_vulkan_surface_attach(
   mln_map* map, const mln_vulkan_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::vulkan_surface_attach(map, descriptor, out_surface);
+    auto output_status = mln::core::validate_render_session_attach_output(
+      out_session, "out_session must not be null",
+      "out_session must point to a null handle"
+    );
+    if (output_status != MLN_STATUS_OK) {
+      return output_status;
+    }
+    auto* surface = static_cast<mln_surface_session*>(nullptr);
+    auto status = mln::core::vulkan_surface_attach(map, descriptor, &surface);
+    if (status == MLN_STATUS_OK) {
+      *out_session = as_render_session(surface);
+    }
+    return status;
   });
 }
 
-auto mln_surface_resize(
-  mln_surface_session* surface, uint32_t width, uint32_t height,
+auto mln_render_session_resize(
+  mln_render_session* session, uint32_t width, uint32_t height,
   double scale_factor
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::surface_resize(surface, width, height, scale_factor);
+    auto kind = mln::core::RenderSessionKind::Surface;
+    auto status = mln::core::render_session_kind(session, &kind);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    if (kind == mln::core::RenderSessionKind::Surface) {
+      return mln::core::surface_resize(
+        as_surface_session(session), width, height, scale_factor
+      );
+    }
+    return mln::core::texture_resize(
+      as_texture_session(session), width, height, scale_factor
+    );
   });
 }
 
-auto mln_surface_render_update(mln_surface_session* surface) noexcept
+auto mln_render_session_render_update(mln_render_session* session) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::surface_render_update(surface);
+    auto kind = mln::core::RenderSessionKind::Surface;
+    auto status = mln::core::render_session_kind(session, &kind);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    if (kind == mln::core::RenderSessionKind::Surface) {
+      return mln::core::surface_render_update(as_surface_session(session));
+    }
+    return mln::core::texture_render_update(as_texture_session(session));
   });
 }
 
-auto mln_surface_detach(mln_surface_session* surface) noexcept -> mln_status {
+auto mln_render_session_detach(mln_render_session* session) noexcept
+  -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::surface_detach(surface);
+    auto kind = mln::core::RenderSessionKind::Surface;
+    auto status = mln::core::render_session_kind(session, &kind);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    if (kind == mln::core::RenderSessionKind::Surface) {
+      return mln::core::surface_detach(as_surface_session(session));
+    }
+    return mln::core::texture_detach(as_texture_session(session));
   });
 }
 
-auto mln_surface_destroy(mln_surface_session* surface) noexcept -> mln_status {
+auto mln_render_session_destroy(mln_render_session* session) noexcept
+  -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::surface_destroy(surface);
+    auto kind = mln::core::RenderSessionKind::Surface;
+    auto status = mln::core::render_session_kind(session, &kind);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    if (kind == mln::core::RenderSessionKind::Surface) {
+      status = mln::core::surface_destroy(as_surface_session(session));
+    } else {
+      status = mln::core::texture_destroy(as_texture_session(session));
+    }
+    if (status == MLN_STATUS_OK) {
+      mln::core::unregister_render_session(session);
+    }
+    return status;
+  });
+}
+
+auto mln_render_session_reduce_memory_use(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return with_renderer(session, [](auto& renderer) -> void {
+      renderer.reduceMemoryUse();
+    });
+  });
+}
+
+auto mln_render_session_clear_data(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return with_renderer(session, [](auto& renderer) -> void {
+      renderer.clearData();
+    });
+  });
+}
+
+auto mln_render_session_dump_debug_logs(mln_render_session* session) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return with_renderer(session, [](auto& renderer) -> void {
+      renderer.dumpDebugLogs();
+    });
   });
 }

--- a/src/c_api/surface.cpp
+++ b/src/c_api/surface.cpp
@@ -1,10 +1,7 @@
 #define MLN_BUILDING_C
 
-#include <cstdint>
-
 #include "c_api/boundary.hpp"
 #include "maplibre_native_c.h"
-#include "render/render_session_common.hpp"
 #include "render/surface_session.hpp"
 
 auto mln_metal_surface_descriptor_default(void) noexcept
@@ -32,58 +29,5 @@ auto mln_vulkan_surface_attach(
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::vulkan_surface_attach(map, descriptor, out_session);
-  });
-}
-
-auto mln_render_session_resize(
-  mln_render_session* session, uint32_t width, uint32_t height,
-  double scale_factor
-) noexcept -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::render_session_resize(
-      session, width, height, scale_factor
-    );
-  });
-}
-
-auto mln_render_session_render_update(mln_render_session* session) noexcept
-  -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::render_session_render_update(session);
-  });
-}
-
-auto mln_render_session_detach(mln_render_session* session) noexcept
-  -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::render_session_detach(session);
-  });
-}
-
-auto mln_render_session_destroy(mln_render_session* session) noexcept
-  -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::render_session_destroy(session);
-  });
-}
-
-auto mln_render_session_reduce_memory_use(mln_render_session* session) noexcept
-  -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::render_session_reduce_memory_use(session);
-  });
-}
-
-auto mln_render_session_clear_data(mln_render_session* session) noexcept
-  -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::render_session_clear_data(session);
-  });
-}
-
-auto mln_render_session_dump_debug_logs(mln_render_session* session) noexcept
-  -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::render_session_dump_debug_logs(session);
   });
 }

--- a/src/c_api/surface.cpp
+++ b/src/c_api/surface.cpp
@@ -3,63 +3,9 @@
 #include <cstdint>
 
 #include "c_api/boundary.hpp"
-#include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
 #include "render/render_session_common.hpp"
 #include "render/surface_session.hpp"
-#include "render/texture_session.hpp"
-
-namespace {
-
-auto as_render_session(mln_surface_session* surface) -> mln_render_session* {
-  return static_cast<mln_render_session*>(surface);
-}
-
-auto as_surface_session(mln_render_session* session) -> mln_surface_session* {
-  return static_cast<mln_surface_session*>(session->concrete);
-}
-
-auto as_texture_session(mln_render_session* session) -> mln_texture_session* {
-  return static_cast<mln_texture_session*>(session->concrete);
-}
-
-template <typename Operation>
-auto with_renderer(mln_render_session* session, Operation operation)
-  -> mln_status {
-  auto kind = mln::core::RenderSessionKind::Surface;
-  auto status = mln::core::render_session_kind(session, &kind);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-
-  if (kind == mln::core::RenderSessionKind::Surface) {
-    auto* surface = as_surface_session(session);
-    status = mln::core::validate_live_attached_surface(surface);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    if (surface->renderer == nullptr) {
-      mln::core::set_thread_error("render session renderer is not available");
-      return MLN_STATUS_INVALID_STATE;
-    }
-    operation(*surface->renderer);
-    return MLN_STATUS_OK;
-  }
-
-  auto* texture = as_texture_session(session);
-  status = mln::core::validate_live_attached_texture(texture);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (texture->renderer == nullptr) {
-    mln::core::set_thread_error("render session renderer is not available");
-    return MLN_STATUS_INVALID_STATE;
-  }
-  operation(*texture->renderer);
-  return MLN_STATUS_OK;
-}
-
-}  // namespace
 
 auto mln_metal_surface_descriptor_default(void) noexcept
   -> mln_metal_surface_descriptor {
@@ -76,19 +22,7 @@ auto mln_metal_surface_attach(
   mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto output_status = mln::core::validate_render_session_attach_output(
-      out_session, "out_session must not be null",
-      "out_session must point to a null handle"
-    );
-    if (output_status != MLN_STATUS_OK) {
-      return output_status;
-    }
-    auto* surface = static_cast<mln_surface_session*>(nullptr);
-    auto status = mln::core::metal_surface_attach(map, descriptor, &surface);
-    if (status == MLN_STATUS_OK) {
-      *out_session = as_render_session(surface);
-    }
-    return status;
+    return mln::core::metal_surface_attach(map, descriptor, out_session);
   });
 }
 
@@ -97,19 +31,7 @@ auto mln_vulkan_surface_attach(
   mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto output_status = mln::core::validate_render_session_attach_output(
-      out_session, "out_session must not be null",
-      "out_session must point to a null handle"
-    );
-    if (output_status != MLN_STATUS_OK) {
-      return output_status;
-    }
-    auto* surface = static_cast<mln_surface_session*>(nullptr);
-    auto status = mln::core::vulkan_surface_attach(map, descriptor, &surface);
-    if (status == MLN_STATUS_OK) {
-      *out_session = as_render_session(surface);
-    }
-    return status;
+    return mln::core::vulkan_surface_attach(map, descriptor, out_session);
   });
 }
 
@@ -118,18 +40,8 @@ auto mln_render_session_resize(
   double scale_factor
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto kind = mln::core::RenderSessionKind::Surface;
-    auto status = mln::core::render_session_kind(session, &kind);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    if (kind == mln::core::RenderSessionKind::Surface) {
-      return mln::core::surface_resize(
-        as_surface_session(session), width, height, scale_factor
-      );
-    }
-    return mln::core::texture_resize(
-      as_texture_session(session), width, height, scale_factor
+    return mln::core::render_session_resize(
+      session, width, height, scale_factor
     );
   });
 }
@@ -137,76 +49,41 @@ auto mln_render_session_resize(
 auto mln_render_session_render_update(mln_render_session* session) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto kind = mln::core::RenderSessionKind::Surface;
-    auto status = mln::core::render_session_kind(session, &kind);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    if (kind == mln::core::RenderSessionKind::Surface) {
-      return mln::core::surface_render_update(as_surface_session(session));
-    }
-    return mln::core::texture_render_update(as_texture_session(session));
+    return mln::core::render_session_render_update(session);
   });
 }
 
 auto mln_render_session_detach(mln_render_session* session) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto kind = mln::core::RenderSessionKind::Surface;
-    auto status = mln::core::render_session_kind(session, &kind);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    if (kind == mln::core::RenderSessionKind::Surface) {
-      return mln::core::surface_detach(as_surface_session(session));
-    }
-    return mln::core::texture_detach(as_texture_session(session));
+    return mln::core::render_session_detach(session);
   });
 }
 
 auto mln_render_session_destroy(mln_render_session* session) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto kind = mln::core::RenderSessionKind::Surface;
-    auto status = mln::core::render_session_kind(session, &kind);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    if (kind == mln::core::RenderSessionKind::Surface) {
-      status = mln::core::surface_destroy(as_surface_session(session));
-    } else {
-      status = mln::core::texture_destroy(as_texture_session(session));
-    }
-    if (status == MLN_STATUS_OK) {
-      mln::core::unregister_render_session(session);
-    }
-    return status;
+    return mln::core::render_session_destroy(session);
   });
 }
 
 auto mln_render_session_reduce_memory_use(mln_render_session* session) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return with_renderer(session, [](auto& renderer) -> void {
-      renderer.reduceMemoryUse();
-    });
+    return mln::core::render_session_reduce_memory_use(session);
   });
 }
 
 auto mln_render_session_clear_data(mln_render_session* session) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return with_renderer(session, [](auto& renderer) -> void {
-      renderer.clearData();
-    });
+    return mln::core::render_session_clear_data(session);
   });
 }
 
 auto mln_render_session_dump_debug_logs(mln_render_session* session) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return with_renderer(session, [](auto& renderer) -> void {
-      renderer.dumpDebugLogs();
-    });
+    return mln::core::render_session_dump_debug_logs(session);
   });
 }

--- a/src/c_api/texture.cpp
+++ b/src/c_api/texture.cpp
@@ -4,55 +4,8 @@
 #include <cstdint>
 
 #include "c_api/boundary.hpp"
-#include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
-#include "render/render_session_common.hpp"
 #include "render/texture_session.hpp"
-
-namespace {
-
-auto as_render_session(mln_texture_session* texture) -> mln_render_session* {
-  return static_cast<mln_render_session*>(texture);
-}
-
-auto as_texture_session(mln_render_session* session) -> mln_texture_session* {
-  return static_cast<mln_texture_session*>(session->concrete);
-}
-
-auto validate_texture_render_session(mln_render_session* session)
-  -> mln_status {
-  auto kind = mln::core::RenderSessionKind::Surface;
-  auto status = mln::core::render_session_kind(session, &kind);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (kind != mln::core::RenderSessionKind::Texture) {
-    mln::core::set_thread_error("render session is not a texture session");
-    return MLN_STATUS_UNSUPPORTED;
-  }
-  return MLN_STATUS_OK;
-}
-
-auto attach_texture_session(
-  auto attach, mln_map* map, const auto* descriptor,
-  mln_render_session** out_session
-) -> mln_status {
-  auto output_status = mln::core::validate_render_session_attach_output(
-    out_session, "out_session must not be null",
-    "out_session must point to a null handle"
-  );
-  if (output_status != MLN_STATUS_OK) {
-    return output_status;
-  }
-  auto* texture = static_cast<mln_texture_session*>(nullptr);
-  auto status = attach(map, descriptor, &texture);
-  if (status == MLN_STATUS_OK) {
-    *out_session = as_render_session(texture);
-  }
-  return status;
-}
-
-}  // namespace
 
 auto mln_owned_texture_descriptor_default(void) noexcept
   -> mln_owned_texture_descriptor {
@@ -88,9 +41,7 @@ auto mln_owned_texture_attach(
   mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return attach_texture_session(
-      mln::core::owned_texture_attach, map, descriptor, out_session
-    );
+    return mln::core::owned_texture_attach(map, descriptor, out_session);
   });
 }
 
@@ -99,9 +50,7 @@ auto mln_metal_owned_texture_attach(
   mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return attach_texture_session(
-      mln::core::metal_owned_texture_attach, map, descriptor, out_session
-    );
+    return mln::core::metal_owned_texture_attach(map, descriptor, out_session);
   });
 }
 
@@ -110,8 +59,8 @@ auto mln_metal_borrowed_texture_attach(
   mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return attach_texture_session(
-      mln::core::metal_borrowed_texture_attach, map, descriptor, out_session
+    return mln::core::metal_borrowed_texture_attach(
+      map, descriptor, out_session
     );
   });
 }
@@ -121,9 +70,7 @@ auto mln_vulkan_owned_texture_attach(
   mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return attach_texture_session(
-      mln::core::vulkan_owned_texture_attach, map, descriptor, out_session
-    );
+    return mln::core::vulkan_owned_texture_attach(map, descriptor, out_session);
   });
 }
 
@@ -132,8 +79,8 @@ auto mln_vulkan_borrowed_texture_attach(
   mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return attach_texture_session(
-      mln::core::vulkan_borrowed_texture_attach, map, descriptor, out_session
+    return mln::core::vulkan_borrowed_texture_attach(
+      map, descriptor, out_session
     );
   });
 }
@@ -143,12 +90,8 @@ auto mln_texture_read_premultiplied_rgba8(
   mln_texture_image_info* out_info
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto status = validate_texture_render_session(session);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
     return mln::core::texture_read_premultiplied_rgba8(
-      as_texture_session(session), out_data, out_data_capacity, out_info
+      session, out_data, out_data_capacity, out_info
     );
   });
 }
@@ -157,13 +100,7 @@ auto mln_metal_owned_texture_acquire_frame(
   mln_render_session* session, mln_metal_owned_texture_frame* out_frame
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto status = validate_texture_render_session(session);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    return mln::core::metal_owned_texture_acquire_frame(
-      as_texture_session(session), out_frame
-    );
+    return mln::core::metal_owned_texture_acquire_frame(session, out_frame);
   });
 }
 
@@ -171,13 +108,7 @@ auto mln_metal_owned_texture_release_frame(
   mln_render_session* session, const mln_metal_owned_texture_frame* frame
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto status = validate_texture_render_session(session);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    return mln::core::metal_owned_texture_release_frame(
-      as_texture_session(session), frame
-    );
+    return mln::core::metal_owned_texture_release_frame(session, frame);
   });
 }
 
@@ -185,13 +116,7 @@ auto mln_vulkan_owned_texture_acquire_frame(
   mln_render_session* session, mln_vulkan_owned_texture_frame* out_frame
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto status = validate_texture_render_session(session);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    return mln::core::vulkan_owned_texture_acquire_frame(
-      as_texture_session(session), out_frame
-    );
+    return mln::core::vulkan_owned_texture_acquire_frame(session, out_frame);
   });
 }
 
@@ -199,12 +124,6 @@ auto mln_vulkan_owned_texture_release_frame(
   mln_render_session* session, const mln_vulkan_owned_texture_frame* frame
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    auto status = validate_texture_render_session(session);
-    if (status != MLN_STATUS_OK) {
-      return status;
-    }
-    return mln::core::vulkan_owned_texture_release_frame(
-      as_texture_session(session), frame
-    );
+    return mln::core::vulkan_owned_texture_release_frame(session, frame);
   });
 }

--- a/src/c_api/texture.cpp
+++ b/src/c_api/texture.cpp
@@ -4,8 +4,55 @@
 #include <cstdint>
 
 #include "c_api/boundary.hpp"
+#include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
+#include "render/render_session_common.hpp"
 #include "render/texture_session.hpp"
+
+namespace {
+
+auto as_render_session(mln_texture_session* texture) -> mln_render_session* {
+  return static_cast<mln_render_session*>(texture);
+}
+
+auto as_texture_session(mln_render_session* session) -> mln_texture_session* {
+  return static_cast<mln_texture_session*>(session->concrete);
+}
+
+auto validate_texture_render_session(mln_render_session* session)
+  -> mln_status {
+  auto kind = mln::core::RenderSessionKind::Surface;
+  auto status = mln::core::render_session_kind(session, &kind);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (kind != mln::core::RenderSessionKind::Texture) {
+    mln::core::set_thread_error("render session is not a texture session");
+    return MLN_STATUS_UNSUPPORTED;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto attach_texture_session(
+  auto attach, mln_map* map, const auto* descriptor,
+  mln_render_session** out_session
+) -> mln_status {
+  auto output_status = mln::core::validate_render_session_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+  auto* texture = static_cast<mln_texture_session*>(nullptr);
+  auto status = attach(map, descriptor, &texture);
+  if (status == MLN_STATUS_OK) {
+    *out_session = as_render_session(texture);
+  }
+  return status;
+}
+
+}  // namespace
 
 auto mln_owned_texture_descriptor_default(void) noexcept
   -> mln_owned_texture_descriptor {
@@ -38,120 +85,126 @@ auto mln_texture_image_info_default(void) noexcept -> mln_texture_image_info {
 
 auto mln_owned_texture_attach(
   mln_map* map, const mln_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::owned_texture_attach(map, descriptor, out_texture);
+    return attach_texture_session(
+      mln::core::owned_texture_attach, map, descriptor, out_session
+    );
   });
 }
 
 auto mln_metal_owned_texture_attach(
   mln_map* map, const mln_metal_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::metal_owned_texture_attach(map, descriptor, out_texture);
+    return attach_texture_session(
+      mln::core::metal_owned_texture_attach, map, descriptor, out_session
+    );
   });
 }
 
 auto mln_metal_borrowed_texture_attach(
   mln_map* map, const mln_metal_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::metal_borrowed_texture_attach(
-      map, descriptor, out_texture
+    return attach_texture_session(
+      mln::core::metal_borrowed_texture_attach, map, descriptor, out_session
     );
   });
 }
 
 auto mln_vulkan_owned_texture_attach(
   mln_map* map, const mln_vulkan_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::vulkan_owned_texture_attach(map, descriptor, out_texture);
+    return attach_texture_session(
+      mln::core::vulkan_owned_texture_attach, map, descriptor, out_session
+    );
   });
 }
 
 auto mln_vulkan_borrowed_texture_attach(
   mln_map* map, const mln_vulkan_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_session
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::vulkan_borrowed_texture_attach(
-      map, descriptor, out_texture
+    return attach_texture_session(
+      mln::core::vulkan_borrowed_texture_attach, map, descriptor, out_session
     );
   });
 }
 
-auto mln_texture_resize(
-  mln_texture_session* texture, uint32_t width, uint32_t height,
-  double scale_factor
-) noexcept -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::texture_resize(texture, width, height, scale_factor);
-  });
-}
-
-auto mln_texture_render_update(mln_texture_session* texture) noexcept
-  -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::texture_render_update(texture);
-  });
-}
-
 auto mln_texture_read_premultiplied_rgba8(
-  mln_texture_session* texture, uint8_t* out_data, size_t out_data_capacity,
+  mln_render_session* session, uint8_t* out_data, size_t out_data_capacity,
   mln_texture_image_info* out_info
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
+    auto status = validate_texture_render_session(session);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
     return mln::core::texture_read_premultiplied_rgba8(
-      texture, out_data, out_data_capacity, out_info
+      as_texture_session(session), out_data, out_data_capacity, out_info
     );
   });
 }
 
 auto mln_metal_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_metal_owned_texture_frame* out_frame
+  mln_render_session* session, mln_metal_owned_texture_frame* out_frame
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::metal_owned_texture_acquire_frame(texture, out_frame);
+    auto status = validate_texture_render_session(session);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    return mln::core::metal_owned_texture_acquire_frame(
+      as_texture_session(session), out_frame
+    );
   });
 }
 
 auto mln_metal_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_metal_owned_texture_frame* frame
+  mln_render_session* session, const mln_metal_owned_texture_frame* frame
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::metal_owned_texture_release_frame(texture, frame);
+    auto status = validate_texture_render_session(session);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    return mln::core::metal_owned_texture_release_frame(
+      as_texture_session(session), frame
+    );
   });
 }
 
 auto mln_vulkan_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_vulkan_owned_texture_frame* out_frame
+  mln_render_session* session, mln_vulkan_owned_texture_frame* out_frame
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::vulkan_owned_texture_acquire_frame(texture, out_frame);
+    auto status = validate_texture_render_session(session);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    return mln::core::vulkan_owned_texture_acquire_frame(
+      as_texture_session(session), out_frame
+    );
   });
 }
 
 auto mln_vulkan_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_vulkan_owned_texture_frame* frame
+  mln_render_session* session, const mln_vulkan_owned_texture_frame* frame
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::vulkan_owned_texture_release_frame(texture, frame);
-  });
-}
-
-auto mln_texture_detach(mln_texture_session* texture) noexcept -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::texture_detach(texture);
-  });
-}
-
-auto mln_texture_destroy(mln_texture_session* texture) noexcept -> mln_status {
-  return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::texture_destroy(texture);
+    auto status = validate_texture_render_session(session);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+    return mln::core::vulkan_owned_texture_release_frame(
+      as_texture_session(session), frame
+    );
   });
 }

--- a/src/render/metal/metal_surface_session.mm
+++ b/src/render/metal/metal_surface_session.mm
@@ -228,7 +228,7 @@ class MetalSurfaceBackend final : public mbgl::mtl::RendererBackend,
 void resize_metal_surface(
   mln_render_session* surface, uint32_t physical_width, uint32_t physical_height
 ) {
-  static_cast<MetalSurfaceBackend&>(*surface->surface_backend)
+  static_cast<MetalSurfaceBackend&>(*surface->surface.backend)
     .setSize(mbgl::Size{physical_width, physical_height});
 }
 
@@ -270,7 +270,7 @@ namespace mln::core {
 
 auto metal_surface_attach(
   mln_map* map, const mln_metal_surface_descriptor* descriptor,
-  mln_render_session** out_surface
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -280,12 +280,16 @@ auto metal_surface_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_surface_attach_output(out_surface);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
-  const auto physical_status = validate_surface_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+  const auto physical_status = validate_physical_size(
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled surface dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -298,21 +302,28 @@ auto metal_surface_attach(
   session->height = descriptor->height;
   session->scale_factor = descriptor->scale_factor;
   session->physical_width =
-    surface_physical_dimension(descriptor->width, descriptor->scale_factor);
+    physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
-    surface_physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->surface_backend = std::make_unique<MetalSurfaceBackend>(
+    physical_dimension(descriptor->height, descriptor->scale_factor);
+  session->surface.backend = std::make_unique<MetalSurfaceBackend>(
     static_cast<CA::MetalLayer*>(descriptor->layer),
     static_cast<MTL::Device*>(descriptor->device),
     mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->resize_surface_backend = resize_metal_surface;
-  return surface_attach_session(std::move(session), out_surface);
+  session->surface.resize_backend = resize_metal_surface;
+  return attach_render_session(
+    std::move(session), out_session, RenderSessionKind::Surface,
+    RenderSessionAttachMessages{
+      .null_session = "surface session must not be null",
+      .null_output = "out_session must not be null",
+      .non_null_output = "out_session must point to a null handle"
+    }
+  );
 }
 
 auto vulkan_surface_attach(
   mln_map* map, const mln_vulkan_surface_descriptor* descriptor,
-  mln_render_session** out_surface
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -322,12 +333,16 @@ auto vulkan_surface_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_surface_attach_output(out_surface);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
-  const auto physical_status = validate_surface_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+  const auto physical_status = validate_physical_size(
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled surface dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;

--- a/src/render/metal/metal_surface_session.mm
+++ b/src/render/metal/metal_surface_session.mm
@@ -21,6 +21,7 @@
 
 #include "diagnostics/diagnostics.hpp"
 #include "map/map.hpp"
+#include "render/render_session_common.hpp"
 #include "render/surface_session.hpp"
 
 namespace {
@@ -225,10 +226,9 @@ class MetalSurfaceBackend final : public mbgl::mtl::RendererBackend,
 };
 
 void resize_metal_surface(
-  mln_surface_session* surface, uint32_t physical_width,
-  uint32_t physical_height
+  mln_render_session* surface, uint32_t physical_width, uint32_t physical_height
 ) {
-  static_cast<MetalSurfaceBackend&>(*surface->backend)
+  static_cast<MetalSurfaceBackend&>(*surface->surface_backend)
     .setSize(mbgl::Size{physical_width, physical_height});
 }
 
@@ -270,7 +270,7 @@ namespace mln::core {
 
 auto metal_surface_attach(
   mln_map* map, const mln_metal_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_surface
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -291,7 +291,7 @@ auto metal_surface_attach(
     return physical_status;
   }
 
-  auto session = std::make_unique<mln_surface_session>();
+  auto session = std::make_unique<mln_render_session>();
   session->map = map;
   session->owner_thread = map_owner_thread(map);
   session->width = descriptor->width;
@@ -301,18 +301,18 @@ auto metal_surface_attach(
     surface_physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     surface_physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->backend = std::make_unique<MetalSurfaceBackend>(
+  session->surface_backend = std::make_unique<MetalSurfaceBackend>(
     static_cast<CA::MetalLayer*>(descriptor->layer),
     static_cast<MTL::Device*>(descriptor->device),
     mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->resize_backend = resize_metal_surface;
+  session->resize_surface_backend = resize_metal_surface;
   return surface_attach_session(std::move(session), out_surface);
 }
 
 auto vulkan_surface_attach(
   mln_map* map, const mln_vulkan_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_surface
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -251,13 +251,6 @@ auto metal_owned_texture_attach(
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
-
-  auto session = std::make_unique<mln_render_session>();
-  session->map = map;
-  session->owner_thread = map_owner_thread(map);
-  session->width = descriptor->width;
-  session->height = descriptor->height;
-  session->scale_factor = descriptor->scale_factor;
   const auto physical_status = validate_physical_size(
     descriptor->width, descriptor->height, descriptor->scale_factor,
     "scaled texture dimensions are too large"
@@ -265,6 +258,13 @@ auto metal_owned_texture_attach(
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
   }
+
+  auto session = std::make_unique<mln_render_session>();
+  session->map = map;
+  session->owner_thread = map_owner_thread(map);
+  session->width = descriptor->width;
+  session->height = descriptor->height;
+  session->scale_factor = descriptor->scale_factor;
   session->physical_width =
     physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -71,7 +71,8 @@ auto validate_borrowed_descriptor(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
   const auto physical_status = mln::core::validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -170,7 +171,7 @@ auto validate_vulkan_borrowed_descriptor(
 auto finish_metal_render(mln_render_session* texture) -> mln_status {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   auto& backend =
-    static_cast<mln::core::MetalTextureBackend&>(*texture->texture_backend);
+    static_cast<mln::core::MetalTextureBackend&>(*texture->texture.backend);
   auto* rendered_texture = backend.metal_texture();
   if (rendered_texture == nullptr) {
     mln::core::set_thread_error(
@@ -178,7 +179,7 @@ auto finish_metal_render(mln_render_session* texture) -> mln_status {
     );
     return MLN_STATUS_INVALID_STATE;
   }
-  texture->rendered_native_texture = rendered_texture;
+  texture->texture.rendered_native_texture = rendered_texture;
   return MLN_STATUS_OK;
 }
 
@@ -186,7 +187,7 @@ auto fill_frame(
   mln_render_session* texture, mln_metal_owned_texture_frame* out_frame
 ) -> mln_status {
   auto* metal_texture =
-    static_cast<MTL::Texture*>(texture->rendered_native_texture);
+    static_cast<MTL::Texture*>(texture->texture.rendered_native_texture);
   if (metal_texture == nullptr) {
     mln::core::set_thread_error("rendered Metal texture is not available");
     return MLN_STATUS_INVALID_STATE;
@@ -198,7 +199,7 @@ auto fill_frame(
     .width = texture->physical_width,
     .height = texture->physical_height,
     .scale_factor = texture->scale_factor,
-    .frame_id = texture->next_frame_id,
+    .frame_id = texture->texture.next_frame_id,
     .texture = metal_texture,
     .device = metal_texture->device(),
     .pixel_format = static_cast<uint64_t>(metal_texture->pixelFormat())
@@ -233,7 +234,7 @@ auto metal_borrowed_texture_descriptor_default() noexcept
 
 auto metal_owned_texture_attach(
   mln_map* map, const mln_metal_owned_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -243,7 +244,10 @@ auto metal_owned_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
@@ -255,7 +259,8 @@ auto metal_owned_texture_attach(
   session->height = descriptor->height;
   session->scale_factor = descriptor->scale_factor;
   const auto physical_status = validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -264,19 +269,26 @@ auto metal_owned_texture_attach(
     physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->api_kind = TextureSessionApi::Metal;
-  session->mode = TextureSessionMode::Owned;
-  session->texture_backend = std::make_unique<MetalTextureBackend>(
+  session->texture.api_kind = TextureSessionApi::Metal;
+  session->texture.mode = TextureSessionMode::Owned;
+  session->texture.backend = std::make_unique<MetalTextureBackend>(
     static_cast<MTL::Device*>(descriptor->device),
     mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->after_render = finish_metal_render;
-  return texture_attach_session(std::move(session), out_texture);
+  session->texture.after_render = finish_metal_render;
+  return attach_render_session(
+    std::move(session), out_session, RenderSessionKind::Texture,
+    RenderSessionAttachMessages{
+      .null_session = "texture session must not be null",
+      .null_output = "out_session must not be null",
+      .non_null_output = "out_session must point to a null handle"
+    }
+  );
 }
 
 auto metal_borrowed_texture_attach(
   mln_map* map, const mln_metal_borrowed_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -286,7 +298,10 @@ auto metal_borrowed_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
@@ -301,14 +316,21 @@ auto metal_borrowed_texture_attach(
     physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->api_kind = TextureSessionApi::Metal;
-  session->mode = TextureSessionMode::Borrowed;
-  session->texture_backend = std::make_unique<MetalTextureBackend>(
+  session->texture.api_kind = TextureSessionApi::Metal;
+  session->texture.mode = TextureSessionMode::Borrowed;
+  session->texture.backend = std::make_unique<MetalTextureBackend>(
     static_cast<MTL::Texture*>(descriptor->texture),
     mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->after_render = finish_metal_render;
-  return texture_attach_session(std::move(session), out_texture);
+  session->texture.after_render = finish_metal_render;
+  return attach_render_session(
+    std::move(session), out_session, RenderSessionKind::Texture,
+    RenderSessionAttachMessages{
+      .null_session = "texture session must not be null",
+      .null_output = "out_session must not be null",
+      .non_null_output = "out_session must point to a null handle"
+    }
+  );
 }
 
 auto metal_owned_texture_acquire_frame(
@@ -325,7 +347,7 @@ auto metal_owned_texture_acquire_frame(
     set_thread_error("out_frame must not be null and must have a valid size");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  if (texture->acquired) {
+  if (texture->texture.acquired) {
     set_thread_error("a texture frame is already acquired");
     return MLN_STATUS_INVALID_STATE;
   }
@@ -334,8 +356,8 @@ auto metal_owned_texture_acquire_frame(
     return MLN_STATUS_INVALID_STATE;
   }
   if (
-    texture->mode != TextureSessionMode::Owned ||
-    texture->api_kind != TextureSessionApi::Metal
+    texture->texture.mode != TextureSessionMode::Owned ||
+    texture->texture.api_kind != TextureSessionApi::Metal
   ) {
     set_thread_error("texture session cannot expose a Metal texture frame");
     return MLN_STATUS_UNSUPPORTED;
@@ -345,11 +367,12 @@ auto metal_owned_texture_acquire_frame(
   if (frame_status != MLN_STATUS_OK) {
     return frame_status;
   }
-  texture->acquired_native_texture = texture->rendered_native_texture;
-  texture->acquired = true;
-  texture->acquired_frame_id = out_frame->frame_id;
-  texture->acquired_frame_kind = TextureSessionFrameKind::MetalOwned;
-  ++texture->next_frame_id;
+  texture->texture.acquired_native_texture =
+    texture->texture.rendered_native_texture;
+  texture->texture.acquired = true;
+  texture->texture.acquired_frame_id = out_frame->frame_id;
+  texture->texture.acquired_frame_kind = TextureSessionFrameKind::MetalOwned;
+  ++texture->texture.next_frame_id;
   return MLN_STATUS_OK;
 }
 
@@ -365,8 +388,8 @@ auto metal_owned_texture_release_frame(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
   if (
-    !texture->acquired ||
-    texture->acquired_frame_kind != TextureSessionFrameKind::MetalOwned
+    !texture->texture.acquired ||
+    texture->texture.acquired_frame_kind != TextureSessionFrameKind::MetalOwned
   ) {
     set_thread_error("no texture frame is currently acquired");
     return MLN_STATUS_INVALID_STATE;
@@ -375,14 +398,14 @@ auto metal_owned_texture_release_frame(
     set_thread_error("frame generation does not match acquired frame");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  if (frame->frame_id != texture->acquired_frame_id) {
+  if (frame->frame_id != texture->texture.acquired_frame_id) {
     set_thread_error("frame identity does not match acquired frame");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  texture->acquired = false;
-  texture->acquired_frame_id = 0;
-  texture->acquired_frame_kind = TextureSessionFrameKind::None;
-  texture->acquired_native_texture = nullptr;
+  texture->texture.acquired = false;
+  texture->texture.acquired_frame_id = 0;
+  texture->texture.acquired_frame_kind = TextureSessionFrameKind::None;
+  texture->texture.acquired_native_texture = nullptr;
   return MLN_STATUS_OK;
 }
 
@@ -423,7 +446,7 @@ auto vulkan_borrowed_texture_descriptor_default() noexcept
 
 auto vulkan_owned_texture_attach(
   mln_map* map, const mln_vulkan_owned_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -433,12 +456,16 @@ auto vulkan_owned_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
   const auto physical_status = validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -449,7 +476,7 @@ auto vulkan_owned_texture_attach(
 
 auto vulkan_borrowed_texture_attach(
   mln_map* map, const mln_vulkan_borrowed_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -460,12 +487,16 @@ auto vulkan_borrowed_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
   const auto physical_status = validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -10,6 +10,7 @@
 #include "diagnostics/diagnostics.hpp"
 #include "map/map.hpp"
 #include "render/metal/metal_texture_backend.inc"
+#include "render/render_session_common.hpp"
 #include "render/texture_session.hpp"
 
 namespace {
@@ -166,10 +167,10 @@ auto validate_vulkan_borrowed_descriptor(
   return MLN_STATUS_OK;
 }
 
-auto finish_metal_render(mln_texture_session* texture) -> mln_status {
+auto finish_metal_render(mln_render_session* texture) -> mln_status {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   auto& backend =
-    static_cast<mln::core::MetalTextureBackend&>(*texture->backend);
+    static_cast<mln::core::MetalTextureBackend&>(*texture->texture_backend);
   auto* rendered_texture = backend.metal_texture();
   if (rendered_texture == nullptr) {
     mln::core::set_thread_error(
@@ -182,7 +183,7 @@ auto finish_metal_render(mln_texture_session* texture) -> mln_status {
 }
 
 auto fill_frame(
-  mln_texture_session* texture, mln_metal_owned_texture_frame* out_frame
+  mln_render_session* texture, mln_metal_owned_texture_frame* out_frame
 ) -> mln_status {
   auto* metal_texture =
     static_cast<MTL::Texture*>(texture->rendered_native_texture);
@@ -232,7 +233,7 @@ auto metal_borrowed_texture_descriptor_default() noexcept
 
 auto metal_owned_texture_attach(
   mln_map* map, const mln_metal_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -247,7 +248,7 @@ auto metal_owned_texture_attach(
     return output_status;
   }
 
-  auto session = std::make_unique<mln_texture_session>();
+  auto session = std::make_unique<mln_render_session>();
   session->map = map;
   session->owner_thread = map_owner_thread(map);
   session->width = descriptor->width;
@@ -265,7 +266,7 @@ auto metal_owned_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->api_kind = TextureSessionApi::Metal;
   session->mode = TextureSessionMode::Owned;
-  session->backend = std::make_unique<MetalTextureBackend>(
+  session->texture_backend = std::make_unique<MetalTextureBackend>(
     static_cast<MTL::Device*>(descriptor->device),
     mbgl::Size{session->physical_width, session->physical_height}
   );
@@ -275,7 +276,7 @@ auto metal_owned_texture_attach(
 
 auto metal_borrowed_texture_attach(
   mln_map* map, const mln_metal_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -290,7 +291,7 @@ auto metal_borrowed_texture_attach(
     return output_status;
   }
 
-  auto session = std::make_unique<mln_texture_session>();
+  auto session = std::make_unique<mln_render_session>();
   session->map = map;
   session->owner_thread = map_owner_thread(map);
   session->width = descriptor->width;
@@ -302,7 +303,7 @@ auto metal_borrowed_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->api_kind = TextureSessionApi::Metal;
   session->mode = TextureSessionMode::Borrowed;
-  session->backend = std::make_unique<MetalTextureBackend>(
+  session->texture_backend = std::make_unique<MetalTextureBackend>(
     static_cast<MTL::Texture*>(descriptor->texture),
     mbgl::Size{session->physical_width, session->physical_height}
   );
@@ -311,7 +312,7 @@ auto metal_borrowed_texture_attach(
 }
 
 auto metal_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_metal_owned_texture_frame* out_frame
+  mln_render_session* texture, mln_metal_owned_texture_frame* out_frame
 ) -> mln_status {
   const auto status = validate_live_attached_texture(texture);
   if (status != MLN_STATUS_OK) {
@@ -353,7 +354,7 @@ auto metal_owned_texture_acquire_frame(
 }
 
 auto metal_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_metal_owned_texture_frame* frame
+  mln_render_session* texture, const mln_metal_owned_texture_frame* frame
 ) -> mln_status {
   const auto status = validate_texture(texture);
   if (status != MLN_STATUS_OK) {
@@ -422,7 +423,7 @@ auto vulkan_borrowed_texture_descriptor_default() noexcept
 
 auto vulkan_owned_texture_attach(
   mln_map* map, const mln_vulkan_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -448,7 +449,7 @@ auto vulkan_owned_texture_attach(
 
 auto vulkan_borrowed_texture_attach(
   mln_map* map, const mln_vulkan_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -474,7 +475,7 @@ auto vulkan_borrowed_texture_attach(
 }
 
 auto vulkan_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_vulkan_owned_texture_frame* out_frame
+  mln_render_session* texture, mln_vulkan_owned_texture_frame* out_frame
 ) -> mln_status {
   const auto status = validate_texture(texture);
   if (status != MLN_STATUS_OK) {
@@ -492,7 +493,7 @@ auto vulkan_owned_texture_acquire_frame(
 }
 
 auto vulkan_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_vulkan_owned_texture_frame* frame
+  mln_render_session* texture, const mln_vulkan_owned_texture_frame* frame
 ) -> mln_status {
   const auto status = validate_texture(texture);
   if (status != MLN_STATUS_OK) {

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -1,9 +1,21 @@
+#include <cmath>
+#include <cstdint>
+#include <memory>
 #include <mutex>
+#include <thread>
 #include <unordered_map>
+#include <utility>
+
+#include <mbgl/gfx/backend_scope.hpp>
+#include <mbgl/gfx/renderer_backend.hpp>
+#include <mbgl/map/map.hpp>
+#include <mbgl/renderer/renderer.hpp>
+#include <mbgl/util/size.hpp>
 
 #include "render/render_session_common.hpp"
 
 #include "diagnostics/diagnostics.hpp"
+#include "map/map.hpp"
 #include "maplibre_native_c.h"
 
 namespace {
@@ -13,11 +25,39 @@ auto render_session_mutex() -> std::mutex& {
   return value;
 }
 
-auto render_sessions()
-  -> std::unordered_map<mln_render_session*, mln::core::RenderSessionKind>& {
-  static auto value =
-    std::unordered_map<mln_render_session*, mln::core::RenderSessionKind>{};
+auto render_sessions() -> std::unordered_map<
+  mln_render_session*, std::unique_ptr<mln_render_session>>& {
+  static auto value = std::unordered_map<
+    mln_render_session*, std::unique_ptr<mln_render_session>>{};
   return value;
+}
+
+auto has_backend(const mln_render_session* session) -> bool {
+  if (session->kind == mln::core::RenderSessionKind::Surface) {
+    return session->surface_backend != nullptr;
+  }
+  return session->texture_backend != nullptr;
+}
+
+auto validate_dimensions(
+  uint32_t width, uint32_t height, double scale_factor, const char* message
+) -> mln_status {
+  if (
+    width == 0 || height == 0 || !std::isfinite(scale_factor) ||
+    scale_factor <= 0.0
+  ) {
+    mln::core::set_thread_error(message);
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto renderer_backend(mln_render_session* session)
+  -> mbgl::gfx::RendererBackend* {
+  if (session->kind == mln::core::RenderSessionKind::Surface) {
+    return session->surface_backend.get();
+  }
+  return session->texture_backend->getRendererBackend();
 }
 
 }  // namespace
@@ -25,10 +65,10 @@ auto render_sessions()
 namespace mln::core {
 
 auto register_render_session(
-  mln_render_session* session, RenderSessionKind kind
+  mln_render_session* handle, std::unique_ptr<mln_render_session> session
 ) -> void {
   const auto lock = std::scoped_lock{render_session_mutex()};
-  render_sessions().emplace(session, kind);
+  render_sessions().emplace(handle, std::move(session));
 }
 
 auto unregister_render_session(mln_render_session* session) -> void {
@@ -36,20 +76,284 @@ auto unregister_render_session(mln_render_session* session) -> void {
   render_sessions().erase(session);
 }
 
-auto render_session_kind(
-  mln_render_session* session, RenderSessionKind* out_kind
-) -> mln_status {
+auto validate_render_session(mln_render_session* session) -> mln_status {
   if (session == nullptr) {
     set_thread_error("render session must not be null");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
   const auto lock = std::scoped_lock{render_session_mutex()};
-  const auto found = render_sessions().find(session);
-  if (found == render_sessions().end()) {
+  if (!render_sessions().contains(session)) {
     set_thread_error("render session is not a live handle");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  *out_kind = found->second;
+  if (session->owner_thread != std::this_thread::get_id()) {
+    set_thread_error("render session call must be made on its owner thread");
+    return MLN_STATUS_WRONG_THREAD;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_live_attached_render_session(mln_render_session* session)
+  -> mln_status {
+  const auto status = validate_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!session->attached || !has_backend(session)) {
+    set_thread_error("render session is detached");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto erase_render_session(mln_render_session* session)
+  -> std::unique_ptr<mln_render_session> {
+  const auto lock = std::scoped_lock{render_session_mutex()};
+  auto found = render_sessions().find(session);
+  if (found == render_sessions().end()) {
+    return nullptr;
+  }
+  auto owned = std::move(found->second);
+  render_sessions().erase(found);
+  return owned;
+}
+
+auto attach_render_session(
+  std::unique_ptr<mln_render_session> session, mln_render_session** out_session,
+  RenderSessionKind kind, RenderSessionAttachMessages messages
+) -> mln_status {
+  if (session == nullptr) {
+    set_thread_error(messages.null_session);
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto output_status = validate_render_session_attach_output(
+    out_session, messages.null_output, messages.non_null_output
+  );
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+
+  auto* map = session->map;
+  auto* handle = session.get();
+  const auto attach_status = map_attach_render_target_session(map, handle);
+  if (attach_status != MLN_STATUS_OK) {
+    return attach_status;
+  }
+  try {
+    if (auto* native_map = map_native(map); native_map != nullptr) {
+      native_map->setSize(mbgl::Size{session->width, session->height});
+    }
+    session->kind = kind;
+    register_render_session(handle, std::move(session));
+  } catch (...) {
+    static_cast<void>(map_detach_render_target_session(map, handle));
+    throw;
+  }
+
+  *out_session = handle;
+  return MLN_STATUS_OK;
+}
+
+auto render_session_resize(
+  mln_render_session* session, uint32_t width, uint32_t height,
+  double scale_factor
+) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto dimensions_status = validate_dimensions(
+    width, height, scale_factor,
+    session->kind == RenderSessionKind::Surface
+      ? "surface dimensions and scale_factor must be positive"
+      : "texture dimensions and scale_factor must be positive"
+  );
+  if (dimensions_status != MLN_STATUS_OK) {
+    return dimensions_status;
+  }
+  if (session->kind == RenderSessionKind::Texture && session->acquired) {
+    set_thread_error("cannot resize while a texture frame is acquired");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  if (
+    session->kind == RenderSessionKind::Texture &&
+    session->mode == TextureSessionMode::Borrowed
+  ) {
+    set_thread_error(
+      "borrowed texture sessions cannot be resized; attach a new target"
+    );
+    return MLN_STATUS_UNSUPPORTED;
+  }
+  const auto physical_status = validate_render_session_physical_size(
+    width, height, scale_factor,
+    session->kind == RenderSessionKind::Surface
+      ? "scaled surface dimensions are too large"
+      : "scaled texture dimensions are too large"
+  );
+  if (physical_status != MLN_STATUS_OK) {
+    return physical_status;
+  }
+
+  const auto physical_width =
+    render_session_physical_dimension(width, scale_factor);
+  const auto physical_height =
+    render_session_physical_dimension(height, scale_factor);
+  if (session->kind == RenderSessionKind::Surface) {
+    if (session->resize_surface_backend != nullptr) {
+      session->resize_surface_backend(session, physical_width, physical_height);
+    }
+  } else {
+    session->texture_backend->setSize(
+      mbgl::Size{physical_width, physical_height}
+    );
+    session->rendered_native_texture = nullptr;
+    session->acquired_native_texture = nullptr;
+    session->acquired_frame_kind = TextureSessionFrameKind::None;
+  }
+  if (auto* native_map = map_native(session->map); native_map != nullptr) {
+    native_map->setSize(mbgl::Size{width, height});
+  }
+  session->renderer.reset();
+  session->rendered_generation = 0;
+  session->width = width;
+  session->height = height;
+  session->physical_width = physical_width;
+  session->physical_height = physical_height;
+  session->scale_factor = scale_factor;
+  ++session->generation;
+  return MLN_STATUS_OK;
+}
+
+auto render_session_render_update(mln_render_session* session) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (session->kind == RenderSessionKind::Texture && session->acquired) {
+    set_thread_error("cannot render while a texture frame is acquired");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto update = map_latest_update(session->map);
+  if (!update) {
+    set_thread_error("no map render update is available");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  if (session->prepare_render_resources != nullptr) {
+    session->prepare_render_resources(session);
+  }
+  auto* backend = renderer_backend(session);
+  if (backend == nullptr) {
+    set_thread_error("render session renderer backend is not available");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
+  map_run_render_jobs(session->map);
+  if (session->renderer == nullptr) {
+    session->renderer = std::make_unique<mbgl::Renderer>(
+      *backend, static_cast<float>(session->scale_factor)
+    );
+    session->renderer->setObserver(map_renderer_observer(session->map));
+  }
+
+  session->renderer->render(update);
+  if (session->after_render != nullptr) {
+    const auto after_status = session->after_render(session);
+    if (after_status != MLN_STATUS_OK) {
+      return after_status;
+    }
+  }
+  session->rendered_generation = session->generation;
+  return MLN_STATUS_OK;
+}
+
+auto render_session_detach(mln_render_session* session) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (session->kind == RenderSessionKind::Texture && session->acquired) {
+    set_thread_error("cannot detach while a texture frame is acquired");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  const auto detach_status =
+    map_detach_render_target_session(session->map, session);
+  if (detach_status != MLN_STATUS_OK) {
+    return detach_status;
+  }
+  session->renderer.reset();
+  session->surface_backend.reset();
+  session->texture_backend.reset();
+  session->attached = false;
+  session->rendered_generation = 0;
+  session->rendered_native_texture = nullptr;
+  session->acquired_native_texture = nullptr;
+  session->acquired_frame_kind = TextureSessionFrameKind::None;
+  ++session->generation;
+  return MLN_STATUS_OK;
+}
+
+auto render_session_destroy(mln_render_session* session) -> mln_status {
+  const auto status = validate_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (session->kind == RenderSessionKind::Texture && session->acquired) {
+    set_thread_error("cannot destroy while a texture frame is acquired");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  if (session->attached) {
+    const auto detach_status = render_session_detach(session);
+    if (detach_status != MLN_STATUS_OK) {
+      return detach_status;
+    }
+  }
+  auto owned_session = erase_render_session(session);
+  owned_session.reset();
+  return MLN_STATUS_OK;
+}
+
+auto render_session_reduce_memory_use(mln_render_session* session)
+  -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (session->renderer == nullptr) {
+    set_thread_error("render session renderer is not available");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  session->renderer->reduceMemoryUse();
+  return MLN_STATUS_OK;
+}
+
+auto render_session_clear_data(mln_render_session* session) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (session->renderer == nullptr) {
+    set_thread_error("render session renderer is not available");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  session->renderer->clearData();
+  return MLN_STATUS_OK;
+}
+
+auto render_session_dump_debug_logs(mln_render_session* session) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (session->renderer == nullptr) {
+    set_thread_error("render session renderer is not available");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  session->renderer->dumpDebugLogs();
   return MLN_STATUS_OK;
 }
 

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -1,0 +1,56 @@
+#include <mutex>
+#include <unordered_map>
+
+#include "render/render_session_common.hpp"
+
+#include "diagnostics/diagnostics.hpp"
+#include "maplibre_native_c.h"
+
+namespace {
+
+auto render_session_mutex() -> std::mutex& {
+  static auto value = std::mutex{};
+  return value;
+}
+
+auto render_sessions()
+  -> std::unordered_map<mln_render_session*, mln::core::RenderSessionKind>& {
+  static auto value =
+    std::unordered_map<mln_render_session*, mln::core::RenderSessionKind>{};
+  return value;
+}
+
+}  // namespace
+
+namespace mln::core {
+
+auto register_render_session(
+  mln_render_session* session, RenderSessionKind kind
+) -> void {
+  const auto lock = std::scoped_lock{render_session_mutex()};
+  render_sessions().emplace(session, kind);
+}
+
+auto unregister_render_session(mln_render_session* session) -> void {
+  const auto lock = std::scoped_lock{render_session_mutex()};
+  render_sessions().erase(session);
+}
+
+auto render_session_kind(
+  mln_render_session* session, RenderSessionKind* out_kind
+) -> mln_status {
+  if (session == nullptr) {
+    set_thread_error("render session must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto lock = std::scoped_lock{render_session_mutex()};
+  const auto found = render_sessions().find(session);
+  if (found == render_sessions().end()) {
+    set_thread_error("render session is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_kind = found->second;
+  return MLN_STATUS_OK;
+}
+
+}  // namespace mln::core

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -60,6 +60,22 @@ auto renderer_backend(mln_render_session* session)
   return session->texture.backend->getRendererBackend();
 }
 
+auto validate_renderer_backend(mln_render_session* session)
+  -> mbgl::gfx::RendererBackend* {
+  if (session->renderer == nullptr) {
+    mln::core::set_thread_error("render session renderer is not available");
+    return nullptr;
+  }
+  auto* backend = renderer_backend(session);
+  if (backend == nullptr) {
+    mln::core::set_thread_error(
+      "render session renderer backend is not available"
+    );
+    return nullptr;
+  }
+  return backend;
+}
+
 }  // namespace
 
 namespace mln::core {
@@ -330,10 +346,13 @@ auto render_session_reduce_memory_use(mln_render_session* session)
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  if (session->renderer == nullptr) {
-    set_thread_error("render session renderer is not available");
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
     return MLN_STATUS_INVALID_STATE;
   }
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
   session->renderer->reduceMemoryUse();
   return MLN_STATUS_OK;
 }
@@ -343,10 +362,13 @@ auto render_session_clear_data(mln_render_session* session) -> mln_status {
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  if (session->renderer == nullptr) {
-    set_thread_error("render session renderer is not available");
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
     return MLN_STATUS_INVALID_STATE;
   }
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
   session->renderer->clearData();
   return MLN_STATUS_OK;
 }
@@ -356,10 +378,13 @@ auto render_session_dump_debug_logs(mln_render_session* session) -> mln_status {
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  if (session->renderer == nullptr) {
-    set_thread_error("render session renderer is not available");
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
     return MLN_STATUS_INVALID_STATE;
   }
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
   session->renderer->dumpDebugLogs();
   return MLN_STATUS_OK;
 }

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -71,11 +71,6 @@ auto register_render_session(
   render_sessions().emplace(handle, std::move(session));
 }
 
-auto unregister_render_session(mln_render_session* session) -> void {
-  const auto lock = std::scoped_lock{render_session_mutex()};
-  render_sessions().erase(session);
-}
-
 auto validate_render_session(mln_render_session* session) -> mln_status {
   if (session == nullptr) {
     set_thread_error("render session must not be null");
@@ -242,7 +237,10 @@ auto render_session_render_update(mln_render_session* session) -> mln_status {
     return MLN_STATUS_INVALID_STATE;
   }
 
-  if (session->texture.prepare_render_resources != nullptr) {
+  if (
+    session->kind == RenderSessionKind::Texture &&
+    session->texture.prepare_render_resources != nullptr
+  ) {
     session->texture.prepare_render_resources(session);
   }
   auto* backend = renderer_backend(session);
@@ -262,7 +260,10 @@ auto render_session_render_update(mln_render_session* session) -> mln_status {
   }
 
   session->renderer->render(update);
-  if (session->texture.after_render != nullptr) {
+  if (
+    session->kind == RenderSessionKind::Texture &&
+    session->texture.after_render != nullptr
+  ) {
     const auto after_status = session->texture.after_render(session);
     if (after_status != MLN_STATUS_OK) {
       return after_status;

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -34,9 +34,9 @@ auto render_sessions() -> std::unordered_map<
 
 auto has_backend(const mln_render_session* session) -> bool {
   if (session->kind == mln::core::RenderSessionKind::Surface) {
-    return session->surface_backend != nullptr;
+    return session->surface.backend != nullptr;
   }
-  return session->texture_backend != nullptr;
+  return session->texture.backend != nullptr;
 }
 
 auto validate_dimensions(
@@ -55,9 +55,9 @@ auto validate_dimensions(
 auto renderer_backend(mln_render_session* session)
   -> mbgl::gfx::RendererBackend* {
   if (session->kind == mln::core::RenderSessionKind::Surface) {
-    return session->surface_backend.get();
+    return session->surface.backend.get();
   }
-  return session->texture_backend->getRendererBackend();
+  return session->texture.backend->getRendererBackend();
 }
 
 }  // namespace
@@ -126,7 +126,7 @@ auto attach_render_session(
     set_thread_error(messages.null_session);
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  const auto output_status = validate_render_session_attach_output(
+  const auto output_status = validate_attach_output(
     out_session, messages.null_output, messages.non_null_output
   );
   if (output_status != MLN_STATUS_OK) {
@@ -171,20 +171,22 @@ auto render_session_resize(
   if (dimensions_status != MLN_STATUS_OK) {
     return dimensions_status;
   }
-  if (session->kind == RenderSessionKind::Texture && session->acquired) {
+  if (
+    session->kind == RenderSessionKind::Texture && session->texture.acquired
+  ) {
     set_thread_error("cannot resize while a texture frame is acquired");
     return MLN_STATUS_INVALID_STATE;
   }
   if (
     session->kind == RenderSessionKind::Texture &&
-    session->mode == TextureSessionMode::Borrowed
+    session->texture.mode == TextureSessionMode::Borrowed
   ) {
     set_thread_error(
       "borrowed texture sessions cannot be resized; attach a new target"
     );
     return MLN_STATUS_UNSUPPORTED;
   }
-  const auto physical_status = validate_render_session_physical_size(
+  const auto physical_status = validate_physical_size(
     width, height, scale_factor,
     session->kind == RenderSessionKind::Surface
       ? "scaled surface dimensions are too large"
@@ -194,21 +196,19 @@ auto render_session_resize(
     return physical_status;
   }
 
-  const auto physical_width =
-    render_session_physical_dimension(width, scale_factor);
-  const auto physical_height =
-    render_session_physical_dimension(height, scale_factor);
+  const auto physical_width = physical_dimension(width, scale_factor);
+  const auto physical_height = physical_dimension(height, scale_factor);
   if (session->kind == RenderSessionKind::Surface) {
-    if (session->resize_surface_backend != nullptr) {
-      session->resize_surface_backend(session, physical_width, physical_height);
+    if (session->surface.resize_backend != nullptr) {
+      session->surface.resize_backend(session, physical_width, physical_height);
     }
   } else {
-    session->texture_backend->setSize(
+    session->texture.backend->setSize(
       mbgl::Size{physical_width, physical_height}
     );
-    session->rendered_native_texture = nullptr;
-    session->acquired_native_texture = nullptr;
-    session->acquired_frame_kind = TextureSessionFrameKind::None;
+    session->texture.rendered_native_texture = nullptr;
+    session->texture.acquired_native_texture = nullptr;
+    session->texture.acquired_frame_kind = TextureSessionFrameKind::None;
   }
   if (auto* native_map = map_native(session->map); native_map != nullptr) {
     native_map->setSize(mbgl::Size{width, height});
@@ -229,7 +229,9 @@ auto render_session_render_update(mln_render_session* session) -> mln_status {
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  if (session->kind == RenderSessionKind::Texture && session->acquired) {
+  if (
+    session->kind == RenderSessionKind::Texture && session->texture.acquired
+  ) {
     set_thread_error("cannot render while a texture frame is acquired");
     return MLN_STATUS_INVALID_STATE;
   }
@@ -240,8 +242,8 @@ auto render_session_render_update(mln_render_session* session) -> mln_status {
     return MLN_STATUS_INVALID_STATE;
   }
 
-  if (session->prepare_render_resources != nullptr) {
-    session->prepare_render_resources(session);
+  if (session->texture.prepare_render_resources != nullptr) {
+    session->texture.prepare_render_resources(session);
   }
   auto* backend = renderer_backend(session);
   if (backend == nullptr) {
@@ -260,8 +262,8 @@ auto render_session_render_update(mln_render_session* session) -> mln_status {
   }
 
   session->renderer->render(update);
-  if (session->after_render != nullptr) {
-    const auto after_status = session->after_render(session);
+  if (session->texture.after_render != nullptr) {
+    const auto after_status = session->texture.after_render(session);
     if (after_status != MLN_STATUS_OK) {
       return after_status;
     }
@@ -275,7 +277,9 @@ auto render_session_detach(mln_render_session* session) -> mln_status {
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  if (session->kind == RenderSessionKind::Texture && session->acquired) {
+  if (
+    session->kind == RenderSessionKind::Texture && session->texture.acquired
+  ) {
     set_thread_error("cannot detach while a texture frame is acquired");
     return MLN_STATUS_INVALID_STATE;
   }
@@ -286,13 +290,13 @@ auto render_session_detach(mln_render_session* session) -> mln_status {
     return detach_status;
   }
   session->renderer.reset();
-  session->surface_backend.reset();
-  session->texture_backend.reset();
+  session->surface.backend.reset();
+  session->texture.backend.reset();
   session->attached = false;
   session->rendered_generation = 0;
-  session->rendered_native_texture = nullptr;
-  session->acquired_native_texture = nullptr;
-  session->acquired_frame_kind = TextureSessionFrameKind::None;
+  session->texture.rendered_native_texture = nullptr;
+  session->texture.acquired_native_texture = nullptr;
+  session->texture.acquired_frame_kind = TextureSessionFrameKind::None;
   ++session->generation;
   return MLN_STATUS_OK;
 }
@@ -302,7 +306,9 @@ auto render_session_destroy(mln_render_session* session) -> mln_status {
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  if (session->kind == RenderSessionKind::Texture && session->acquired) {
+  if (
+    session->kind == RenderSessionKind::Texture && session->texture.acquired
+  ) {
     set_thread_error("cannot destroy while a texture frame is acquired");
     return MLN_STATUS_INVALID_STATE;
   }

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -17,6 +17,25 @@
 
 namespace mln::core {
 
+enum class RenderSessionKind : uint8_t { Surface, Texture };
+
+auto register_render_session(
+  mln_render_session* session, RenderSessionKind kind
+) -> void;
+auto unregister_render_session(mln_render_session* session) -> void;
+auto render_session_kind(
+  mln_render_session* session, RenderSessionKind* out_kind
+) -> mln_status;
+
+}  // namespace mln::core
+
+struct mln_render_session {
+  mln::core::RenderSessionKind kind = mln::core::RenderSessionKind::Surface;
+  void* concrete = nullptr;
+};
+
+namespace mln::core {
+
 struct RenderSessionAttachMessages {
   const char* null_session;
   const char* null_output;
@@ -122,7 +141,8 @@ inline auto validate_render_session_physical_size(
 template <typename Session>
 auto attach_render_session(
   std::unique_ptr<Session> session, Session** out_session,
-  RenderSessionRegistry<Session>& registry, RenderSessionAttachMessages messages
+  RenderSessionRegistry<Session>& registry, RenderSessionKind kind,
+  RenderSessionAttachMessages messages
 ) -> mln_status {
   if (session == nullptr) {
     set_thread_error(messages.null_session);
@@ -145,9 +165,14 @@ auto attach_render_session(
     if (auto* native_map = map_native(map); native_map != nullptr) {
       native_map->setSize(mbgl::Size{session->width, session->height});
     }
+    session->kind = kind;
+    session->concrete = handle;
     registry.emplace(handle, std::move(session));
+    register_render_session(static_cast<mln_render_session*>(handle), kind);
   } catch (...) {
+    unregister_render_session(static_cast<mln_render_session*>(handle));
     static_cast<void>(map_detach_render_target_session(map, handle));
+    static_cast<void>(registry.erase(handle));
     throw;
   }
 

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -4,34 +4,59 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
-#include <mutex>
 #include <thread>
-#include <unordered_map>
-#include <utility>
 
-#include <mbgl/util/size.hpp>
+#include <mbgl/gfx/headless_backend.hpp>
+#include <mbgl/gfx/renderer_backend.hpp>
+#include <mbgl/renderer/renderer.hpp>
 
 #include "diagnostics/diagnostics.hpp"
-#include "map/map.hpp"
 #include "maplibre_native_c.h"
 
 namespace mln::core {
 
 enum class RenderSessionKind : uint8_t { Surface, Texture };
+enum class TextureSessionApi : uint8_t { Generic, Metal, Vulkan };
+enum class TextureSessionFrameKind : uint8_t { None, MetalOwned, VulkanOwned };
+enum class TextureSessionMode : uint8_t { Owned, Borrowed };
 
-auto register_render_session(
-  mln_render_session* session, RenderSessionKind kind
-) -> void;
-auto unregister_render_session(mln_render_session* session) -> void;
-auto render_session_kind(
-  mln_render_session* session, RenderSessionKind* out_kind
-) -> mln_status;
+using SurfaceSessionResizeCallback =
+  void (*)(mln_render_session*, uint32_t, uint32_t);
+using TextureSessionPrepareCallback = void (*)(mln_render_session*);
+using TextureSessionAfterRenderCallback = mln_status (*)(mln_render_session*);
 
 }  // namespace mln::core
 
 struct mln_render_session {
   mln::core::RenderSessionKind kind = mln::core::RenderSessionKind::Surface;
-  void* concrete = nullptr;
+  mln_map* map = nullptr;
+  std::thread::id owner_thread;
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t physical_width = 0;
+  uint32_t physical_height = 0;
+  double scale_factor = 1.0;
+  uint64_t generation = 1;
+  uint64_t rendered_generation = 0;
+  bool attached = true;
+
+  std::unique_ptr<mbgl::Renderer> renderer = nullptr;
+
+  std::unique_ptr<mbgl::gfx::RendererBackend> surface_backend = nullptr;
+  mln::core::SurfaceSessionResizeCallback resize_surface_backend = nullptr;
+
+  std::unique_ptr<mbgl::gfx::HeadlessBackend> texture_backend = nullptr;
+  uint64_t next_frame_id = 1;
+  uint64_t acquired_frame_id = 0;
+  bool acquired = false;
+  mln::core::TextureSessionFrameKind acquired_frame_kind =
+    mln::core::TextureSessionFrameKind::None;
+  mln::core::TextureSessionApi api_kind = mln::core::TextureSessionApi::Generic;
+  mln::core::TextureSessionMode mode = mln::core::TextureSessionMode::Owned;
+  void* rendered_native_texture = nullptr;
+  void* acquired_native_texture = nullptr;
+  mln::core::TextureSessionPrepareCallback prepare_render_resources = nullptr;
+  mln::core::TextureSessionAfterRenderCallback after_render = nullptr;
 };
 
 namespace mln::core {
@@ -42,53 +67,19 @@ struct RenderSessionAttachMessages {
   const char* non_null_output;
 };
 
-template <typename Session>
-class RenderSessionRegistry final {
- public:
-  auto validate(
-    Session* session, const char* null_message, const char* not_live_message,
-    const char* wrong_thread_message
-  ) -> mln_status {
-    if (session == nullptr) {
-      set_thread_error(null_message);
-      return MLN_STATUS_INVALID_ARGUMENT;
-    }
-    const std::scoped_lock lock(mutex_);
-    if (!sessions_.contains(session)) {
-      set_thread_error(not_live_message);
-      return MLN_STATUS_INVALID_ARGUMENT;
-    }
-    if (session->owner_thread != std::this_thread::get_id()) {
-      set_thread_error(wrong_thread_message);
-      return MLN_STATUS_WRONG_THREAD;
-    }
-    return MLN_STATUS_OK;
-  }
+auto register_render_session(
+  mln_render_session* handle, std::unique_ptr<mln_render_session> session
+) -> void;
+auto unregister_render_session(mln_render_session* session) -> void;
+auto validate_render_session(mln_render_session* session) -> mln_status;
+auto validate_live_attached_render_session(mln_render_session* session)
+  -> mln_status;
+auto erase_render_session(mln_render_session* session)
+  -> std::unique_ptr<mln_render_session>;
 
-  auto emplace(Session* handle, std::unique_ptr<Session> session) -> void {
-    const std::scoped_lock lock(mutex_);
-    sessions_.emplace(handle, std::move(session));
-  }
-
-  auto erase(Session* handle) -> std::unique_ptr<Session> {
-    const std::scoped_lock lock(mutex_);
-    auto found = sessions_.find(handle);
-    if (found == sessions_.end()) {
-      return nullptr;
-    }
-    auto session = std::move(found->second);
-    sessions_.erase(found);
-    return session;
-  }
-
- private:
-  std::mutex mutex_;
-  std::unordered_map<Session*, std::unique_ptr<Session>> sessions_;
-};
-
-template <typename Session>
-auto validate_render_session_attach_output(
-  Session** out_session, const char* null_message, const char* not_null_message
+inline auto validate_render_session_attach_output(
+  mln_render_session** out_session, const char* null_message,
+  const char* not_null_message
 ) -> mln_status {
   if (out_session == nullptr) {
     set_thread_error(null_message);
@@ -97,21 +88,6 @@ auto validate_render_session_attach_output(
   if (*out_session != nullptr) {
     set_thread_error(not_null_message);
     return MLN_STATUS_INVALID_ARGUMENT;
-  }
-  return MLN_STATUS_OK;
-}
-
-template <typename Session, typename Validate>
-auto validate_live_attached_render_session(
-  Session* session, Validate validate, const char* detached_message
-) -> mln_status {
-  const auto status = validate(session);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (!session->attached || session->backend == nullptr) {
-    set_thread_error(detached_message);
-    return MLN_STATUS_INVALID_STATE;
   }
   return MLN_STATUS_OK;
 }
@@ -138,46 +114,21 @@ inline auto validate_render_session_physical_size(
   return MLN_STATUS_OK;
 }
 
-template <typename Session>
 auto attach_render_session(
-  std::unique_ptr<Session> session, Session** out_session,
-  RenderSessionRegistry<Session>& registry, RenderSessionKind kind,
-  RenderSessionAttachMessages messages
-) -> mln_status {
-  if (session == nullptr) {
-    set_thread_error(messages.null_session);
-    return MLN_STATUS_INVALID_ARGUMENT;
-  }
-  const auto output_status = validate_render_session_attach_output(
-    out_session, messages.null_output, messages.non_null_output
-  );
-  if (output_status != MLN_STATUS_OK) {
-    return output_status;
-  }
+  std::unique_ptr<mln_render_session> session, mln_render_session** out_session,
+  RenderSessionKind kind, RenderSessionAttachMessages messages
+) -> mln_status;
 
-  auto* map = session->map;
-  auto* handle = session.get();
-  const auto attach_status = map_attach_render_target_session(map, handle);
-  if (attach_status != MLN_STATUS_OK) {
-    return attach_status;
-  }
-  try {
-    if (auto* native_map = map_native(map); native_map != nullptr) {
-      native_map->setSize(mbgl::Size{session->width, session->height});
-    }
-    session->kind = kind;
-    session->concrete = handle;
-    registry.emplace(handle, std::move(session));
-    register_render_session(static_cast<mln_render_session*>(handle), kind);
-  } catch (...) {
-    unregister_render_session(static_cast<mln_render_session*>(handle));
-    static_cast<void>(map_detach_render_target_session(map, handle));
-    static_cast<void>(registry.erase(handle));
-    throw;
-  }
-
-  *out_session = handle;
-  return MLN_STATUS_OK;
-}
+auto render_session_resize(
+  mln_render_session* session, uint32_t width, uint32_t height,
+  double scale_factor
+) -> mln_status;
+auto render_session_render_update(mln_render_session* session) -> mln_status;
+auto render_session_detach(mln_render_session* session) -> mln_status;
+auto render_session_destroy(mln_render_session* session) -> mln_status;
+auto render_session_reduce_memory_use(mln_render_session* session)
+  -> mln_status;
+auto render_session_clear_data(mln_render_session* session) -> mln_status;
+auto render_session_dump_debug_logs(mln_render_session* session) -> mln_status;
 
 }  // namespace mln::core

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -75,7 +75,6 @@ struct RenderSessionAttachMessages {
 auto register_render_session(
   mln_render_session* handle, std::unique_ptr<mln_render_session> session
 ) -> void;
-auto unregister_render_session(mln_render_session* session) -> void;
 auto validate_render_session(mln_render_session* session) -> mln_status;
 auto validate_live_attached_render_session(mln_render_session* session)
   -> mln_status;

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -25,6 +25,25 @@ using SurfaceSessionResizeCallback =
 using TextureSessionPrepareCallback = void (*)(mln_render_session*);
 using TextureSessionAfterRenderCallback = mln_status (*)(mln_render_session*);
 
+struct RenderSurfaceState {
+  std::unique_ptr<mbgl::gfx::RendererBackend> backend = nullptr;
+  SurfaceSessionResizeCallback resize_backend = nullptr;
+};
+
+struct RenderTextureState {
+  std::unique_ptr<mbgl::gfx::HeadlessBackend> backend = nullptr;
+  uint64_t next_frame_id = 1;
+  uint64_t acquired_frame_id = 0;
+  bool acquired = false;
+  TextureSessionFrameKind acquired_frame_kind = TextureSessionFrameKind::None;
+  TextureSessionApi api_kind = TextureSessionApi::Generic;
+  TextureSessionMode mode = TextureSessionMode::Owned;
+  void* rendered_native_texture = nullptr;
+  void* acquired_native_texture = nullptr;
+  TextureSessionPrepareCallback prepare_render_resources = nullptr;
+  TextureSessionAfterRenderCallback after_render = nullptr;
+};
+
 }  // namespace mln::core
 
 struct mln_render_session {
@@ -41,22 +60,8 @@ struct mln_render_session {
   bool attached = true;
 
   std::unique_ptr<mbgl::Renderer> renderer = nullptr;
-
-  std::unique_ptr<mbgl::gfx::RendererBackend> surface_backend = nullptr;
-  mln::core::SurfaceSessionResizeCallback resize_surface_backend = nullptr;
-
-  std::unique_ptr<mbgl::gfx::HeadlessBackend> texture_backend = nullptr;
-  uint64_t next_frame_id = 1;
-  uint64_t acquired_frame_id = 0;
-  bool acquired = false;
-  mln::core::TextureSessionFrameKind acquired_frame_kind =
-    mln::core::TextureSessionFrameKind::None;
-  mln::core::TextureSessionApi api_kind = mln::core::TextureSessionApi::Generic;
-  mln::core::TextureSessionMode mode = mln::core::TextureSessionMode::Owned;
-  void* rendered_native_texture = nullptr;
-  void* acquired_native_texture = nullptr;
-  mln::core::TextureSessionPrepareCallback prepare_render_resources = nullptr;
-  mln::core::TextureSessionAfterRenderCallback after_render = nullptr;
+  mln::core::RenderSurfaceState surface;
+  mln::core::RenderTextureState texture;
 };
 
 namespace mln::core {
@@ -77,7 +82,7 @@ auto validate_live_attached_render_session(mln_render_session* session)
 auto erase_render_session(mln_render_session* session)
   -> std::unique_ptr<mln_render_session>;
 
-inline auto validate_render_session_attach_output(
+inline auto validate_attach_output(
   mln_render_session** out_session, const char* null_message,
   const char* not_null_message
 ) -> mln_status {
@@ -92,13 +97,12 @@ inline auto validate_render_session_attach_output(
   return MLN_STATUS_OK;
 }
 
-inline auto render_session_physical_dimension(
-  uint32_t logical, double scale_factor
-) -> uint32_t {
+inline auto physical_dimension(uint32_t logical, double scale_factor)
+  -> uint32_t {
   return static_cast<uint32_t>(std::ceil(logical * scale_factor));
 }
 
-inline auto validate_render_session_physical_size(
+inline auto validate_physical_size(
   uint32_t width, uint32_t height, double scale_factor,
   const char* too_large_message
 ) -> mln_status {

--- a/src/render/surface_session.cpp
+++ b/src/render/surface_session.cpp
@@ -1,11 +1,6 @@
-#include <cstdint>
-#include <memory>
-#include <utility>
-
 #include "render/surface_session.hpp"
 
 #include "maplibre_native_c.h"
-#include "render/render_session_common.hpp"
 
 namespace mln::core {
 
@@ -35,48 +30,6 @@ auto vulkan_surface_descriptor_default() noexcept
     .graphics_queue_family_index = 0,
     .surface = nullptr
   };
-}
-
-auto validate_surface_attach_output(mln_render_session** out_surface)
-  -> mln_status {
-  return validate_render_session_attach_output(
-    out_surface, "out_surface must not be null",
-    "out_surface must point to a null handle"
-  );
-}
-
-auto validate_surface(mln_render_session* surface) -> mln_status {
-  return validate_render_session(surface);
-}
-
-auto validate_live_attached_surface(mln_render_session* surface) -> mln_status {
-  return validate_live_attached_render_session(surface);
-}
-
-auto surface_physical_dimension(uint32_t logical, double scale_factor)
-  -> uint32_t {
-  return render_session_physical_dimension(logical, scale_factor);
-}
-
-auto validate_surface_physical_size(
-  uint32_t width, uint32_t height, double scale_factor
-) -> mln_status {
-  return validate_render_session_physical_size(
-    width, height, scale_factor, "scaled surface dimensions are too large"
-  );
-}
-
-auto surface_attach_session(
-  std::unique_ptr<mln_render_session> session, mln_render_session** out_surface
-) -> mln_status {
-  return attach_render_session(
-    std::move(session), out_surface, RenderSessionKind::Surface,
-    RenderSessionAttachMessages{
-      .null_session = "surface session must not be null",
-      .null_output = "out_surface must not be null",
-      .non_null_output = "out_surface must point to a null handle"
-    }
-  );
 }
 
 }  // namespace mln::core

--- a/src/render/surface_session.cpp
+++ b/src/render/surface_session.cpp
@@ -1,32 +1,11 @@
-#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <utility>
 
-#include <mbgl/gfx/backend_scope.hpp>
-#include <mbgl/gfx/renderer_backend.hpp>
-#include <mbgl/map/map.hpp>
-#include <mbgl/renderer/renderer.hpp>
-#include <mbgl/util/size.hpp>
-
 #include "render/surface_session.hpp"
 
-#include "diagnostics/diagnostics.hpp"
-#include "map/map.hpp"
 #include "maplibre_native_c.h"
 #include "render/render_session_common.hpp"
-
-namespace {
-
-using SurfaceRegistry = mln::core::RenderSessionRegistry<mln_surface_session>;
-
-auto surface_registry()
-  -> mln::core::RenderSessionRegistry<mln_surface_session>& {
-  static auto registry = SurfaceRegistry{};
-  return registry;
-}
-
-}  // namespace
 
 namespace mln::core {
 
@@ -58,7 +37,7 @@ auto vulkan_surface_descriptor_default() noexcept
   };
 }
 
-auto validate_surface_attach_output(mln_surface_session** out_surface)
+auto validate_surface_attach_output(mln_render_session** out_surface)
   -> mln_status {
   return validate_render_session_attach_output(
     out_surface, "out_surface must not be null",
@@ -66,19 +45,12 @@ auto validate_surface_attach_output(mln_surface_session** out_surface)
   );
 }
 
-auto validate_surface(mln_surface_session* surface) -> mln_status {
-  return surface_registry().validate(
-    surface, "surface session must not be null",
-    "surface session is not a live handle",
-    "surface session call must be made on its owner thread"
-  );
+auto validate_surface(mln_render_session* surface) -> mln_status {
+  return validate_render_session(surface);
 }
 
-auto validate_live_attached_surface(mln_surface_session* surface)
-  -> mln_status {
-  return validate_live_attached_render_session(
-    surface, validate_surface, "surface session is detached"
-  );
+auto validate_live_attached_surface(mln_render_session* surface) -> mln_status {
+  return validate_live_attached_render_session(surface);
 }
 
 auto surface_physical_dimension(uint32_t logical, double scale_factor)
@@ -95,123 +67,16 @@ auto validate_surface_physical_size(
 }
 
 auto surface_attach_session(
-  std::unique_ptr<mln_surface_session> session,
-  mln_surface_session** out_surface
+  std::unique_ptr<mln_render_session> session, mln_render_session** out_surface
 ) -> mln_status {
   return attach_render_session(
-    std::move(session), out_surface, surface_registry(),
-    RenderSessionKind::Surface,
+    std::move(session), out_surface, RenderSessionKind::Surface,
     RenderSessionAttachMessages{
       .null_session = "surface session must not be null",
       .null_output = "out_surface must not be null",
       .non_null_output = "out_surface must point to a null handle"
     }
   );
-}
-
-auto surface_resize(
-  mln_surface_session* surface, uint32_t width, uint32_t height,
-  double scale_factor
-) -> mln_status {
-  const auto status = validate_live_attached_surface(surface);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (
-    width == 0 || height == 0 || !std::isfinite(scale_factor) ||
-    scale_factor <= 0.0
-  ) {
-    set_thread_error("surface dimensions and scale_factor must be positive");
-    return MLN_STATUS_INVALID_ARGUMENT;
-  }
-  const auto physical_status =
-    validate_surface_physical_size(width, height, scale_factor);
-  if (physical_status != MLN_STATUS_OK) {
-    return physical_status;
-  }
-  const auto physical_width = surface_physical_dimension(width, scale_factor);
-  const auto physical_height = surface_physical_dimension(height, scale_factor);
-
-  if (surface->resize_backend != nullptr) {
-    surface->resize_backend(surface, physical_width, physical_height);
-  }
-  if (auto* map = map_native(surface->map); map != nullptr) {
-    map->setSize(mbgl::Size{width, height});
-  }
-  surface->renderer.reset();
-  surface->rendered_generation = 0;
-  surface->width = width;
-  surface->height = height;
-  surface->physical_width = physical_width;
-  surface->physical_height = physical_height;
-  surface->scale_factor = scale_factor;
-  ++surface->generation;
-  return MLN_STATUS_OK;
-}
-
-auto surface_render_update(mln_surface_session* surface) -> mln_status {
-  const auto status = validate_live_attached_surface(surface);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-
-  auto update = map_latest_update(surface->map);
-  if (!update) {
-    set_thread_error("no map render update is available");
-    return MLN_STATUS_INVALID_STATE;
-  }
-
-  auto& renderer_backend = *surface->backend;
-  auto guard = mbgl::gfx::BackendScope{
-    renderer_backend, mbgl::gfx::BackendScope::ScopeType::Implicit
-  };
-  map_run_render_jobs(surface->map);
-  if (surface->renderer == nullptr) {
-    surface->renderer = std::make_unique<mbgl::Renderer>(
-      renderer_backend, static_cast<float>(surface->scale_factor)
-    );
-    surface->renderer->setObserver(map_renderer_observer(surface->map));
-  }
-
-  surface->renderer->render(update);
-  surface->rendered_generation = surface->generation;
-  return MLN_STATUS_OK;
-}
-
-auto surface_detach(mln_surface_session* surface) -> mln_status {
-  const auto status = validate_live_attached_surface(surface);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-
-  const auto detach_status =
-    map_detach_render_target_session(surface->map, surface);
-  if (detach_status != MLN_STATUS_OK) {
-    return detach_status;
-  }
-  surface->renderer.reset();
-  surface->backend.reset();
-  surface->attached = false;
-  surface->rendered_generation = 0;
-  ++surface->generation;
-  return MLN_STATUS_OK;
-}
-
-auto surface_destroy(mln_surface_session* surface) -> mln_status {
-  const auto status = validate_surface(surface);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (surface->attached) {
-    const auto detach_status = surface_detach(surface);
-    if (detach_status != MLN_STATUS_OK) {
-      return detach_status;
-    }
-  }
-
-  auto owned_surface = surface_registry().erase(surface);
-  owned_surface.reset();
-  return MLN_STATUS_OK;
 }
 
 }  // namespace mln::core

--- a/src/render/surface_session.cpp
+++ b/src/render/surface_session.cpp
@@ -100,6 +100,7 @@ auto surface_attach_session(
 ) -> mln_status {
   return attach_render_session(
     std::move(session), out_surface, surface_registry(),
+    RenderSessionKind::Surface,
     RenderSessionAttachMessages{
       .null_session = "surface session must not be null",
       .null_output = "out_surface must not be null",

--- a/src/render/surface_session.hpp
+++ b/src/render/surface_session.hpp
@@ -2,38 +2,10 @@
 
 #include <cstdint>
 #include <memory>
-#include <thread>
-
-#include <mbgl/gfx/renderer_backend.hpp>
-#include <mbgl/renderer/renderer.hpp>
 
 #include "maplibre_native_c.h"
-#include "render/render_session_common.hpp"
 
-struct mln_surface_session;
-
-namespace mln::core {
-
-using SurfaceSessionResizeCallback =
-  void (*)(mln_surface_session*, uint32_t, uint32_t);
-
-}  // namespace mln::core
-
-struct mln_surface_session : mln_render_session {
-  mln_map* map = nullptr;
-  std::thread::id owner_thread;
-  uint32_t width = 0;
-  uint32_t height = 0;
-  uint32_t physical_width = 0;
-  uint32_t physical_height = 0;
-  double scale_factor = 1.0;
-  uint64_t generation = 1;
-  uint64_t rendered_generation = 0;
-  bool attached = true;
-  std::unique_ptr<mbgl::gfx::RendererBackend> backend = nullptr;
-  std::unique_ptr<mbgl::Renderer> renderer = nullptr;
-  mln::core::SurfaceSessionResizeCallback resize_backend = nullptr;
-};
+struct mln_render_session;
 
 namespace mln::core {
 
@@ -41,33 +13,25 @@ auto metal_surface_descriptor_default() noexcept
   -> mln_metal_surface_descriptor;
 auto vulkan_surface_descriptor_default() noexcept
   -> mln_vulkan_surface_descriptor;
-auto validate_surface_attach_output(mln_surface_session** out_surface)
+auto validate_surface_attach_output(mln_render_session** out_surface)
   -> mln_status;
-auto validate_surface(mln_surface_session* surface) -> mln_status;
-auto validate_live_attached_surface(mln_surface_session* surface) -> mln_status;
+auto validate_surface(mln_render_session* surface) -> mln_status;
+auto validate_live_attached_surface(mln_render_session* surface) -> mln_status;
 auto surface_physical_dimension(uint32_t logical, double scale_factor)
   -> uint32_t;
 auto validate_surface_physical_size(
   uint32_t width, uint32_t height, double scale_factor
 ) -> mln_status;
 auto surface_attach_session(
-  std::unique_ptr<mln_surface_session> session,
-  mln_surface_session** out_surface
+  std::unique_ptr<mln_render_session> session, mln_render_session** out_surface
 ) -> mln_status;
 auto metal_surface_attach(
   mln_map* map, const mln_metal_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_surface
 ) -> mln_status;
 auto vulkan_surface_attach(
   mln_map* map, const mln_vulkan_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_surface
 ) -> mln_status;
-auto surface_resize(
-  mln_surface_session* surface, uint32_t width, uint32_t height,
-  double scale_factor
-) -> mln_status;
-auto surface_render_update(mln_surface_session* surface) -> mln_status;
-auto surface_detach(mln_surface_session* surface) -> mln_status;
-auto surface_destroy(mln_surface_session* surface) -> mln_status;
 
 }  // namespace mln::core

--- a/src/render/surface_session.hpp
+++ b/src/render/surface_session.hpp
@@ -8,6 +8,7 @@
 #include <mbgl/renderer/renderer.hpp>
 
 #include "maplibre_native_c.h"
+#include "render/render_session_common.hpp"
 
 struct mln_surface_session;
 
@@ -18,7 +19,7 @@ using SurfaceSessionResizeCallback =
 
 }  // namespace mln::core
 
-struct mln_surface_session {
+struct mln_surface_session : mln_render_session {
   mln_map* map = nullptr;
   std::thread::id owner_thread;
   uint32_t width = 0;

--- a/src/render/surface_session.hpp
+++ b/src/render/surface_session.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <cstdint>
-#include <memory>
-
 #include "maplibre_native_c.h"
 
 struct mln_render_session;
@@ -13,25 +10,13 @@ auto metal_surface_descriptor_default() noexcept
   -> mln_metal_surface_descriptor;
 auto vulkan_surface_descriptor_default() noexcept
   -> mln_vulkan_surface_descriptor;
-auto validate_surface_attach_output(mln_render_session** out_surface)
-  -> mln_status;
-auto validate_surface(mln_render_session* surface) -> mln_status;
-auto validate_live_attached_surface(mln_render_session* surface) -> mln_status;
-auto surface_physical_dimension(uint32_t logical, double scale_factor)
-  -> uint32_t;
-auto validate_surface_physical_size(
-  uint32_t width, uint32_t height, double scale_factor
-) -> mln_status;
-auto surface_attach_session(
-  std::unique_ptr<mln_render_session> session, mln_render_session** out_surface
-) -> mln_status;
 auto metal_surface_attach(
   mln_map* map, const mln_metal_surface_descriptor* descriptor,
-  mln_render_session** out_surface
+  mln_render_session** out_session
 ) -> mln_status;
 auto vulkan_surface_attach(
   mln_map* map, const mln_vulkan_surface_descriptor* descriptor,
-  mln_render_session** out_surface
+  mln_render_session** out_session
 ) -> mln_status;
 
 }  // namespace mln::core

--- a/src/render/texture_session.cpp
+++ b/src/render/texture_session.cpp
@@ -9,8 +9,6 @@
 #include <mbgl/gfx/headless_backend.hpp>
 #include <mbgl/gfx/renderable.hpp>
 #include <mbgl/gfx/renderer_backend.hpp>
-#include <mbgl/map/map.hpp>
-#include <mbgl/renderer/renderer.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/size.hpp>
 
@@ -22,14 +20,6 @@
 #include "render/render_session_common.hpp"
 
 namespace {
-
-using TextureRegistry = mln::core::RenderSessionRegistry<mln_texture_session>;
-
-auto texture_registry()
-  -> mln::core::RenderSessionRegistry<mln_texture_session>& {
-  static auto registry = TextureRegistry{};
-  return registry;
-}
 
 auto validate_owned_descriptor(const mln_owned_texture_descriptor* descriptor)
   -> mln_status {
@@ -79,26 +69,19 @@ auto texture_image_info_default() noexcept -> mln_texture_image_info {
   };
 }
 
-auto validate_attach_output(mln_texture_session** out_texture) -> mln_status {
+auto validate_attach_output(mln_render_session** out_texture) -> mln_status {
   return validate_render_session_attach_output(
     out_texture, "out_texture must not be null",
     "out_texture must point to a null handle"
   );
 }
 
-auto validate_texture(mln_texture_session* texture) -> mln_status {
-  return texture_registry().validate(
-    texture, "texture session must not be null",
-    "texture session is not a live handle",
-    "texture session call must be made on its owner thread"
-  );
+auto validate_texture(mln_render_session* texture) -> mln_status {
+  return validate_render_session(texture);
 }
 
-auto validate_live_attached_texture(mln_texture_session* texture)
-  -> mln_status {
-  return validate_live_attached_render_session(
-    texture, validate_texture, "texture session is detached"
-  );
+auto validate_live_attached_texture(mln_render_session* texture) -> mln_status {
+  return validate_live_attached_render_session(texture);
 }
 
 auto physical_dimension(uint32_t logical, double scale_factor) -> uint32_t {
@@ -114,12 +97,10 @@ auto validate_physical_size(
 }
 
 auto texture_attach_session(
-  std::unique_ptr<mln_texture_session> session,
-  mln_texture_session** out_texture
+  std::unique_ptr<mln_render_session> session, mln_render_session** out_texture
 ) -> mln_status {
   return attach_render_session(
-    std::move(session), out_texture, texture_registry(),
-    RenderSessionKind::Texture,
+    std::move(session), out_texture, RenderSessionKind::Texture,
     RenderSessionAttachMessages{
       .null_session = "texture session must not be null",
       .null_output = "out_texture must not be null",
@@ -130,7 +111,7 @@ auto texture_attach_session(
 
 auto owned_texture_attach(
   mln_map* map, const mln_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -151,7 +132,7 @@ auto owned_texture_attach(
     return physical_status;
   }
 
-  auto session = std::make_unique<mln_texture_session>();
+  auto session = std::make_unique<mln_render_session>();
   session->map = map;
   session->owner_thread = map_owner_thread(map);
   session->width = descriptor->width;
@@ -163,112 +144,15 @@ auto owned_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->api_kind = TextureSessionApi::Generic;
   session->mode = TextureSessionMode::Owned;
-  session->backend = mbgl::gfx::HeadlessBackend::Create(
+  session->texture_backend = mbgl::gfx::HeadlessBackend::Create(
     mbgl::Size{session->physical_width, session->physical_height},
     mbgl::gfx::Renderable::SwapBehaviour::Flush, mbgl::gfx::ContextMode::Unique
   );
   return texture_attach_session(std::move(session), out_texture);
 }
 
-auto texture_resize(
-  mln_texture_session* texture, uint32_t width, uint32_t height,
-  double scale_factor
-) -> mln_status {
-  const auto status = validate_live_attached_texture(texture);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (
-    width == 0 || height == 0 || !std::isfinite(scale_factor) ||
-    scale_factor <= 0.0
-  ) {
-    set_thread_error("texture dimensions and scale_factor must be positive");
-    return MLN_STATUS_INVALID_ARGUMENT;
-  }
-  if (texture->acquired) {
-    set_thread_error("cannot resize while a texture frame is acquired");
-    return MLN_STATUS_INVALID_STATE;
-  }
-  if (texture->mode == TextureSessionMode::Borrowed) {
-    set_thread_error(
-      "borrowed texture sessions cannot be resized; attach a new target"
-    );
-    return MLN_STATUS_UNSUPPORTED;
-  }
-  const auto physical_status =
-    validate_physical_size(width, height, scale_factor);
-  if (physical_status != MLN_STATUS_OK) {
-    return physical_status;
-  }
-  const auto physical_width = physical_dimension(width, scale_factor);
-  const auto physical_height = physical_dimension(height, scale_factor);
-
-  texture->backend->setSize(mbgl::Size{physical_width, physical_height});
-  if (auto* map = map_native(texture->map); map != nullptr) {
-    map->setSize(mbgl::Size{width, height});
-  }
-  texture->renderer.reset();
-  texture->rendered_native_texture = nullptr;
-  texture->acquired_native_texture = nullptr;
-  texture->rendered_generation = 0;
-  texture->acquired_frame_kind = TextureSessionFrameKind::None;
-  texture->width = width;
-  texture->height = height;
-  texture->physical_width = physical_width;
-  texture->physical_height = physical_height;
-  texture->scale_factor = scale_factor;
-  ++texture->generation;
-  return MLN_STATUS_OK;
-}
-
-auto texture_render_update(mln_texture_session* texture) -> mln_status {
-  const auto status = validate_live_attached_texture(texture);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (texture->acquired) {
-    set_thread_error("cannot render while a texture frame is acquired");
-    return MLN_STATUS_INVALID_STATE;
-  }
-
-  auto update = map_latest_update(texture->map);
-  if (!update) {
-    set_thread_error("no map render update is available");
-    return MLN_STATUS_INVALID_STATE;
-  }
-
-  if (texture->prepare_render_resources != nullptr) {
-    texture->prepare_render_resources(texture);
-  }
-  auto* renderer_backend = texture->backend->getRendererBackend();
-  if (renderer_backend == nullptr) {
-    set_thread_error("texture session renderer backend is not available");
-    return MLN_STATUS_INVALID_STATE;
-  }
-  auto guard = mbgl::gfx::BackendScope{
-    *renderer_backend, mbgl::gfx::BackendScope::ScopeType::Implicit
-  };
-  map_run_render_jobs(texture->map);
-  if (texture->renderer == nullptr) {
-    texture->renderer = std::make_unique<mbgl::Renderer>(
-      *renderer_backend, static_cast<float>(texture->scale_factor)
-    );
-    texture->renderer->setObserver(map_renderer_observer(texture->map));
-  }
-
-  texture->renderer->render(update);
-  if (texture->after_render != nullptr) {
-    const auto after_status = texture->after_render(texture);
-    if (after_status != MLN_STATUS_OK) {
-      return after_status;
-    }
-  }
-  texture->rendered_generation = texture->generation;
-  return MLN_STATUS_OK;
-}
-
 auto texture_read_premultiplied_rgba8(
-  mln_texture_session* texture, uint8_t* out_data, size_t out_data_capacity,
+  mln_render_session* texture, uint8_t* out_data, size_t out_data_capacity,
   mln_texture_image_info* out_info
 ) -> mln_status {
   const auto status = validate_live_attached_texture(texture);
@@ -320,7 +204,7 @@ auto texture_read_premultiplied_rgba8(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  auto* renderer_backend = texture->backend->getRendererBackend();
+  auto* renderer_backend = texture->texture_backend->getRendererBackend();
   if (renderer_backend == nullptr) {
     set_thread_error("texture session renderer backend is not available");
     return MLN_STATUS_INVALID_STATE;
@@ -328,7 +212,7 @@ auto texture_read_premultiplied_rgba8(
   auto guard = mbgl::gfx::BackendScope{
     *renderer_backend, mbgl::gfx::BackendScope::ScopeType::Implicit
   };
-  auto image = texture->backend->readStillImage();
+  auto image = texture->texture_backend->readStillImage();
   if (!image.valid()) {
     set_thread_error("texture readback did not produce an image");
     return MLN_STATUS_INVALID_STATE;
@@ -343,53 +227,6 @@ auto texture_read_premultiplied_rgba8(
   }
 
   std::memcpy(out_data, image.data.get(), image.bytes());
-  return MLN_STATUS_OK;
-}
-
-auto texture_detach(mln_texture_session* texture) -> mln_status {
-  const auto status = validate_live_attached_texture(texture);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (texture->acquired) {
-    set_thread_error("cannot detach while a texture frame is acquired");
-    return MLN_STATUS_INVALID_STATE;
-  }
-
-  const auto detach_status =
-    map_detach_render_target_session(texture->map, texture);
-  if (detach_status != MLN_STATUS_OK) {
-    return detach_status;
-  }
-  texture->renderer.reset();
-  texture->rendered_native_texture = nullptr;
-  texture->acquired_native_texture = nullptr;
-  texture->backend.reset();
-  texture->attached = false;
-  texture->rendered_generation = 0;
-  texture->acquired_frame_kind = TextureSessionFrameKind::None;
-  ++texture->generation;
-  return MLN_STATUS_OK;
-}
-
-auto texture_destroy(mln_texture_session* texture) -> mln_status {
-  const auto status = validate_texture(texture);
-  if (status != MLN_STATUS_OK) {
-    return status;
-  }
-  if (texture->acquired) {
-    set_thread_error("cannot destroy while a texture frame is acquired");
-    return MLN_STATUS_INVALID_STATE;
-  }
-  if (texture->attached) {
-    const auto detach_status = texture_detach(texture);
-    if (detach_status != MLN_STATUS_OK) {
-      return detach_status;
-    }
-  }
-
-  auto owned_texture = texture_registry().erase(texture);
-  owned_texture.reset();
   return MLN_STATUS_OK;
 }
 

--- a/src/render/texture_session.cpp
+++ b/src/render/texture_session.cpp
@@ -69,49 +69,33 @@ auto texture_image_info_default() noexcept -> mln_texture_image_info {
   };
 }
 
-auto validate_attach_output(mln_render_session** out_texture) -> mln_status {
-  return validate_render_session_attach_output(
-    out_texture, "out_texture must not be null",
-    "out_texture must point to a null handle"
-  );
-}
-
 auto validate_texture(mln_render_session* texture) -> mln_status {
-  return validate_render_session(texture);
+  const auto status = validate_render_session(texture);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (texture->kind != RenderSessionKind::Texture) {
+    set_thread_error("render session is not a texture session");
+    return MLN_STATUS_UNSUPPORTED;
+  }
+  return MLN_STATUS_OK;
 }
 
 auto validate_live_attached_texture(mln_render_session* texture) -> mln_status {
-  return validate_live_attached_render_session(texture);
-}
-
-auto physical_dimension(uint32_t logical, double scale_factor) -> uint32_t {
-  return render_session_physical_dimension(logical, scale_factor);
-}
-
-auto validate_physical_size(
-  uint32_t width, uint32_t height, double scale_factor
-) -> mln_status {
-  return validate_render_session_physical_size(
-    width, height, scale_factor, "scaled texture dimensions are too large"
-  );
-}
-
-auto texture_attach_session(
-  std::unique_ptr<mln_render_session> session, mln_render_session** out_texture
-) -> mln_status {
-  return attach_render_session(
-    std::move(session), out_texture, RenderSessionKind::Texture,
-    RenderSessionAttachMessages{
-      .null_session = "texture session must not be null",
-      .null_output = "out_texture must not be null",
-      .non_null_output = "out_texture must point to a null handle"
-    }
-  );
+  const auto status = validate_texture(texture);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!texture->attached || texture->texture.backend == nullptr) {
+    set_thread_error("render session is detached");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  return MLN_STATUS_OK;
 }
 
 auto owned_texture_attach(
   mln_map* map, const mln_owned_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -121,12 +105,16 @@ auto owned_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
   const auto physical_status = validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -142,13 +130,20 @@ auto owned_texture_attach(
     physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->api_kind = TextureSessionApi::Generic;
-  session->mode = TextureSessionMode::Owned;
-  session->texture_backend = mbgl::gfx::HeadlessBackend::Create(
+  session->texture.api_kind = TextureSessionApi::Generic;
+  session->texture.mode = TextureSessionMode::Owned;
+  session->texture.backend = mbgl::gfx::HeadlessBackend::Create(
     mbgl::Size{session->physical_width, session->physical_height},
     mbgl::gfx::Renderable::SwapBehaviour::Flush, mbgl::gfx::ContextMode::Unique
   );
-  return texture_attach_session(std::move(session), out_texture);
+  return attach_render_session(
+    std::move(session), out_session, RenderSessionKind::Texture,
+    RenderSessionAttachMessages{
+      .null_session = "texture session must not be null",
+      .null_output = "out_session must not be null",
+      .non_null_output = "out_session must point to a null handle"
+    }
+  );
 }
 
 auto texture_read_premultiplied_rgba8(
@@ -163,11 +158,11 @@ auto texture_read_premultiplied_rgba8(
     set_thread_error("out_info must not be null and must have a valid size");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  if (texture->acquired) {
+  if (texture->texture.acquired) {
     set_thread_error("cannot read while a texture frame is acquired");
     return MLN_STATUS_INVALID_STATE;
   }
-  if (texture->mode != TextureSessionMode::Owned) {
+  if (texture->texture.mode != TextureSessionMode::Owned) {
     set_thread_error("texture session does not support CPU readback");
     return MLN_STATUS_UNSUPPORTED;
   }
@@ -204,7 +199,7 @@ auto texture_read_premultiplied_rgba8(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  auto* renderer_backend = texture->texture_backend->getRendererBackend();
+  auto* renderer_backend = texture->texture.backend->getRendererBackend();
   if (renderer_backend == nullptr) {
     set_thread_error("texture session renderer backend is not available");
     return MLN_STATUS_INVALID_STATE;
@@ -212,7 +207,7 @@ auto texture_read_premultiplied_rgba8(
   auto guard = mbgl::gfx::BackendScope{
     *renderer_backend, mbgl::gfx::BackendScope::ScopeType::Implicit
   };
-  auto image = texture->texture_backend->readStillImage();
+  auto image = texture->texture.backend->readStillImage();
   if (!image.valid()) {
     set_thread_error("texture readback did not produce an image");
     return MLN_STATUS_INVALID_STATE;

--- a/src/render/texture_session.cpp
+++ b/src/render/texture_session.cpp
@@ -119,6 +119,7 @@ auto texture_attach_session(
 ) -> mln_status {
   return attach_render_session(
     std::move(session), out_texture, texture_registry(),
+    RenderSessionKind::Texture,
     RenderSessionAttachMessages{
       .null_session = "texture session must not be null",
       .null_output = "out_texture must not be null",

--- a/src/render/texture_session.hpp
+++ b/src/render/texture_session.hpp
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 
 #include "maplibre_native_c.h"
 
@@ -21,35 +20,27 @@ auto vulkan_owned_texture_descriptor_default() noexcept
 auto vulkan_borrowed_texture_descriptor_default() noexcept
   -> mln_vulkan_borrowed_texture_descriptor;
 auto texture_image_info_default() noexcept -> mln_texture_image_info;
-auto validate_attach_output(mln_render_session** out_texture) -> mln_status;
 auto validate_texture(mln_render_session* texture) -> mln_status;
 auto validate_live_attached_texture(mln_render_session* texture) -> mln_status;
-auto physical_dimension(uint32_t logical, double scale_factor) -> uint32_t;
-auto validate_physical_size(
-  uint32_t width, uint32_t height, double scale_factor
-) -> mln_status;
-auto texture_attach_session(
-  std::unique_ptr<mln_render_session> session, mln_render_session** out_texture
-) -> mln_status;
 auto owned_texture_attach(
   mln_map* map, const mln_owned_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status;
 auto metal_owned_texture_attach(
   mln_map* map, const mln_metal_owned_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status;
 auto metal_borrowed_texture_attach(
   mln_map* map, const mln_metal_borrowed_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status;
 auto vulkan_owned_texture_attach(
   mln_map* map, const mln_vulkan_owned_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status;
 auto vulkan_borrowed_texture_attach(
   mln_map* map, const mln_vulkan_borrowed_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status;
 auto texture_read_premultiplied_rgba8(
   mln_render_session* texture, uint8_t* out_data, size_t out_data_capacity,

--- a/src/render/texture_session.hpp
+++ b/src/render/texture_session.hpp
@@ -3,52 +3,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <thread>
-
-#include <mbgl/gfx/headless_backend.hpp>
-#include <mbgl/renderer/renderer.hpp>
 
 #include "maplibre_native_c.h"
-#include "render/render_session_common.hpp"
 
-struct mln_texture_session;
-
-namespace mln::core {
-
-enum class TextureSessionApi : uint8_t { Generic, Metal, Vulkan };
-enum class TextureSessionFrameKind : uint8_t { None, MetalOwned, VulkanOwned };
-enum class TextureSessionMode : uint8_t { Owned, Borrowed };
-
-using TextureSessionPrepareCallback = void (*)(mln_texture_session*);
-using TextureSessionAfterRenderCallback = mln_status (*)(mln_texture_session*);
-
-}  // namespace mln::core
-
-struct mln_texture_session : mln_render_session {
-  mln_map* map = nullptr;
-  std::thread::id owner_thread;
-  uint32_t width = 0;
-  uint32_t height = 0;
-  uint32_t physical_width = 0;
-  uint32_t physical_height = 0;
-  double scale_factor = 1.0;
-  uint64_t generation = 1;
-  uint64_t next_frame_id = 1;
-  uint64_t acquired_frame_id = 0;
-  uint64_t rendered_generation = 0;
-  bool attached = true;
-  bool acquired = false;
-  mln::core::TextureSessionFrameKind acquired_frame_kind =
-    mln::core::TextureSessionFrameKind::None;
-  mln::core::TextureSessionApi api_kind = mln::core::TextureSessionApi::Generic;
-  mln::core::TextureSessionMode mode = mln::core::TextureSessionMode::Owned;
-  std::unique_ptr<mbgl::gfx::HeadlessBackend> backend = nullptr;
-  std::unique_ptr<mbgl::Renderer> renderer = nullptr;
-  void* rendered_native_texture = nullptr;
-  void* acquired_native_texture = nullptr;
-  mln::core::TextureSessionPrepareCallback prepare_render_resources = nullptr;
-  mln::core::TextureSessionAfterRenderCallback after_render = nullptr;
-};
+struct mln_render_session;
 
 namespace mln::core {
 
@@ -63,59 +21,51 @@ auto vulkan_owned_texture_descriptor_default() noexcept
 auto vulkan_borrowed_texture_descriptor_default() noexcept
   -> mln_vulkan_borrowed_texture_descriptor;
 auto texture_image_info_default() noexcept -> mln_texture_image_info;
-auto validate_attach_output(mln_texture_session** out_texture) -> mln_status;
-auto validate_texture(mln_texture_session* texture) -> mln_status;
-auto validate_live_attached_texture(mln_texture_session* texture) -> mln_status;
+auto validate_attach_output(mln_render_session** out_texture) -> mln_status;
+auto validate_texture(mln_render_session* texture) -> mln_status;
+auto validate_live_attached_texture(mln_render_session* texture) -> mln_status;
 auto physical_dimension(uint32_t logical, double scale_factor) -> uint32_t;
 auto validate_physical_size(
   uint32_t width, uint32_t height, double scale_factor
 ) -> mln_status;
 auto texture_attach_session(
-  std::unique_ptr<mln_texture_session> session,
-  mln_texture_session** out_texture
+  std::unique_ptr<mln_render_session> session, mln_render_session** out_texture
 ) -> mln_status;
 auto owned_texture_attach(
   mln_map* map, const mln_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status;
 auto metal_owned_texture_attach(
   mln_map* map, const mln_metal_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status;
 auto metal_borrowed_texture_attach(
   mln_map* map, const mln_metal_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status;
 auto vulkan_owned_texture_attach(
   mln_map* map, const mln_vulkan_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status;
 auto vulkan_borrowed_texture_attach(
   mln_map* map, const mln_vulkan_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status;
-auto texture_resize(
-  mln_texture_session* texture, uint32_t width, uint32_t height,
-  double scale_factor
-) -> mln_status;
-auto texture_render_update(mln_texture_session* texture) -> mln_status;
 auto texture_read_premultiplied_rgba8(
-  mln_texture_session* texture, uint8_t* out_data, size_t out_data_capacity,
+  mln_render_session* texture, uint8_t* out_data, size_t out_data_capacity,
   mln_texture_image_info* out_info
 ) -> mln_status;
 auto metal_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_metal_owned_texture_frame* out_frame
+  mln_render_session* texture, mln_metal_owned_texture_frame* out_frame
 ) -> mln_status;
 auto metal_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_metal_owned_texture_frame* frame
+  mln_render_session* texture, const mln_metal_owned_texture_frame* frame
 ) -> mln_status;
 auto vulkan_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_vulkan_owned_texture_frame* out_frame
+  mln_render_session* texture, mln_vulkan_owned_texture_frame* out_frame
 ) -> mln_status;
 auto vulkan_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_vulkan_owned_texture_frame* frame
+  mln_render_session* texture, const mln_vulkan_owned_texture_frame* frame
 ) -> mln_status;
-auto texture_detach(mln_texture_session* texture) -> mln_status;
-auto texture_destroy(mln_texture_session* texture) -> mln_status;
 
 }  // namespace mln::core

--- a/src/render/texture_session.hpp
+++ b/src/render/texture_session.hpp
@@ -9,6 +9,7 @@
 #include <mbgl/renderer/renderer.hpp>
 
 #include "maplibre_native_c.h"
+#include "render/render_session_common.hpp"
 
 struct mln_texture_session;
 
@@ -23,7 +24,7 @@ using TextureSessionAfterRenderCallback = mln_status (*)(mln_texture_session*);
 
 }  // namespace mln::core
 
-struct mln_texture_session {
+struct mln_texture_session : mln_render_session {
   mln_map* map = nullptr;
   std::thread::id owner_thread;
   uint32_t width = 0;

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -13,6 +13,7 @@
 
 #include "diagnostics/diagnostics.hpp"
 #include "map/map.hpp"
+#include "render/render_session_common.hpp"
 #include "render/surface_session.hpp"
 
 namespace {
@@ -379,10 +380,9 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
 };
 
 void resize_vulkan_surface(
-  mln_surface_session* surface, uint32_t physical_width,
-  uint32_t physical_height
+  mln_render_session* surface, uint32_t physical_width, uint32_t physical_height
 ) {
-  static_cast<VulkanSurfaceBackend&>(*surface->backend)
+  static_cast<VulkanSurfaceBackend&>(*surface->surface_backend)
     .setSize(mbgl::Size{physical_width, physical_height});
 }
 
@@ -392,7 +392,7 @@ namespace mln::core {
 
 auto metal_surface_attach(
   mln_map* map, const mln_metal_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_surface
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -418,7 +418,7 @@ auto metal_surface_attach(
 
 auto vulkan_surface_attach(
   mln_map* map, const mln_vulkan_surface_descriptor* descriptor,
-  mln_surface_session** out_surface
+  mln_render_session** out_surface
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -443,7 +443,7 @@ auto vulkan_surface_attach(
     return vulkan_status;
   }
 
-  auto session = std::make_unique<mln_surface_session>();
+  auto session = std::make_unique<mln_render_session>();
   session->map = map;
   session->owner_thread = map_owner_thread(map);
   session->width = descriptor->width;
@@ -453,10 +453,10 @@ auto vulkan_surface_attach(
     surface_physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     surface_physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->backend = std::make_unique<VulkanSurfaceBackend>(
+  session->surface_backend = std::make_unique<VulkanSurfaceBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->resize_backend = resize_vulkan_surface;
+  session->resize_surface_backend = resize_vulkan_surface;
   return surface_attach_session(std::move(session), out_surface);
 }
 

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -382,7 +382,7 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
 void resize_vulkan_surface(
   mln_render_session* surface, uint32_t physical_width, uint32_t physical_height
 ) {
-  static_cast<VulkanSurfaceBackend&>(*surface->surface_backend)
+  static_cast<VulkanSurfaceBackend&>(*surface->surface.backend)
     .setSize(mbgl::Size{physical_width, physical_height});
 }
 
@@ -392,7 +392,7 @@ namespace mln::core {
 
 auto metal_surface_attach(
   mln_map* map, const mln_metal_surface_descriptor* descriptor,
-  mln_render_session** out_surface
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -402,12 +402,16 @@ auto metal_surface_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_surface_attach_output(out_surface);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
-  const auto physical_status = validate_surface_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+  const auto physical_status = validate_physical_size(
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled surface dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -418,7 +422,7 @@ auto metal_surface_attach(
 
 auto vulkan_surface_attach(
   mln_map* map, const mln_vulkan_surface_descriptor* descriptor,
-  mln_render_session** out_surface
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -428,12 +432,16 @@ auto vulkan_surface_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_surface_attach_output(out_surface);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
-  const auto physical_status = validate_surface_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+  const auto physical_status = validate_physical_size(
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled surface dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -450,14 +458,21 @@ auto vulkan_surface_attach(
   session->height = descriptor->height;
   session->scale_factor = descriptor->scale_factor;
   session->physical_width =
-    surface_physical_dimension(descriptor->width, descriptor->scale_factor);
+    physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
-    surface_physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->surface_backend = std::make_unique<VulkanSurfaceBackend>(
+    physical_dimension(descriptor->height, descriptor->scale_factor);
+  session->surface.backend = std::make_unique<VulkanSurfaceBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->resize_surface_backend = resize_vulkan_surface;
-  return surface_attach_session(std::move(session), out_surface);
+  session->surface.resize_backend = resize_vulkan_surface;
+  return attach_render_session(
+    std::move(session), out_session, RenderSessionKind::Surface,
+    RenderSessionAttachMessages{
+      .null_session = "surface session must not be null",
+      .null_output = "out_session must not be null",
+      .non_null_output = "out_session must point to a null handle"
+    }
+  );
 }
 
 }  // namespace mln::core

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -218,7 +218,7 @@ void prepare_vulkan_render_resources(mln_render_session* texture) {
   // Renderer::render creates the Vulkan context before requesting the default
   // renderable, so shared-device resources must be ready first.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-  static_cast<mln::core::VulkanTextureBackend&>(*texture->texture_backend)
+  static_cast<mln::core::VulkanTextureBackend&>(*texture->texture.backend)
     .prepareRenderResources();
 }
 
@@ -263,7 +263,7 @@ auto vulkan_borrowed_texture_descriptor_default() noexcept
 
 auto vulkan_owned_texture_attach(
   mln_map* map, const mln_vulkan_owned_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -273,12 +273,16 @@ auto vulkan_owned_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
   const auto physical_status = validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -298,18 +302,25 @@ auto vulkan_owned_texture_attach(
     physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->api_kind = TextureSessionApi::Vulkan;
-  session->mode = TextureSessionMode::Owned;
-  session->texture_backend = std::make_unique<VulkanTextureBackend>(
+  session->texture.api_kind = TextureSessionApi::Vulkan;
+  session->texture.mode = TextureSessionMode::Owned;
+  session->texture.backend = std::make_unique<VulkanTextureBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->prepare_render_resources = prepare_vulkan_render_resources;
-  return texture_attach_session(std::move(session), out_texture);
+  session->texture.prepare_render_resources = prepare_vulkan_render_resources;
+  return attach_render_session(
+    std::move(session), out_session, RenderSessionKind::Texture,
+    RenderSessionAttachMessages{
+      .null_session = "texture session must not be null",
+      .null_output = "out_session must not be null",
+      .non_null_output = "out_session must point to a null handle"
+    }
+  );
 }
 
 auto vulkan_borrowed_texture_attach(
   mln_map* map, const mln_vulkan_borrowed_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -319,12 +330,16 @@ auto vulkan_borrowed_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
   const auto physical_status = validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -355,13 +370,20 @@ auto vulkan_borrowed_texture_attach(
     physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->api_kind = TextureSessionApi::Vulkan;
-  session->mode = TextureSessionMode::Borrowed;
-  session->texture_backend = std::make_unique<VulkanTextureBackend>(
+  session->texture.api_kind = TextureSessionApi::Vulkan;
+  session->texture.mode = TextureSessionMode::Borrowed;
+  session->texture.backend = std::make_unique<VulkanTextureBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->prepare_render_resources = prepare_vulkan_render_resources;
-  return texture_attach_session(std::move(session), out_texture);
+  session->texture.prepare_render_resources = prepare_vulkan_render_resources;
+  return attach_render_session(
+    std::move(session), out_session, RenderSessionKind::Texture,
+    RenderSessionAttachMessages{
+      .null_session = "texture session must not be null",
+      .null_output = "out_session must not be null",
+      .non_null_output = "out_session must point to a null handle"
+    }
+  );
 }
 
 auto vulkan_owned_texture_acquire_frame(
@@ -378,7 +400,7 @@ auto vulkan_owned_texture_acquire_frame(
     set_thread_error("out_frame must not be null and must have a valid size");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  if (texture->acquired) {
+  if (texture->texture.acquired) {
     set_thread_error("a texture frame is already acquired");
     return MLN_STATUS_INVALID_STATE;
   }
@@ -387,8 +409,8 @@ auto vulkan_owned_texture_acquire_frame(
     return MLN_STATUS_INVALID_STATE;
   }
   if (
-    texture->mode != TextureSessionMode::Owned ||
-    texture->api_kind != TextureSessionApi::Vulkan
+    texture->texture.mode != TextureSessionMode::Owned ||
+    texture->texture.api_kind != TextureSessionApi::Vulkan
   ) {
     set_thread_error("texture session cannot expose a Vulkan texture frame");
     return MLN_STATUS_UNSUPPORTED;
@@ -397,7 +419,7 @@ auto vulkan_owned_texture_acquire_frame(
   // The Vulkan acquire path is only valid for owned Vulkan sessions, and this
   // Linux build only creates Vulkan sessions.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-  auto& backend = static_cast<VulkanTextureBackend&>(*texture->texture_backend);
+  auto& backend = static_cast<VulkanTextureBackend&>(*texture->texture.backend);
   const auto resources = backend.frame_resources();
   *out_frame = mln_vulkan_owned_texture_frame{
     .size = sizeof(mln_vulkan_owned_texture_frame),
@@ -405,17 +427,17 @@ auto vulkan_owned_texture_acquire_frame(
     .width = texture->physical_width,
     .height = texture->physical_height,
     .scale_factor = texture->scale_factor,
-    .frame_id = texture->next_frame_id,
+    .frame_id = texture->texture.next_frame_id,
     .image = resources.image,
     .image_view = resources.image_view,
     .device = resources.device,
     .format = static_cast<uint32_t>(resources.format),
     .layout = static_cast<uint32_t>(vk::ImageLayout::eShaderReadOnlyOptimal),
   };
-  texture->acquired = true;
-  texture->acquired_frame_id = out_frame->frame_id;
-  texture->acquired_frame_kind = TextureSessionFrameKind::VulkanOwned;
-  ++texture->next_frame_id;
+  texture->texture.acquired = true;
+  texture->texture.acquired_frame_id = out_frame->frame_id;
+  texture->texture.acquired_frame_kind = TextureSessionFrameKind::VulkanOwned;
+  ++texture->texture.next_frame_id;
   return MLN_STATUS_OK;
 }
 
@@ -433,8 +455,8 @@ auto vulkan_owned_texture_release_frame(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
   if (
-    !texture->acquired ||
-    texture->acquired_frame_kind != TextureSessionFrameKind::VulkanOwned
+    !texture->texture.acquired ||
+    texture->texture.acquired_frame_kind != TextureSessionFrameKind::VulkanOwned
   ) {
     set_thread_error("no texture frame is currently acquired");
     return MLN_STATUS_INVALID_STATE;
@@ -443,13 +465,13 @@ auto vulkan_owned_texture_release_frame(
     set_thread_error("frame generation does not match acquired frame");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  if (frame->frame_id != texture->acquired_frame_id) {
+  if (frame->frame_id != texture->texture.acquired_frame_id) {
     set_thread_error("frame identity does not match acquired frame");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  texture->acquired = false;
-  texture->acquired_frame_id = 0;
-  texture->acquired_frame_kind = TextureSessionFrameKind::None;
+  texture->texture.acquired = false;
+  texture->texture.acquired_frame_id = 0;
+  texture->texture.acquired_frame_kind = TextureSessionFrameKind::None;
   return MLN_STATUS_OK;
 }
 
@@ -477,7 +499,7 @@ auto metal_borrowed_texture_descriptor_default() noexcept
 
 auto metal_owned_texture_attach(
   mln_map* map, const mln_metal_owned_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -487,12 +509,16 @@ auto metal_owned_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
   const auto physical_status = validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;
@@ -503,7 +529,7 @@ auto metal_owned_texture_attach(
 
 auto metal_borrowed_texture_attach(
   mln_map* map, const mln_metal_borrowed_texture_descriptor* descriptor,
-  mln_render_session** out_texture
+  mln_render_session** out_session
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -513,12 +539,16 @@ auto metal_borrowed_texture_attach(
   if (descriptor_status != MLN_STATUS_OK) {
     return descriptor_status;
   }
-  const auto output_status = validate_attach_output(out_texture);
+  const auto output_status = validate_attach_output(
+    out_session, "out_session must not be null",
+    "out_session must point to a null handle"
+  );
   if (output_status != MLN_STATUS_OK) {
     return output_status;
   }
   const auto physical_status = validate_physical_size(
-    descriptor->width, descriptor->height, descriptor->scale_factor
+    descriptor->width, descriptor->height, descriptor->scale_factor,
+    "scaled texture dimensions are too large"
   );
   if (physical_status != MLN_STATUS_OK) {
     return physical_status;

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -7,6 +7,7 @@
 #include "diagnostics/diagnostics.hpp"
 #include "map/map.hpp"
 #include "maplibre_native_c.h"
+#include "render/render_session_common.hpp"
 #include "render/texture_session.hpp"
 #include "render/vulkan/vulkan_texture_backend.hpp"
 
@@ -213,11 +214,11 @@ auto validate_vulkan_handles(
   return MLN_STATUS_OK;
 }
 
-void prepare_vulkan_render_resources(mln_texture_session* texture) {
+void prepare_vulkan_render_resources(mln_render_session* texture) {
   // Renderer::render creates the Vulkan context before requesting the default
   // renderable, so shared-device resources must be ready first.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-  static_cast<mln::core::VulkanTextureBackend&>(*texture->backend)
+  static_cast<mln::core::VulkanTextureBackend&>(*texture->texture_backend)
     .prepareRenderResources();
 }
 
@@ -262,7 +263,7 @@ auto vulkan_borrowed_texture_descriptor_default() noexcept
 
 auto vulkan_owned_texture_attach(
   mln_map* map, const mln_vulkan_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -287,7 +288,7 @@ auto vulkan_owned_texture_attach(
     return vulkan_status;
   }
 
-  auto session = std::make_unique<mln_texture_session>();
+  auto session = std::make_unique<mln_render_session>();
   session->map = map;
   session->owner_thread = map_owner_thread(map);
   session->width = descriptor->width;
@@ -299,7 +300,7 @@ auto vulkan_owned_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->api_kind = TextureSessionApi::Vulkan;
   session->mode = TextureSessionMode::Owned;
-  session->backend = std::make_unique<VulkanTextureBackend>(
+  session->texture_backend = std::make_unique<VulkanTextureBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
   session->prepare_render_resources = prepare_vulkan_render_resources;
@@ -308,7 +309,7 @@ auto vulkan_owned_texture_attach(
 
 auto vulkan_borrowed_texture_attach(
   mln_map* map, const mln_vulkan_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -344,7 +345,7 @@ auto vulkan_borrowed_texture_attach(
     return vulkan_status;
   }
 
-  auto session = std::make_unique<mln_texture_session>();
+  auto session = std::make_unique<mln_render_session>();
   session->map = map;
   session->owner_thread = map_owner_thread(map);
   session->width = descriptor->width;
@@ -356,7 +357,7 @@ auto vulkan_borrowed_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->api_kind = TextureSessionApi::Vulkan;
   session->mode = TextureSessionMode::Borrowed;
-  session->backend = std::make_unique<VulkanTextureBackend>(
+  session->texture_backend = std::make_unique<VulkanTextureBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
   session->prepare_render_resources = prepare_vulkan_render_resources;
@@ -364,7 +365,7 @@ auto vulkan_borrowed_texture_attach(
 }
 
 auto vulkan_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_vulkan_owned_texture_frame* out_frame
+  mln_render_session* texture, mln_vulkan_owned_texture_frame* out_frame
 ) -> mln_status {
   const auto status = validate_live_attached_texture(texture);
   if (status != MLN_STATUS_OK) {
@@ -396,7 +397,7 @@ auto vulkan_owned_texture_acquire_frame(
   // The Vulkan acquire path is only valid for owned Vulkan sessions, and this
   // Linux build only creates Vulkan sessions.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-  auto& backend = static_cast<VulkanTextureBackend&>(*texture->backend);
+  auto& backend = static_cast<VulkanTextureBackend&>(*texture->texture_backend);
   const auto resources = backend.frame_resources();
   *out_frame = mln_vulkan_owned_texture_frame{
     .size = sizeof(mln_vulkan_owned_texture_frame),
@@ -419,7 +420,7 @@ auto vulkan_owned_texture_acquire_frame(
 }
 
 auto vulkan_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_vulkan_owned_texture_frame* frame
+  mln_render_session* texture, const mln_vulkan_owned_texture_frame* frame
 ) -> mln_status {
   const auto status = validate_texture(texture);
   if (status != MLN_STATUS_OK) {
@@ -476,7 +477,7 @@ auto metal_borrowed_texture_descriptor_default() noexcept
 
 auto metal_owned_texture_attach(
   mln_map* map, const mln_metal_owned_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -502,7 +503,7 @@ auto metal_owned_texture_attach(
 
 auto metal_borrowed_texture_attach(
   mln_map* map, const mln_metal_borrowed_texture_descriptor* descriptor,
-  mln_texture_session** out_texture
+  mln_render_session** out_texture
 ) -> mln_status {
   const auto map_status = validate_map(map);
   if (map_status != MLN_STATUS_OK) {
@@ -527,7 +528,7 @@ auto metal_borrowed_texture_attach(
 }
 
 auto metal_owned_texture_acquire_frame(
-  mln_texture_session* texture, mln_metal_owned_texture_frame* out_frame
+  mln_render_session* texture, mln_metal_owned_texture_frame* out_frame
 ) -> mln_status {
   const auto status = validate_texture(texture);
   if (status != MLN_STATUS_OK) {
@@ -545,7 +546,7 @@ auto metal_owned_texture_acquire_frame(
 }
 
 auto metal_owned_texture_release_frame(
-  mln_texture_session* texture, const mln_metal_owned_texture_frame* frame
+  mln_render_session* texture, const mln_metal_owned_texture_frame* frame
 ) -> mln_status {
   const auto status = validate_texture(texture);
   if (status != MLN_STATUS_OK) {

--- a/tests/c/surface.zig
+++ b/tests/c/surface.zig
@@ -35,7 +35,7 @@ test "Metal surface attach rejects invalid arguments" {
     defer support.destroyMap(map);
 
     var descriptor = c.mln_metal_surface_descriptor_default();
-    var surface: ?*c.mln_surface_session = null;
+    var surface: ?*c.mln_render_session = null;
 
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_metal_surface_attach(null, &descriptor, &surface));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_metal_surface_attach(map, null, &surface));
@@ -80,23 +80,23 @@ test "Metal surface lifecycle and render update" {
     descriptor.height = 64;
     descriptor.layer = try metal_support.createLayer();
 
-    var surface: ?*c.mln_surface_session = null;
+    var surface: ?*c.mln_render_session = null;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_metal_surface_attach(map, &descriptor, &surface));
 
     var texture_descriptor = c.mln_owned_texture_descriptor_default();
-    var texture: ?*c.mln_texture_session = null;
+    var texture: ?*c.mln_render_session = null;
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_owned_texture_attach(map, &texture_descriptor, &texture));
-    try testing.expectEqual(@as(?*c.mln_texture_session, null), texture);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), texture);
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_surface_render_update(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(surface.?));
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_surface_resize(surface.?, 32, 32, 2.0));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_surface_detach(surface.?));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_surface_render_update(surface.?));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_surface_destroy(surface.?));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_surface_destroy(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_resize(surface.?, 32, 32, 2.0));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_detach(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_render_update(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_destroy(surface.?));
 }
 
 test "Metal surface renders to window-attached layer under autorelease pool" {
@@ -120,13 +120,13 @@ test "Metal surface renders to window-attached layer under autorelease pool" {
     descriptor.height = 64;
     descriptor.layer = window_layer.layer.?;
 
-    var surface: ?*c.mln_surface_session = null;
+    var surface: ?*c.mln_render_session = null;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_metal_surface_attach(map, &descriptor, &surface));
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_surface_render_update(surface.?));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_surface_destroy(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(surface.?));
 }
 
 test "Metal surface render acquires one drawable per frame" {
@@ -150,15 +150,15 @@ test "Metal surface render acquires one drawable per frame" {
     descriptor.height = 64;
     descriptor.layer = window_layer.layer.?;
 
-    var surface: ?*c.mln_surface_session = null;
+    var surface: ?*c.mln_render_session = null;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_metal_surface_attach(map, &descriptor, &surface));
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
     try testing.expectEqual(@as(u32, 0), metal_support.nextDrawableCount(window_layer.layer.?));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_surface_render_update(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(surface.?));
     try testing.expectEqual(@as(u32, 1), metal_support.nextDrawableCount(window_layer.layer.?));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_surface_destroy(surface.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(surface.?));
 }
 
 test "Vulkan surface unsupported backend validates arguments" {
@@ -176,13 +176,13 @@ test "Vulkan surface unsupported backend validates arguments" {
     descriptor.graphics_queue = @ptrFromInt(1);
     descriptor.surface = @ptrFromInt(1);
 
-    var surface: ?*c.mln_surface_session = @ptrFromInt(1);
+    var surface: ?*c.mln_render_session = @ptrFromInt(1);
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_vulkan_surface_attach(map, &descriptor, &surface));
     try testing.expect(surface != null);
 
     surface = null;
     try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_vulkan_surface_attach(map, &descriptor, &surface));
-    try testing.expectEqual(@as(?*c.mln_surface_session, null), surface);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), surface);
 }
 
 test "Vulkan surface attach rejects invalid arguments" {
@@ -194,7 +194,7 @@ test "Vulkan surface attach rejects invalid arguments" {
     defer support.destroyMap(map);
 
     var descriptor = c.mln_vulkan_surface_descriptor_default();
-    var surface: ?*c.mln_surface_session = null;
+    var surface: ?*c.mln_render_session = null;
 
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_vulkan_surface_attach(null, &descriptor, &surface));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_vulkan_surface_attach(map, null, &surface));
@@ -229,7 +229,7 @@ test "Vulkan surface attach rejects invalid arguments" {
 
     descriptor = c.mln_vulkan_surface_descriptor_default();
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_vulkan_surface_attach(map, &descriptor, &surface));
-    try testing.expectEqual(@as(?*c.mln_surface_session, null), surface);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), surface);
 }
 
 test "Metal surface unsupported backend validates arguments" {
@@ -243,11 +243,11 @@ test "Metal surface unsupported backend validates arguments" {
     var descriptor = c.mln_metal_surface_descriptor_default();
     descriptor.layer = @ptrFromInt(1);
 
-    var surface: ?*c.mln_surface_session = @ptrFromInt(1);
+    var surface: ?*c.mln_render_session = @ptrFromInt(1);
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_metal_surface_attach(map, &descriptor, &surface));
     try testing.expect(surface != null);
 
     surface = null;
     try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_metal_surface_attach(map, &descriptor, &surface));
-    try testing.expectEqual(@as(?*c.mln_surface_session, null), surface);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), surface);
 }

--- a/tests/c/texture.zig
+++ b/tests/c/texture.zig
@@ -56,11 +56,11 @@ pub fn expectAttachRejectsInvalidArguments(comptime Backend: type) !void {
     var context = try Backend.AttachContext.init();
     defer context.deinit();
 
-    var texture: ?*c.mln_texture_session = null;
+    var texture: ?*c.mln_render_session = null;
     var descriptor = context.descriptor();
 
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, Backend.attach(null, &descriptor, &texture));
-    try testing.expectEqual(@as(?*c.mln_texture_session, null), texture);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), texture);
 
     const runtime = try support.createRuntime();
     defer support.destroyRuntime(runtime);
@@ -97,7 +97,7 @@ pub fn expectAttachRejectsInvalidArguments(comptime Backend: type) !void {
     var scaled_descriptor = context.descriptor();
     scaled_descriptor.scale_factor = 2.0;
     try testing.expectEqual(c.MLN_STATUS_OK, Backend.attach(map, &scaled_descriptor, &texture));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(texture.?));
 }
 
 pub fn expectLifecycleEnforcesActiveSessionAndStaleHandles(comptime Backend: type) !void {
@@ -107,14 +107,14 @@ pub fn expectLifecycleEnforcesActiveSessionAndStaleHandles(comptime Backend: typ
     defer support.destroyMap(map);
 
     var fixture = try Backend.Fixture.create(map);
-    var second: ?*c.mln_texture_session = null;
+    var second: ?*c.mln_render_session = null;
     var descriptor = fixture.descriptor();
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, Backend.attach(map, &descriptor, &second));
-    try testing.expectEqual(@as(?*c.mln_texture_session, null), second);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), second);
 
     fixture.destroy();
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_texture_destroy(fixture.texture));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_texture_render_update(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_destroy(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_render_update(fixture.texture));
 
     var replacement = try Backend.Fixture.create(map);
     replacement.destroy();
@@ -130,17 +130,17 @@ pub fn expectWrongThreadCallsRejected(comptime Backend: type) !void {
     const ThreadFns = struct {
         fn callTextureOnThread(args: ThreadCallArgs) void {
             args.out_status.* = switch (args.call) {
-                .resize => c.mln_texture_resize(args.fixture.texture, 128, 128, 1.0),
-                .render_update => c.mln_texture_render_update(args.fixture.texture),
+                .resize => c.mln_render_session_resize(args.fixture.texture, 128, 128, 1.0),
+                .render_update => c.mln_render_session_render_update(args.fixture.texture),
                 .acquire => args.fixture.acquire(args.frame),
                 .release => args.fixture.release(args.frame),
-                .detach => c.mln_texture_detach(args.fixture.texture),
-                .destroy => c.mln_texture_destroy(args.fixture.texture),
+                .detach => c.mln_render_session_detach(args.fixture.texture),
+                .destroy => c.mln_render_session_destroy(args.fixture.texture),
             };
         }
 
-        fn renderTextureOnThread(texture: *c.mln_texture_session, out_status: *c.mln_status) void {
-            out_status.* = c.mln_texture_render_update(texture);
+        fn renderTextureOnThread(texture: *c.mln_render_session, out_status: *c.mln_status) void {
+            out_status.* = c.mln_render_session_render_update(texture);
         }
     };
 
@@ -183,7 +183,7 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(fixture.texture));
     try testing.expectEqual(c.MLN_STATUS_OK, fixture.acquire(&frame));
     var frame_acquired = true;
     errdefer {
@@ -197,9 +197,9 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     var second_frame = frame;
     second_frame.clearNativeHandles();
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, fixture.acquire(&second_frame));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_resize(fixture.texture, 128, 128, 1.0));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_detach(fixture.texture));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_destroy(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_resize(fixture.texture, 128, 128, 1.0));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_detach(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_destroy(fixture.texture));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, fixture.release(&stale_same_generation));
 
     try testing.expectEqual(c.MLN_STATUS_OK, fixture.release(&frame));
@@ -207,10 +207,10 @@ pub fn expectRenderAcquireReleaseAndResizeGeneration(comptime Backend: type) !vo
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, fixture.release(&frame));
 
     const old_frame = frame;
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_resize(fixture.texture, 128, 64, 2.0));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_resize(fixture.texture, 128, 64, 2.0));
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, fixture.release(&old_frame));
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(fixture.texture));
     frame.resetSize();
     try testing.expectEqual(c.MLN_STATUS_OK, fixture.acquire(&frame));
     frame_acquired = true;
@@ -233,7 +233,7 @@ pub fn expectOwnedTextureReadback(comptime Backend: type) !void {
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(fixture.texture));
 
     var image_info = c.mln_texture_image_info_default();
     var small: [4]u8 = .{ 0, 0, 0, 0 };
@@ -268,7 +268,7 @@ pub fn expectRenderObserverEvents(comptime Backend: type) !void {
 
         if (pending_render_update) {
             pending_render_update = false;
-            const render_status = c.mln_texture_render_update(fixture.texture);
+            const render_status = c.mln_render_session_render_update(fixture.texture);
             if (render_status == c.MLN_STATUS_OK) {
                 rendered_update = true;
             } else if (render_status != c.MLN_STATUS_INVALID_STATE) {
@@ -343,7 +343,7 @@ pub fn expectStillModeStillImageRequest(comptime Backend: type, map_mode: u32) !
     defer fixture.destroy();
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_render_update(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_render_update(fixture.texture));
 
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_map_request_repaint(map));
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_request_still_image(map));
@@ -362,7 +362,7 @@ pub fn expectStillModeStillImageRequest(comptime Backend: type, map_mode: u32) !
 
             switch (event.type) {
                 c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE => {
-                    const render_status = c.mln_texture_render_update(fixture.texture);
+                    const render_status = c.mln_render_session_render_update(fixture.texture);
                     if (render_status == c.MLN_STATUS_OK) {
                         rendered_frame = true;
                     } else if (render_status != c.MLN_STATUS_INVALID_STATE) {
@@ -395,10 +395,10 @@ pub fn expectDetachLeavesHandleLiveButUnusable(comptime Backend: type) !void {
     var fixture = try Backend.Fixture.create(map);
     defer fixture.deinitContextOnly();
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_detach(fixture.texture));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_render_update(fixture.texture));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_detach(fixture.texture));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_detach(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_render_update(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_detach(fixture.texture));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(fixture.texture));
     fixture.markDestroyed();
 }
 

--- a/tests/c/texture_metal.zig
+++ b/tests/c/texture_metal.zig
@@ -29,7 +29,7 @@ const Backend = struct {
     };
 
     pub const Fixture = struct {
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         context: ?AttachContext,
 
         pub fn create(map: *c.mln_map) !Fixture {
@@ -38,7 +38,7 @@ const Backend = struct {
             texture_descriptor.width = 256;
             texture_descriptor.height = 256;
 
-            var texture: ?*c.mln_texture_session = null;
+            var texture: ?*c.mln_render_session = null;
             try testing.expectEqual(c.MLN_STATUS_OK, c.mln_metal_owned_texture_attach(map, &texture_descriptor, &texture));
             return .{ .texture = texture orelse return error.TextureCreateFailed, .context = context };
         }
@@ -48,7 +48,7 @@ const Backend = struct {
         }
 
         pub fn destroy(self: *Fixture) void {
-            testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(self.texture)) catch @panic("texture destroy failed");
+            testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(self.texture)) catch @panic("texture destroy failed");
             self.context = null;
         }
 
@@ -70,10 +70,10 @@ const Backend = struct {
     };
 
     pub const Frame = struct {
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         metal: c.mln_metal_owned_texture_frame,
 
-        pub fn empty(texture: *c.mln_texture_session) Frame {
+        pub fn empty(texture: *c.mln_render_session) Frame {
             return .{
                 .texture = texture,
                 .metal = .{
@@ -104,7 +104,7 @@ const Backend = struct {
         }
     };
 
-    pub fn attach(map: ?*c.mln_map, descriptor: ?*const c.mln_metal_owned_texture_descriptor, out_texture: ?*?*c.mln_texture_session) c.mln_status {
+    pub fn attach(map: ?*c.mln_map, descriptor: ?*const c.mln_metal_owned_texture_descriptor, out_texture: ?*?*c.mln_render_session) c.mln_status {
         return c.mln_metal_owned_texture_attach(map, descriptor, out_texture);
     }
 
@@ -153,13 +153,13 @@ test "Metal texture unsupported backend validates arguments" {
     var descriptor = c.mln_metal_owned_texture_descriptor_default();
     descriptor.device = @ptrFromInt(1);
 
-    var texture: ?*c.mln_texture_session = @ptrFromInt(1);
+    var texture: ?*c.mln_render_session = @ptrFromInt(1);
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_metal_owned_texture_attach(map, &descriptor, &texture));
     try testing.expect(texture != null);
 
     texture = null;
     try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_metal_owned_texture_attach(map, &descriptor, &texture));
-    try testing.expectEqual(@as(?*c.mln_texture_session, null), texture);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), texture);
 }
 
 test "Metal texture attach rejects invalid arguments" {
@@ -212,21 +212,21 @@ test "Metal borrowed texture renders into caller texture" {
     descriptor.width = 128;
     descriptor.height = 128;
 
-    var texture: ?*c.mln_texture_session = null;
+    var texture: ?*c.mln_render_session = null;
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_metal_borrowed_texture_attach(map, &descriptor, &texture));
 
     descriptor.texture = borrowed;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_metal_borrowed_texture_attach(map, &descriptor, &texture));
-    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(texture.?)) catch @panic("texture destroy failed");
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(texture.?)) catch @panic("texture destroy failed");
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(texture.?));
     try expectPixelApprox(try metal_support.readTexturePixelRGBA8(borrowed, 0, 0), .{ 0xd8, 0xf1, 0xff, 0xff }, 8);
 
     var frame = Backend.Frame.empty(texture.?);
     try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_metal_owned_texture_acquire_frame(texture.?, &frame.metal));
-    try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_texture_resize(texture.?, 64, 64, 1.0));
+    try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_render_session_resize(texture.?, 64, 64, 1.0));
 
     var image_info = c.mln_texture_image_info_default();
     var pixel: [4]u8 = .{ 0, 0, 0, 0 };

--- a/tests/c/texture_owned.zig
+++ b/tests/c/texture_owned.zig
@@ -12,11 +12,11 @@ test "owned texture descriptor exposes defaults" {
 }
 
 test "owned texture attach rejects invalid arguments" {
-    var texture: ?*c.mln_texture_session = null;
+    var texture: ?*c.mln_render_session = null;
     var descriptor = c.mln_owned_texture_descriptor_default();
 
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_owned_texture_attach(null, &descriptor, &texture));
-    try testing.expectEqual(@as(?*c.mln_texture_session, null), texture);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), texture);
 
     const runtime = try support.createRuntime();
     defer support.destroyRuntime(runtime);
@@ -50,7 +50,7 @@ test "owned texture attach rejects invalid arguments" {
     descriptor.height = 64;
     descriptor.scale_factor = 2.0;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_owned_texture_attach(map, &descriptor, &texture));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(texture.?));
 }
 
 test "owned texture lifecycle and render update" {
@@ -66,22 +66,22 @@ test "owned texture lifecycle and render update" {
     descriptor.width = 128;
     descriptor.height = 128;
 
-    var texture: ?*c.mln_texture_session = null;
+    var texture: ?*c.mln_render_session = null;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_owned_texture_attach(map, &descriptor, &texture));
 
-    var second: ?*c.mln_texture_session = null;
+    var second: ?*c.mln_render_session = null;
     try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_owned_texture_attach(map, &descriptor, &second));
-    try testing.expectEqual(@as(?*c.mln_texture_session, null), second);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), second);
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(texture.?));
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_resize(texture.?, 64, 64, 1.0));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_detach(texture.?));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_texture_render_update(texture.?));
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(texture.?));
-    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_texture_destroy(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_resize(texture.?, 64, 64, 1.0));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_detach(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_render_update(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_destroy(texture.?));
 }
 
 test "owned texture reads premultiplied rgba8" {
@@ -97,9 +97,9 @@ test "owned texture reads premultiplied rgba8" {
     descriptor.width = 32;
     descriptor.height = 16;
 
-    var texture: ?*c.mln_texture_session = null;
+    var texture: ?*c.mln_render_session = null;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_owned_texture_attach(map, &descriptor, &texture));
-    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(texture.?)) catch @panic("texture destroy failed");
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(texture.?)) catch @panic("texture destroy failed");
 
     var info = c.mln_texture_image_info_default();
     const data = try testing.allocator.alloc(u8, descriptor.width * descriptor.height * 4);
@@ -108,7 +108,7 @@ test "owned texture reads premultiplied rgba8" {
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(texture.?));
 
     info = c.mln_texture_image_info_default();
     var small: [4]u8 = .{ 0, 0, 0, 0 };

--- a/tests/c/texture_owned.zig
+++ b/tests/c/texture_owned.zig
@@ -84,6 +84,46 @@ test "owned texture lifecycle and render update" {
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_destroy(texture.?));
 }
 
+test "render session maintenance follows renderer lifetime" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_reduce_memory_use(null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_clear_data(null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_dump_debug_logs(null));
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var descriptor = c.mln_owned_texture_descriptor_default();
+    descriptor.width = 64;
+    descriptor.height = 64;
+
+    var session: ?*c.mln_render_session = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_owned_texture_attach(map, &descriptor, &session));
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_reduce_memory_use(session.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_clear_data(session.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_dump_debug_logs(session.?));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(session.?));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_reduce_memory_use(session.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_dump_debug_logs(session.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_clear_data(session.?));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_detach(session.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_reduce_memory_use(session.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_clear_data(session.?));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_dump_debug_logs(session.?));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(session.?));
+}
+
 test "owned texture reads premultiplied rgba8" {
     try support.suppressLogs();
     defer support.restoreLogs();

--- a/tests/c/texture_vulkan.zig
+++ b/tests/c/texture_vulkan.zig
@@ -115,7 +115,7 @@ const Backend = struct {
     };
 
     pub const Fixture = struct {
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         context: ?AttachContext,
 
         pub fn create(map: *c.mln_map) !Fixture {
@@ -126,7 +126,7 @@ const Backend = struct {
             texture_descriptor.width = 256;
             texture_descriptor.height = 256;
 
-            var texture: ?*c.mln_texture_session = null;
+            var texture: ?*c.mln_render_session = null;
             try testing.expectEqual(c.MLN_STATUS_OK, c.mln_vulkan_owned_texture_attach(map, &texture_descriptor, &texture));
             return .{ .texture = texture orelse return error.TextureCreateFailed, .context = context };
         }
@@ -136,7 +136,7 @@ const Backend = struct {
         }
 
         pub fn destroy(self: *Fixture) void {
-            testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(self.texture)) catch @panic("texture destroy failed");
+            testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(self.texture)) catch @panic("texture destroy failed");
             self.deinitContextOnly();
         }
 
@@ -159,10 +159,10 @@ const Backend = struct {
     };
 
     pub const Frame = struct {
-        texture: *c.mln_texture_session,
+        texture: *c.mln_render_session,
         vulkan: c.mln_vulkan_owned_texture_frame,
 
-        pub fn empty(texture: *c.mln_texture_session) Frame {
+        pub fn empty(texture: *c.mln_render_session) Frame {
             return .{
                 .texture = texture,
                 .vulkan = .{
@@ -196,7 +196,7 @@ const Backend = struct {
         }
     };
 
-    pub fn attach(map: ?*c.mln_map, descriptor: ?*const c.mln_vulkan_owned_texture_descriptor, out_texture: ?*?*c.mln_texture_session) c.mln_status {
+    pub fn attach(map: ?*c.mln_map, descriptor: ?*const c.mln_vulkan_owned_texture_descriptor, out_texture: ?*?*c.mln_render_session) c.mln_status {
         return c.mln_vulkan_owned_texture_attach(map, descriptor, out_texture);
     }
 
@@ -335,13 +335,13 @@ test "Vulkan texture unsupported backend validates arguments" {
     descriptor.device = @ptrFromInt(1);
     descriptor.graphics_queue = @ptrFromInt(1);
 
-    var texture: ?*c.mln_texture_session = @ptrFromInt(1);
+    var texture: ?*c.mln_render_session = @ptrFromInt(1);
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_vulkan_owned_texture_attach(map, &descriptor, &texture));
     try testing.expect(texture != null);
 
     texture = null;
     try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_vulkan_owned_texture_attach(map, &descriptor, &texture));
-    try testing.expectEqual(@as(?*c.mln_texture_session, null), texture);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), texture);
 }
 
 fn expectVk(result: vk.VkResult) !void {
@@ -401,30 +401,30 @@ test "Vulkan borrowed texture renders into caller image" {
     defer support.destroyMap(map);
 
     var descriptor = borrowed.descriptor();
-    var texture: ?*c.mln_texture_session = null;
+    var texture: ?*c.mln_render_session = null;
     var missing_image_descriptor = descriptor;
     missing_image_descriptor.image = null;
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_vulkan_borrowed_texture_attach(map, &missing_image_descriptor, &texture));
-    try testing.expectEqual(@as(?*c.mln_texture_session, null), texture);
+    try testing.expectEqual(@as(?*c.mln_render_session, null), texture);
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_vulkan_borrowed_texture_attach(map, &descriptor, &texture));
     defer if (texture) |live_texture| {
-        testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(live_texture)) catch @panic("texture destroy failed");
+        testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(live_texture)) catch @panic("texture destroy failed");
     };
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
     _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_render_update(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(texture.?));
 
     var frame = Backend.Frame.empty(texture.?);
     try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_vulkan_owned_texture_acquire_frame(texture.?, &frame.vulkan));
-    try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_texture_resize(texture.?, 64, 64, 1.0));
+    try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_render_session_resize(texture.?, 64, 64, 1.0));
 
     var image_info = c.mln_texture_image_info_default();
     var pixel: [4]u8 = .{ 0, 0, 0, 0 };
     try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_texture_read_premultiplied_rgba8(texture.?, pixel[0..].ptr, pixel.len, &image_info));
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_texture_destroy(texture.?));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(texture.?));
     texture = null;
 }
 


### PR DESCRIPTION
## Summary
- Unifies public surface and texture handles behind `mln_render_session`, with shared resize, render update, detach, and destroy APIs.
- Collapses the implementation to one render-session registry and shared lifecycle path, while keeping surface-specific attach and texture-specific readback/acquire APIs separated.
- Adds renderer maintenance APIs on render sessions: `mln_render_session_reduce_memory_use`, `mln_render_session_clear_data`, and `mln_render_session_dump_debug_logs`.
- Updates C tests plus Zig and Swift examples to use the unified render-session API.

## API Shape
- Surface attach APIs now return `mln_render_session**`.
- Texture attach APIs now return `mln_render_session**`.
- Render-session lifecycle and maintenance APIs are target-kind agnostic where the native renderer supports them.
- Texture-only operations still validate that the supplied render session is a texture session.

## Verification
- `mise run test`
- `mise run //examples/swift-map:build`
- `mise run //examples/zig-readback:run`
- `mise run //examples/zig-map:run:borrowed-texture`
- `mise run //examples/swift-map:run` with 10s timeout
- `mise run //examples/zig-map:run:owned-texture` with 10s timeout, launched and rendered before timeout
- `mise run //examples/zig-map:run:native-surface` with 10s timeout, launched and rendered before timeout