### PR TITLE
Add render debug tuning APIs

### DIFF
--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -795,6 +795,63 @@ typedef enum mln_projection_mode_field : uint32_t {
   MLN_PROJECTION_MODE_Y_SKEW = 1u << 2u,
 } mln_projection_mode_field;
 
+/** Debug overlay mask values for mln_map_set_debug_options(). */
+typedef enum mln_map_debug_option : uint32_t {
+  MLN_MAP_DEBUG_TILE_BORDERS = 1u << 1u,
+  MLN_MAP_DEBUG_PARSE_STATUS = 1u << 2u,
+  MLN_MAP_DEBUG_TIMESTAMPS = 1u << 3u,
+  MLN_MAP_DEBUG_COLLISION = 1u << 4u,
+  MLN_MAP_DEBUG_OVERDRAW = 1u << 5u,
+  MLN_MAP_DEBUG_STENCIL_CLIP = 1u << 6u,
+  MLN_MAP_DEBUG_DEPTH_BUFFER = 1u << 7u,
+} mln_map_debug_option;
+
+/** Map north orientation values used by mln_map_viewport_options. */
+typedef enum mln_north_orientation : uint32_t {
+  MLN_NORTH_ORIENTATION_UP = 0,
+  MLN_NORTH_ORIENTATION_RIGHT = 1,
+  MLN_NORTH_ORIENTATION_DOWN = 2,
+  MLN_NORTH_ORIENTATION_LEFT = 3,
+} mln_north_orientation;
+
+/** Map constraint modes used by mln_map_viewport_options. */
+typedef enum mln_constrain_mode : uint32_t {
+  MLN_CONSTRAIN_MODE_NONE = 0,
+  MLN_CONSTRAIN_MODE_HEIGHT_ONLY = 1,
+  MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT = 2,
+  MLN_CONSTRAIN_MODE_SCREEN = 3,
+} mln_constrain_mode;
+
+/** Viewport orientation modes used by mln_map_viewport_options. */
+typedef enum mln_viewport_mode : uint32_t {
+  MLN_VIEWPORT_MODE_DEFAULT = 0,
+  MLN_VIEWPORT_MODE_FLIPPED_Y = 1,
+} mln_viewport_mode;
+
+/** Field mask values for mln_map_viewport_options. */
+typedef enum mln_map_viewport_option_field : uint32_t {
+  MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION = 1u << 0u,
+  MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE = 1u << 1u,
+  MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE = 1u << 2u,
+  MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET = 1u << 3u,
+} mln_map_viewport_option_field;
+
+/** Tile LOD algorithms used by mln_map_tile_options. */
+typedef enum mln_tile_lod_mode : uint32_t {
+  MLN_TILE_LOD_MODE_DEFAULT = 0,
+  MLN_TILE_LOD_MODE_DISTANCE = 1,
+} mln_tile_lod_mode;
+
+/** Field mask values for mln_map_tile_options. */
+typedef enum mln_map_tile_option_field : uint32_t {
+  MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA = 1u << 0u,
+  MLN_MAP_TILE_OPTION_LOD_MIN_RADIUS = 1u << 1u,
+  MLN_MAP_TILE_OPTION_LOD_SCALE = 1u << 2u,
+  MLN_MAP_TILE_OPTION_LOD_PITCH_THRESHOLD = 1u << 3u,
+  MLN_MAP_TILE_OPTION_LOD_ZOOM_SHIFT = 1u << 4u,
+  MLN_MAP_TILE_OPTION_LOD_MODE = 1u << 5u,
+} mln_map_tile_option_field;
+
 /** Map rendering modes used when creating a map. */
 typedef enum mln_map_mode : uint32_t {
   /** Continuously updates as data arrives and map state changes. */
@@ -878,6 +935,33 @@ typedef struct mln_projection_mode {
   /** Native y-skew factor used by the axonometric transform. */
   double y_skew;
 } mln_projection_mode;
+
+/** Live map viewport and render-transform controls. */
+typedef struct mln_map_viewport_options {
+  uint32_t size;
+  uint32_t fields;
+  /** One of mln_north_orientation. */
+  uint32_t north_orientation;
+  /** One of mln_constrain_mode. */
+  uint32_t constrain_mode;
+  /** One of mln_viewport_mode. */
+  uint32_t viewport_mode;
+  mln_edge_insets frustum_offset;
+} mln_map_viewport_options;
+
+/** Tile prefetch and LOD tuning controls. */
+typedef struct mln_map_tile_options {
+  uint32_t size;
+  uint32_t fields;
+  /** Native uint8_t prefetch zoom delta. */
+  uint32_t prefetch_zoom_delta;
+  double lod_min_radius;
+  double lod_scale;
+  double lod_pitch_threshold;
+  double lod_zoom_shift;
+  /** One of mln_tile_lod_mode. */
+  uint32_t lod_mode;
+} mln_map_tile_options;
 
 /**
  * Returns map options initialized for this C API version.
@@ -1012,6 +1096,169 @@ MLN_API mln_camera_options mln_camera_options_default(void) MLN_NOEXCEPT;
  * version.
  */
 MLN_API mln_projection_mode mln_projection_mode_default(void) MLN_NOEXCEPT;
+
+/** Returns empty viewport options initialized for this C API version. */
+MLN_API mln_map_viewport_options
+mln_map_viewport_options_default(void) MLN_NOEXCEPT;
+
+/** Returns empty tile tuning options initialized for this C API version. */
+MLN_API mln_map_tile_options mln_map_tile_options_default(void) MLN_NOEXCEPT;
+
+/**
+ * Applies MapLibre debug overlay mask bits to a map.
+ *
+ * Pass 0 to disable all debug overlays.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, or options
+ *   contains unknown bits.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_map_set_debug_options(mln_map* map, uint32_t options) MLN_NOEXCEPT;
+
+/**
+ * Copies the current MapLibre debug overlay mask bits.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, or out_options is
+ *   null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_map_get_debug_options(mln_map* map, uint32_t* out_options) MLN_NOEXCEPT;
+
+/**
+ * Enables or disables MapLibre's rendering stats overlay view.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_rendering_stats_view_enabled(
+  mln_map* map, bool enabled
+) MLN_NOEXCEPT;
+
+/**
+ * Copies whether MapLibre's rendering stats overlay view is enabled.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, or out_enabled is
+ *   null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_rendering_stats_view_enabled(
+  mln_map* map, bool* out_enabled
+) MLN_NOEXCEPT;
+
+/**
+ * Copies whether MapLibre currently considers the map fully loaded.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, or out_loaded is
+ *   null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_map_is_fully_loaded(mln_map* map, bool* out_loaded) MLN_NOEXCEPT;
+
+/**
+ * Dumps map debug logs through MapLibre Native logging.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_dump_debug_logs(mln_map* map) MLN_NOEXCEPT;
+
+/**
+ * Copies live map viewport and render-transform controls.
+ *
+ * On success, *out_options is overwritten and all known fields are marked.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_options is
+ *   null, or out_options->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_viewport_options(
+  mln_map* map, mln_map_viewport_options* out_options
+) MLN_NOEXCEPT;
+
+/**
+ * Applies selected live map viewport and render-transform controls.
+ *
+ * Only fields indicated by options->fields affect the map.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, options is null,
+ *   options->size is too small, options->fields contains unknown bits, an enum
+ *   value is unknown, or an enabled frustum offset value is invalid.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_viewport_options(
+  mln_map* map, const mln_map_viewport_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Copies tile prefetch and LOD tuning controls.
+ *
+ * On success, *out_options is overwritten and all known fields are marked.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_options is
+ *   null, or out_options->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_tile_options(
+  mln_map* map, mln_map_tile_options* out_options
+) MLN_NOEXCEPT;
+
+/**
+ * Applies selected tile prefetch and LOD tuning controls.
+ *
+ * Only fields indicated by options->fields affect the map.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, options is null,
+ *   options->size is too small, options->fields contains unknown bits,
+ *   prefetch_zoom_delta is greater than 255, a double field is non-finite, or
+ *   lod_mode is unknown.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_tile_options(
+  mln_map* map, const mln_map_tile_options* options
+) MLN_NOEXCEPT;
 
 /**
  * Copies the current camera snapshot.

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -1,6 +1,7 @@
 #define MLN_BUILDING_C
 
 #include <cstddef>
+#include <cstdint>
 
 #include "map/map.hpp"
 
@@ -17,6 +18,15 @@ auto mln_camera_options_default(void) noexcept -> mln_camera_options {
 
 auto mln_projection_mode_default(void) noexcept -> mln_projection_mode {
   return mln::core::projection_mode_default();
+}
+
+auto mln_map_viewport_options_default(void) noexcept
+  -> mln_map_viewport_options {
+  return mln::core::map_viewport_options_default();
+}
+
+auto mln_map_tile_options_default(void) noexcept -> mln_map_tile_options {
+  return mln::core::map_tile_options_default();
 }
 
 auto mln_map_create(
@@ -86,6 +96,81 @@ auto mln_map_set_projection_mode(
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_set_projection_mode(map, mode);
+  });
+}
+
+auto mln_map_set_debug_options(mln_map* map, uint32_t options) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_debug_options(map, options);
+  });
+}
+
+auto mln_map_get_debug_options(mln_map* map, uint32_t* out_options) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_debug_options(map, out_options);
+  });
+}
+
+auto mln_map_set_rendering_stats_view_enabled(
+  mln_map* map, bool enabled
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_rendering_stats_view_enabled(map, enabled);
+  });
+}
+
+auto mln_map_get_rendering_stats_view_enabled(
+  mln_map* map, bool* out_enabled
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_rendering_stats_view_enabled(map, out_enabled);
+  });
+}
+
+auto mln_map_is_fully_loaded(mln_map* map, bool* out_loaded) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_is_fully_loaded(map, out_loaded);
+  });
+}
+
+auto mln_map_dump_debug_logs(mln_map* map) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_dump_debug_logs(map);
+  });
+}
+
+auto mln_map_get_viewport_options(
+  mln_map* map, mln_map_viewport_options* out_options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_viewport_options(map, out_options);
+  });
+}
+
+auto mln_map_set_viewport_options(
+  mln_map* map, const mln_map_viewport_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_viewport_options(map, options);
+  });
+}
+
+auto mln_map_get_tile_options(
+  mln_map* map, mln_map_tile_options* out_options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_tile_options(map, out_options);
+  });
+}
+
+auto mln_map_set_tile_options(
+  mln_map* map, const mln_map_tile_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_tile_options(map, options);
   });
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstring>
 #include <exception>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -456,6 +457,146 @@ auto validate_projection_mode_options(const mln_projection_mode* mode)
   return MLN_STATUS_OK;
 }
 
+auto validate_debug_options(uint32_t options) -> mln_status {
+  constexpr auto known_options =
+    static_cast<uint32_t>(MLN_MAP_DEBUG_TILE_BORDERS) |
+    MLN_MAP_DEBUG_PARSE_STATUS | MLN_MAP_DEBUG_TIMESTAMPS |
+    MLN_MAP_DEBUG_COLLISION | MLN_MAP_DEBUG_OVERDRAW |
+    MLN_MAP_DEBUG_STENCIL_CLIP | MLN_MAP_DEBUG_DEPTH_BUFFER;
+  if ((options & ~known_options) != 0U) {
+    mln::core::set_thread_error("debug options contain unknown bits");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_frustum_offset(mln_edge_insets offset) -> mln_status {
+  if (
+    !std::isfinite(offset.top) || !std::isfinite(offset.left) ||
+    !std::isfinite(offset.bottom) || !std::isfinite(offset.right)
+  ) {
+    mln::core::set_thread_error("frustum offset values must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_viewport_options(const mln_map_viewport_options* options)
+  -> mln_status {
+  if (options == nullptr) {
+    mln::core::set_thread_error("viewport options must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (options->size < sizeof(mln_map_viewport_options)) {
+    mln::core::set_thread_error("mln_map_viewport_options.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION) |
+    MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE |
+    MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE |
+    MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET;
+  if ((options->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_map_viewport_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if ((options->fields & MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION) != 0U) {
+    switch (options->north_orientation) {
+      case MLN_NORTH_ORIENTATION_UP:
+      case MLN_NORTH_ORIENTATION_RIGHT:
+      case MLN_NORTH_ORIENTATION_DOWN:
+      case MLN_NORTH_ORIENTATION_LEFT:
+        break;
+      default:
+        mln::core::set_thread_error("north_orientation is invalid");
+        return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  if ((options->fields & MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE) != 0U) {
+    switch (options->constrain_mode) {
+      case MLN_CONSTRAIN_MODE_NONE:
+      case MLN_CONSTRAIN_MODE_HEIGHT_ONLY:
+      case MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT:
+      case MLN_CONSTRAIN_MODE_SCREEN:
+        break;
+      default:
+        mln::core::set_thread_error("constrain_mode is invalid");
+        return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  if ((options->fields & MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE) != 0U) {
+    switch (options->viewport_mode) {
+      case MLN_VIEWPORT_MODE_DEFAULT:
+      case MLN_VIEWPORT_MODE_FLIPPED_Y:
+        break;
+      default:
+        mln::core::set_thread_error("viewport_mode is invalid");
+        return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  if ((options->fields & MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET) != 0U) {
+    return validate_frustum_offset(options->frustum_offset);
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_tile_options(const mln_map_tile_options* options) -> mln_status {
+  if (options == nullptr) {
+    mln::core::set_thread_error("tile options must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (options->size < sizeof(mln_map_tile_options)) {
+    mln::core::set_thread_error("mln_map_tile_options.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA) |
+    MLN_MAP_TILE_OPTION_LOD_MIN_RADIUS | MLN_MAP_TILE_OPTION_LOD_SCALE |
+    MLN_MAP_TILE_OPTION_LOD_PITCH_THRESHOLD |
+    MLN_MAP_TILE_OPTION_LOD_ZOOM_SHIFT | MLN_MAP_TILE_OPTION_LOD_MODE;
+  if ((options->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_map_tile_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    (options->fields & MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA) != 0U &&
+    options->prefetch_zoom_delta > std::numeric_limits<uint8_t>::max()
+  ) {
+    mln::core::set_thread_error("prefetch_zoom_delta must be at most 255");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    ((options->fields & MLN_MAP_TILE_OPTION_LOD_MIN_RADIUS) != 0U &&
+     !std::isfinite(options->lod_min_radius)) ||
+    ((options->fields & MLN_MAP_TILE_OPTION_LOD_SCALE) != 0U &&
+     !std::isfinite(options->lod_scale)) ||
+    ((options->fields & MLN_MAP_TILE_OPTION_LOD_PITCH_THRESHOLD) != 0U &&
+     !std::isfinite(options->lod_pitch_threshold)) ||
+    ((options->fields & MLN_MAP_TILE_OPTION_LOD_ZOOM_SHIFT) != 0U &&
+     !std::isfinite(options->lod_zoom_shift))
+  ) {
+    mln::core::set_thread_error("tile LOD values must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if ((options->fields & MLN_MAP_TILE_OPTION_LOD_MODE) != 0U) {
+    switch (options->lod_mode) {
+      case MLN_TILE_LOD_MODE_DEFAULT:
+      case MLN_TILE_LOD_MODE_DISTANCE:
+        break;
+      default:
+        mln::core::set_thread_error("lod_mode is invalid");
+        return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  return MLN_STATUS_OK;
+}
+
 auto validate_lat_lng(mln_lat_lng coordinate) -> mln_status {
   if (
     !std::isfinite(coordinate.latitude) || coordinate.latitude < -90.0 ||
@@ -604,6 +745,122 @@ auto to_native_projection_mode(const mln_projection_mode& mode)
     result.withYSkew(mode.y_skew);
   }
   return result;
+}
+
+auto to_native_debug_options(uint32_t options) -> mbgl::MapDebugOptions {
+  return static_cast<mbgl::MapDebugOptions>(options);
+}
+
+auto from_native_debug_options(mbgl::MapDebugOptions options) -> uint32_t {
+  return static_cast<uint32_t>(options);
+}
+
+auto to_native_north_orientation(uint32_t orientation)
+  -> mbgl::NorthOrientation {
+  switch (orientation) {
+    case MLN_NORTH_ORIENTATION_RIGHT:
+      return mbgl::NorthOrientation::Rightwards;
+    case MLN_NORTH_ORIENTATION_DOWN:
+      return mbgl::NorthOrientation::Downwards;
+    case MLN_NORTH_ORIENTATION_LEFT:
+      return mbgl::NorthOrientation::Leftwards;
+    case MLN_NORTH_ORIENTATION_UP:
+    default:
+      return mbgl::NorthOrientation::Upwards;
+  }
+}
+
+auto from_native_north_orientation(mbgl::NorthOrientation orientation)
+  -> uint32_t {
+  switch (orientation) {
+    case mbgl::NorthOrientation::Rightwards:
+      return MLN_NORTH_ORIENTATION_RIGHT;
+    case mbgl::NorthOrientation::Downwards:
+      return MLN_NORTH_ORIENTATION_DOWN;
+    case mbgl::NorthOrientation::Leftwards:
+      return MLN_NORTH_ORIENTATION_LEFT;
+    case mbgl::NorthOrientation::Upwards:
+    default:
+      return MLN_NORTH_ORIENTATION_UP;
+  }
+}
+
+auto to_native_constrain_mode(uint32_t mode) -> mbgl::ConstrainMode {
+  switch (mode) {
+    case MLN_CONSTRAIN_MODE_NONE:
+      return mbgl::ConstrainMode::None;
+    case MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT:
+      return mbgl::ConstrainMode::WidthAndHeight;
+    case MLN_CONSTRAIN_MODE_SCREEN:
+      return mbgl::ConstrainMode::Screen;
+    case MLN_CONSTRAIN_MODE_HEIGHT_ONLY:
+    default:
+      return mbgl::ConstrainMode::HeightOnly;
+  }
+}
+
+auto from_native_constrain_mode(mbgl::ConstrainMode mode) -> uint32_t {
+  switch (mode) {
+    case mbgl::ConstrainMode::None:
+      return MLN_CONSTRAIN_MODE_NONE;
+    case mbgl::ConstrainMode::WidthAndHeight:
+      return MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT;
+    case mbgl::ConstrainMode::Screen:
+      return MLN_CONSTRAIN_MODE_SCREEN;
+    case mbgl::ConstrainMode::HeightOnly:
+    default:
+      return MLN_CONSTRAIN_MODE_HEIGHT_ONLY;
+  }
+}
+
+auto to_native_viewport_mode(uint32_t mode) -> mbgl::ViewportMode {
+  switch (mode) {
+    case MLN_VIEWPORT_MODE_FLIPPED_Y:
+      return mbgl::ViewportMode::FlippedY;
+    case MLN_VIEWPORT_MODE_DEFAULT:
+    default:
+      return mbgl::ViewportMode::Default;
+  }
+}
+
+auto from_native_viewport_mode(mbgl::ViewportMode mode) -> uint32_t {
+  switch (mode) {
+    case mbgl::ViewportMode::FlippedY:
+      return MLN_VIEWPORT_MODE_FLIPPED_Y;
+    case mbgl::ViewportMode::Default:
+    default:
+      return MLN_VIEWPORT_MODE_DEFAULT;
+  }
+}
+
+auto from_native_edge_insets(const mbgl::EdgeInsets& insets)
+  -> mln_edge_insets {
+  return mln_edge_insets{
+    .top = insets.top(),
+    .left = insets.left(),
+    .bottom = insets.bottom(),
+    .right = insets.right()
+  };
+}
+
+auto to_native_tile_lod_mode(uint32_t mode) -> mbgl::TileLodMode {
+  switch (mode) {
+    case MLN_TILE_LOD_MODE_DISTANCE:
+      return mbgl::TileLodMode::Distance;
+    case MLN_TILE_LOD_MODE_DEFAULT:
+    default:
+      return mbgl::TileLodMode::Default;
+  }
+}
+
+auto from_native_tile_lod_mode(mbgl::TileLodMode mode) -> uint32_t {
+  switch (mode) {
+    case mbgl::TileLodMode::Distance:
+      return MLN_TILE_LOD_MODE_DISTANCE;
+    case mbgl::TileLodMode::Default:
+    default:
+      return MLN_TILE_LOD_MODE_DEFAULT;
+  }
 }
 
 auto from_native_projection_mode(const mbgl::ProjectionMode& mode)
@@ -765,6 +1022,30 @@ auto projection_mode_default() noexcept -> mln_projection_mode {
     .axonometric = false,
     .x_skew = 0,
     .y_skew = 0
+  };
+}
+
+auto map_viewport_options_default() noexcept -> mln_map_viewport_options {
+  return mln_map_viewport_options{
+    .size = sizeof(mln_map_viewport_options),
+    .fields = 0,
+    .north_orientation = MLN_NORTH_ORIENTATION_UP,
+    .constrain_mode = MLN_CONSTRAIN_MODE_HEIGHT_ONLY,
+    .viewport_mode = MLN_VIEWPORT_MODE_DEFAULT,
+    .frustum_offset = {.top = 0, .left = 0, .bottom = 0, .right = 0}
+  };
+}
+
+auto map_tile_options_default() noexcept -> mln_map_tile_options {
+  return mln_map_tile_options{
+    .size = sizeof(mln_map_tile_options),
+    .fields = 0,
+    .prefetch_zoom_delta = 0,
+    .lod_min_radius = 0,
+    .lod_scale = 0,
+    .lod_pitch_threshold = 0,
+    .lod_zoom_shift = 0,
+    .lod_mode = MLN_TILE_LOD_MODE_DEFAULT
   };
 }
 
@@ -1099,6 +1380,204 @@ auto map_set_projection_mode(mln_map* map, const mln_projection_mode* mode)
   }
 
   map->map->setProjectionMode(to_native_projection_mode(*mode));
+  return MLN_STATUS_OK;
+}
+
+auto map_set_debug_options(mln_map* map, uint32_t options) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto options_status = validate_debug_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+  map->map->setDebug(to_native_debug_options(options));
+  return MLN_STATUS_OK;
+}
+
+auto map_get_debug_options(mln_map* map, uint32_t* out_options) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_options == nullptr) {
+    set_thread_error("out_options must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_options = from_native_debug_options(map->map->getDebug());
+  return MLN_STATUS_OK;
+}
+
+auto map_set_rendering_stats_view_enabled(mln_map* map, bool enabled)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  map->map->enableRenderingStatsView(enabled);
+  return MLN_STATUS_OK;
+}
+
+auto map_get_rendering_stats_view_enabled(mln_map* map, bool* out_enabled)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_enabled == nullptr) {
+    set_thread_error("out_enabled must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_enabled = map->map->isRenderingStatsViewEnabled();
+  return MLN_STATUS_OK;
+}
+
+auto map_is_fully_loaded(mln_map* map, bool* out_loaded) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_loaded == nullptr) {
+    set_thread_error("out_loaded must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_loaded = map->map->isFullyLoaded();
+  return MLN_STATUS_OK;
+}
+
+auto map_dump_debug_logs(mln_map* map) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  map->map->dumpDebugLogs();
+  return MLN_STATUS_OK;
+}
+
+auto map_get_viewport_options(
+  mln_map* map, mln_map_viewport_options* out_options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (
+    out_options == nullptr ||
+    out_options->size < sizeof(mln_map_viewport_options)
+  ) {
+    set_thread_error("out_options must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto options = map->map->getMapOptions();
+  *out_options = mln_map_viewport_options{
+    .size = sizeof(mln_map_viewport_options),
+    .fields = static_cast<uint32_t>(MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION) |
+              MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE |
+              MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE |
+              MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET,
+    .north_orientation =
+      from_native_north_orientation(options.northOrientation()),
+    .constrain_mode = from_native_constrain_mode(options.constrainMode()),
+    .viewport_mode = from_native_viewport_mode(options.viewportMode()),
+    .frustum_offset = from_native_edge_insets(map->map->getFrustumOffset())
+  };
+  return MLN_STATUS_OK;
+}
+
+auto map_set_viewport_options(
+  mln_map* map, const mln_map_viewport_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto options_status = validate_viewport_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  if ((options->fields & MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION) != 0U) {
+    map->map->setNorthOrientation(
+      to_native_north_orientation(options->north_orientation)
+    );
+  }
+  if ((options->fields & MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE) != 0U) {
+    map->map->setConstrainMode(
+      to_native_constrain_mode(options->constrain_mode)
+    );
+  }
+  if ((options->fields & MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE) != 0U) {
+    map->map->setViewportMode(to_native_viewport_mode(options->viewport_mode));
+  }
+  if ((options->fields & MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET) != 0U) {
+    map->map->setFrustumOffset(to_native_edge_insets(options->frustum_offset));
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_get_tile_options(mln_map* map, mln_map_tile_options* out_options)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (
+    out_options == nullptr || out_options->size < sizeof(mln_map_tile_options)
+  ) {
+    set_thread_error("out_options must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_options = mln_map_tile_options{
+    .size = sizeof(mln_map_tile_options),
+    .fields = static_cast<uint32_t>(MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA) |
+              MLN_MAP_TILE_OPTION_LOD_MIN_RADIUS |
+              MLN_MAP_TILE_OPTION_LOD_SCALE |
+              MLN_MAP_TILE_OPTION_LOD_PITCH_THRESHOLD |
+              MLN_MAP_TILE_OPTION_LOD_ZOOM_SHIFT | MLN_MAP_TILE_OPTION_LOD_MODE,
+    .prefetch_zoom_delta = map->map->getPrefetchZoomDelta(),
+    .lod_min_radius = map->map->getTileLodMinRadius(),
+    .lod_scale = map->map->getTileLodScale(),
+    .lod_pitch_threshold = map->map->getTileLodPitchThreshold(),
+    .lod_zoom_shift = map->map->getTileLodZoomShift(),
+    .lod_mode = from_native_tile_lod_mode(map->map->getTileLodMode())
+  };
+  return MLN_STATUS_OK;
+}
+
+auto map_set_tile_options(mln_map* map, const mln_map_tile_options* options)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto options_status = validate_tile_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  if ((options->fields & MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA) != 0U) {
+    map->map->setPrefetchZoomDelta(
+      static_cast<uint8_t>(options->prefetch_zoom_delta)
+    );
+  }
+  if ((options->fields & MLN_MAP_TILE_OPTION_LOD_MIN_RADIUS) != 0U) {
+    map->map->setTileLodMinRadius(options->lod_min_radius);
+  }
+  if ((options->fields & MLN_MAP_TILE_OPTION_LOD_SCALE) != 0U) {
+    map->map->setTileLodScale(options->lod_scale);
+  }
+  if ((options->fields & MLN_MAP_TILE_OPTION_LOD_PITCH_THRESHOLD) != 0U) {
+    map->map->setTileLodPitchThreshold(options->lod_pitch_threshold);
+  }
+  if ((options->fields & MLN_MAP_TILE_OPTION_LOD_ZOOM_SHIFT) != 0U) {
+    map->map->setTileLodZoomShift(options->lod_zoom_shift);
+  }
+  if ((options->fields & MLN_MAP_TILE_OPTION_LOD_MODE) != 0U) {
+    map->map->setTileLodMode(to_native_tile_lod_mode(options->lod_mode));
+  }
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -478,6 +478,15 @@ auto validate_frustum_offset(mln_edge_insets offset) -> mln_status {
     mln::core::set_thread_error("frustum offset values must be finite");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
+  if (
+    offset.top < 0.0 || offset.left < 0.0 || offset.bottom < 0.0 ||
+    offset.right < 0.0
+  ) {
+    mln::core::set_thread_error(
+      "frustum offset values must be greater than or equal to 0"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <thread>
 
@@ -17,6 +18,8 @@ namespace mln::core {
 auto map_options_default() noexcept -> mln_map_options;
 auto camera_options_default() noexcept -> mln_camera_options;
 auto projection_mode_default() noexcept -> mln_projection_mode;
+auto map_viewport_options_default() noexcept -> mln_map_viewport_options;
+auto map_tile_options_default() noexcept -> mln_map_tile_options;
 auto create_map(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) -> mln_status;
@@ -30,6 +33,24 @@ auto map_jump_to(mln_map* map, const mln_camera_options* camera) -> mln_status;
 auto map_get_projection_mode(mln_map* map, mln_projection_mode* out_mode)
   -> mln_status;
 auto map_set_projection_mode(mln_map* map, const mln_projection_mode* mode)
+  -> mln_status;
+auto map_set_debug_options(mln_map* map, uint32_t options) -> mln_status;
+auto map_get_debug_options(mln_map* map, uint32_t* out_options) -> mln_status;
+auto map_set_rendering_stats_view_enabled(mln_map* map, bool enabled)
+  -> mln_status;
+auto map_get_rendering_stats_view_enabled(mln_map* map, bool* out_enabled)
+  -> mln_status;
+auto map_is_fully_loaded(mln_map* map, bool* out_loaded) -> mln_status;
+auto map_dump_debug_logs(mln_map* map) -> mln_status;
+auto map_get_viewport_options(
+  mln_map* map, mln_map_viewport_options* out_options
+) -> mln_status;
+auto map_set_viewport_options(
+  mln_map* map, const mln_map_viewport_options* options
+) -> mln_status;
+auto map_get_tile_options(mln_map* map, mln_map_tile_options* out_options)
+  -> mln_status;
+auto map_set_tile_options(mln_map* map, const mln_map_tile_options* options)
   -> mln_status;
 auto map_pixel_for_lat_lng(
   mln_map* map, mln_lat_lng coordinate, mln_screen_point* out_point

--- a/tests/c/main.zig
+++ b/tests/c/main.zig
@@ -5,6 +5,7 @@ comptime {
     _ = @import("resources.zig");
     _ = @import("camera.zig");
     _ = @import("projection.zig");
+    _ = @import("map_tuning.zig");
     _ = @import("diagnostics.zig");
     _ = @import("events.zig");
     _ = @import("logging.zig");

--- a/tests/c/map_tuning.zig
+++ b/tests/c/map_tuning.zig
@@ -78,7 +78,7 @@ test "map viewport options update selected fields" {
     options.north_orientation = c.MLN_NORTH_ORIENTATION_RIGHT;
     options.constrain_mode = c.MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT;
     options.viewport_mode = c.MLN_VIEWPORT_MODE_FLIPPED_Y;
-    options.frustum_offset = .{ .top = 1.0, .left = -2.0, .bottom = 3.0, .right = -4.0 };
+    options.frustum_offset = .{ .top = 1.0, .left = 2.0, .bottom = 3.0, .right = 4.0 };
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_viewport_options(map, &options));
 
     var snapshot = c.mln_map_viewport_options_default();
@@ -91,9 +91,9 @@ test "map viewport options update selected fields" {
     try testing.expectEqual(@as(u32, c.MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT), snapshot.constrain_mode);
     try testing.expectEqual(@as(u32, c.MLN_VIEWPORT_MODE_FLIPPED_Y), snapshot.viewport_mode);
     try testing.expectApproxEqAbs(@as(f64, 1.0), snapshot.frustum_offset.top, 0.000001);
-    try testing.expectApproxEqAbs(@as(f64, -2.0), snapshot.frustum_offset.left, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, 2.0), snapshot.frustum_offset.left, 0.000001);
     try testing.expectApproxEqAbs(@as(f64, 3.0), snapshot.frustum_offset.bottom, 0.000001);
-    try testing.expectApproxEqAbs(@as(f64, -4.0), snapshot.frustum_offset.right, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, 4.0), snapshot.frustum_offset.right, 0.000001);
 
     options = c.mln_map_viewport_options_default();
     options.fields = c.MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION;
@@ -142,6 +142,11 @@ test "map viewport options reject invalid arguments" {
     options = c.mln_map_viewport_options_default();
     options.fields = c.MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET;
     options.frustum_offset.top = std.math.inf(f64);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, &options));
+
+    options = c.mln_map_viewport_options_default();
+    options.fields = c.MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET;
+    options.frustum_offset.left = -1.0;
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, &options));
 }
 

--- a/tests/c/map_tuning.zig
+++ b/tests/c/map_tuning.zig
@@ -1,0 +1,224 @@
+const std = @import("std");
+const testing = std.testing;
+const support = @import("support.zig");
+const c = support.c;
+
+test "map tuning exposes default options" {
+    const viewport = c.mln_map_viewport_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_map_viewport_options)), viewport.size);
+    try testing.expectEqual(@as(u32, 0), viewport.fields);
+    try testing.expectEqual(@as(u32, c.MLN_NORTH_ORIENTATION_UP), viewport.north_orientation);
+    try testing.expectEqual(@as(u32, c.MLN_CONSTRAIN_MODE_HEIGHT_ONLY), viewport.constrain_mode);
+    try testing.expectEqual(@as(u32, c.MLN_VIEWPORT_MODE_DEFAULT), viewport.viewport_mode);
+
+    const tile = c.mln_map_tile_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_map_tile_options)), tile.size);
+    try testing.expectEqual(@as(u32, 0), tile.fields);
+    try testing.expectEqual(@as(u32, c.MLN_TILE_LOD_MODE_DEFAULT), tile.lod_mode);
+}
+
+test "map debug options round trip and diagnostics toggles" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    const debug = c.MLN_MAP_DEBUG_TILE_BORDERS | c.MLN_MAP_DEBUG_COLLISION | c.MLN_MAP_DEBUG_DEPTH_BUFFER;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_debug_options(map, debug));
+
+    var snapshot: u32 = 0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_debug_options(map, &snapshot));
+    try testing.expectEqual(@as(u32, debug), snapshot);
+
+    var stats_enabled = true;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_rendering_stats_view_enabled(map, &stats_enabled));
+    try testing.expect(!stats_enabled);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_rendering_stats_view_enabled(map, true));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_rendering_stats_view_enabled(map, &stats_enabled));
+    try testing.expect(stats_enabled);
+
+    var loaded = true;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_is_fully_loaded(map, &loaded));
+}
+
+test "map debug options reject invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var out_options: u32 = 0;
+    var out_bool = false;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_debug_options(null, 0));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_debug_options(map, @as(u32, 1) << 31));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_debug_options(map, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_debug_options(null, &out_options));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_rendering_stats_view_enabled(null, true));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_rendering_stats_view_enabled(map, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_rendering_stats_view_enabled(null, &out_bool));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_is_fully_loaded(map, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_is_fully_loaded(null, &out_bool));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_dump_debug_logs(null));
+}
+
+test "map viewport options update selected fields" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var options = c.mln_map_viewport_options_default();
+    options.fields = c.MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION |
+        c.MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE |
+        c.MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE |
+        c.MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET;
+    options.north_orientation = c.MLN_NORTH_ORIENTATION_RIGHT;
+    options.constrain_mode = c.MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT;
+    options.viewport_mode = c.MLN_VIEWPORT_MODE_FLIPPED_Y;
+    options.frustum_offset = .{ .top = 1.0, .left = -2.0, .bottom = 3.0, .right = -4.0 };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_viewport_options(map, &options));
+
+    var snapshot = c.mln_map_viewport_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_viewport_options(map, &snapshot));
+    try testing.expect((snapshot.fields & c.MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION) != 0);
+    try testing.expect((snapshot.fields & c.MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE) != 0);
+    try testing.expect((snapshot.fields & c.MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE) != 0);
+    try testing.expect((snapshot.fields & c.MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET) != 0);
+    try testing.expectEqual(@as(u32, c.MLN_NORTH_ORIENTATION_RIGHT), snapshot.north_orientation);
+    try testing.expectEqual(@as(u32, c.MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT), snapshot.constrain_mode);
+    try testing.expectEqual(@as(u32, c.MLN_VIEWPORT_MODE_FLIPPED_Y), snapshot.viewport_mode);
+    try testing.expectApproxEqAbs(@as(f64, 1.0), snapshot.frustum_offset.top, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, -2.0), snapshot.frustum_offset.left, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, 3.0), snapshot.frustum_offset.bottom, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, -4.0), snapshot.frustum_offset.right, 0.000001);
+
+    options = c.mln_map_viewport_options_default();
+    options.fields = c.MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION;
+    options.north_orientation = c.MLN_NORTH_ORIENTATION_DOWN;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_viewport_options(map, &options));
+    snapshot = c.mln_map_viewport_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_viewport_options(map, &snapshot));
+    try testing.expectEqual(@as(u32, c.MLN_NORTH_ORIENTATION_DOWN), snapshot.north_orientation);
+    try testing.expectEqual(@as(u32, c.MLN_CONSTRAIN_MODE_WIDTH_AND_HEIGHT), snapshot.constrain_mode);
+}
+
+test "map viewport options reject invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_viewport_options(map, null));
+
+    var options = c.mln_map_viewport_options_default();
+    options.size = @sizeOf(c.mln_map_viewport_options) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_viewport_options(map, &options));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, &options));
+
+    options = c.mln_map_viewport_options_default();
+    options.fields = @as(u32, 1) << 31;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, &options));
+
+    options = c.mln_map_viewport_options_default();
+    options.fields = c.MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION;
+    options.north_orientation = 99;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, &options));
+
+    options = c.mln_map_viewport_options_default();
+    options.fields = c.MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE;
+    options.constrain_mode = 99;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, &options));
+
+    options = c.mln_map_viewport_options_default();
+    options.fields = c.MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE;
+    options.viewport_mode = 99;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, &options));
+
+    options = c.mln_map_viewport_options_default();
+    options.fields = c.MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET;
+    options.frustum_offset.top = std.math.inf(f64);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_viewport_options(map, &options));
+}
+
+test "map tile options update selected fields" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var options = c.mln_map_tile_options_default();
+    options.fields = c.MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA |
+        c.MLN_MAP_TILE_OPTION_LOD_MIN_RADIUS |
+        c.MLN_MAP_TILE_OPTION_LOD_SCALE |
+        c.MLN_MAP_TILE_OPTION_LOD_PITCH_THRESHOLD |
+        c.MLN_MAP_TILE_OPTION_LOD_ZOOM_SHIFT |
+        c.MLN_MAP_TILE_OPTION_LOD_MODE;
+    options.prefetch_zoom_delta = 2;
+    options.lod_min_radius = 1.5;
+    options.lod_scale = 2.5;
+    options.lod_pitch_threshold = 0.75;
+    options.lod_zoom_shift = -1.0;
+    options.lod_mode = c.MLN_TILE_LOD_MODE_DISTANCE;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_tile_options(map, &options));
+
+    var snapshot = c.mln_map_tile_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_tile_options(map, &snapshot));
+    try testing.expect((snapshot.fields & c.MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA) != 0);
+    try testing.expect((snapshot.fields & c.MLN_MAP_TILE_OPTION_LOD_MODE) != 0);
+    try testing.expectEqual(@as(u32, 2), snapshot.prefetch_zoom_delta);
+    try testing.expectApproxEqAbs(@as(f64, 1.5), snapshot.lod_min_radius, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, 2.5), snapshot.lod_scale, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, 0.75), snapshot.lod_pitch_threshold, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, -1.0), snapshot.lod_zoom_shift, 0.000001);
+    try testing.expectEqual(@as(u32, c.MLN_TILE_LOD_MODE_DISTANCE), snapshot.lod_mode);
+
+    options = c.mln_map_tile_options_default();
+    options.fields = c.MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA;
+    options.prefetch_zoom_delta = 7;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_tile_options(map, &options));
+    snapshot = c.mln_map_tile_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_tile_options(map, &snapshot));
+    try testing.expectEqual(@as(u32, 7), snapshot.prefetch_zoom_delta);
+    try testing.expectEqual(@as(u32, c.MLN_TILE_LOD_MODE_DISTANCE), snapshot.lod_mode);
+}
+
+test "map tile options reject invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_tile_options(map, null));
+
+    var options = c.mln_map_tile_options_default();
+    options.size = @sizeOf(c.mln_map_tile_options) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_tile_options(map, &options));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_tile_options(map, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_tile_options(map, &options));
+
+    options = c.mln_map_tile_options_default();
+    options.fields = @as(u32, 1) << 31;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_tile_options(map, &options));
+
+    options = c.mln_map_tile_options_default();
+    options.fields = c.MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA;
+    options.prefetch_zoom_delta = 256;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_tile_options(map, &options));
+
+    options = c.mln_map_tile_options_default();
+    options.fields = c.MLN_MAP_TILE_OPTION_LOD_SCALE;
+    options.lod_scale = std.math.nan(f64);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_tile_options(map, &options));
+
+    options = c.mln_map_tile_options_default();
+    options.fields = c.MLN_MAP_TILE_OPTION_LOD_MODE;
+    options.lod_mode = 99;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_tile_options(map, &options));
+}


### PR DESCRIPTION
## Summary
- Add map-level debug, rendering stats, fully-loaded, and debug-log C APIs.
- Add grouped viewport and tile tuning option structs with size/field-mask validation.
- Cover the new public C ABI with Zig import, round-trip, and invalid-argument tests.

## Testing
- `mise run test`

Closes #28