### PR TITLE
Add tile-pyramid offline region APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ API coverage tracks MapLibre Native domains exposed through the C API.
 | Expressions, filters  | ❌       | [#30](https://github.com/sargunv/maplibre-native-ffi/issues/30)                                                                                                                                                                                                   |
 | Sources, layers       | ❌       | [#29](https://github.com/sargunv/maplibre-native-ffi/issues/29), [#31](https://github.com/sargunv/maplibre-native-ffi/issues/31), [#33](https://github.com/sargunv/maplibre-native-ffi/issues/33)-[#36](https://github.com/sargunv/maplibre-native-ffi/issues/36) |
 | Feature state         | ❌       | [#27](https://github.com/sargunv/maplibre-native-ffi/issues/27)                                                                                                                                                                                                   |
-| Offline regions       | ❌       | [#13](https://github.com/sargunv/maplibre-native-ffi/issues/13)                                                                                                                                                                                                   |
+| Offline regions       | 🟡       | [#13](https://github.com/sargunv/maplibre-native-ffi/issues/13)                                                                                                                                                                                                   |
 
 Language binding support tracks low-level bindings intended to sit directly
 above the C API. No bindings are implemented yet.

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -19,6 +19,7 @@
 
 // NOLINTBEGIN(cppcoreguidelines-use-enum-class)
 // NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
 // NOLINTBEGIN(modernize-deprecated-headers)
 // NOLINTBEGIN(modernize-use-trailing-return-type)
 // NOLINTBEGIN(modernize-use-using)
@@ -71,6 +72,8 @@ typedef enum mln_status : int32_t {
 typedef struct mln_runtime mln_runtime;
 typedef struct mln_map mln_map;
 typedef struct mln_map_projection mln_map_projection;
+typedef struct mln_offline_region_snapshot mln_offline_region_snapshot;
+typedef struct mln_offline_region_list mln_offline_region_list;
 typedef struct mln_resource_request_handle mln_resource_request_handle;
 typedef struct mln_render_session mln_render_session;
 
@@ -218,6 +221,18 @@ typedef enum mln_ambient_cache_operation : uint32_t {
   MLN_AMBIENT_CACHE_OPERATION_INVALIDATE = 3,
   MLN_AMBIENT_CACHE_OPERATION_CLEAR = 4,
 } mln_ambient_cache_operation;
+
+typedef int64_t mln_offline_region_id;
+
+typedef enum mln_offline_region_definition_type : uint32_t {
+  MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID = 1,
+  MLN_OFFLINE_REGION_DEFINITION_GEOMETRY = 2,
+} mln_offline_region_definition_type;
+
+typedef enum mln_offline_region_download_state : uint32_t {
+  MLN_OFFLINE_REGION_DOWNLOAD_INACTIVE = 0,
+  MLN_OFFLINE_REGION_DOWNLOAD_ACTIVE = 1,
+} mln_offline_region_download_state;
 
 /** Runtime event types returned by mln_runtime_poll_event(). */
 typedef enum mln_runtime_event_type : uint32_t {
@@ -891,6 +906,249 @@ typedef struct mln_lat_lng {
   /** Longitude in degrees. Input longitude must be finite. */
   double longitude;
 } mln_lat_lng;
+
+/** Geographic bounds in degrees. */
+typedef struct mln_lat_lng_bounds {
+  mln_lat_lng southwest;
+  mln_lat_lng northeast;
+} mln_lat_lng_bounds;
+
+/** Tile-pyramid offline region definition. */
+typedef struct mln_offline_tile_pyramid_region_definition {
+  uint32_t size;
+  /** Style URL. Copied during region creation. */
+  const char* style_url;
+  mln_lat_lng_bounds bounds;
+  double min_zoom;
+  double max_zoom;
+  float pixel_ratio;
+  bool include_ideographs;
+} mln_offline_tile_pyramid_region_definition;
+
+/** Placeholder for future geometry offline region definitions. */
+typedef struct mln_offline_geometry_region_definition {
+  uint32_t size;
+} mln_offline_geometry_region_definition;
+
+/** Tagged offline region definition. */
+typedef struct mln_offline_region_definition {
+  uint32_t size;
+  /** One of mln_offline_region_definition_type. */
+  uint32_t type;
+  union {
+    mln_offline_tile_pyramid_region_definition tile_pyramid;
+    mln_offline_geometry_region_definition geometry;
+  } data;
+} mln_offline_region_definition;
+
+/** Offline region status snapshot. */
+typedef struct mln_offline_region_status {
+  uint32_t size;
+  /** One of mln_offline_region_download_state. */
+  uint32_t download_state;
+  uint64_t completed_resource_count;
+  uint64_t completed_resource_size;
+  uint64_t completed_tile_count;
+  uint64_t required_tile_count;
+  uint64_t completed_tile_size;
+  uint64_t required_resource_count;
+  bool required_resource_count_is_precise;
+  bool complete;
+} mln_offline_region_status;
+
+/** Region data borrowed from a snapshot or list handle. */
+typedef struct mln_offline_region_info {
+  uint32_t size;
+  mln_offline_region_id id;
+  mln_offline_region_definition definition;
+  /** Borrowed metadata bytes. Valid until the owner snapshot/list is destroyed.
+   */
+  const uint8_t* metadata;
+  size_t metadata_size;
+} mln_offline_region_info;
+
+/**
+ * Creates a tile-pyramid offline region.
+ *
+ * The returned snapshot owns copied region data. Destroy it with
+ * mln_offline_region_snapshot_destroy(). Geometry definitions are reserved for
+ * future shared geometry ABI support and return MLN_STATUS_UNSUPPORTED.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, definition is
+ *   null or invalid, metadata is null with a non-zero size, out_region is null,
+ *   or *out_region is not null.
+ * - MLN_STATUS_UNSUPPORTED when definition is a geometry region.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
+ *   is converted to status.
+ */
+MLN_API mln_status mln_runtime_offline_region_create(
+  mln_runtime* runtime, const mln_offline_region_definition* definition,
+  const uint8_t* metadata, size_t metadata_size,
+  mln_offline_region_snapshot** out_region
+) MLN_NOEXCEPT;
+
+/**
+ * Gets an offline region snapshot by ID.
+ *
+ * On success, out_found indicates whether the region exists. When out_found is
+ * false, *out_region remains null.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, out_region is
+ *   null, *out_region is not null, or out_found is null.
+ * - MLN_STATUS_UNSUPPORTED when the stored region uses a geometry definition.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
+ *   is converted to status.
+ */
+MLN_API mln_status mln_runtime_offline_region_get(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  mln_offline_region_snapshot** out_region, bool* out_found
+) MLN_NOEXCEPT;
+
+/**
+ * Lists offline region snapshots in the runtime database.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live,
+ *   out_regions is null, or *out_regions is not null.
+ * - MLN_STATUS_UNSUPPORTED when any stored region uses a geometry definition.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
+ *   is converted to status.
+ */
+MLN_API mln_status mln_runtime_offline_regions_list(
+  mln_runtime* runtime, mln_offline_region_list** out_regions
+) MLN_NOEXCEPT;
+
+/**
+ * Updates opaque binary metadata for an offline region.
+ *
+ * The returned snapshot contains the updated metadata.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, metadata is
+ *   null with a non-zero size, out_region is null, *out_region is not null, or
+ *   no region exists for id.
+ * - MLN_STATUS_UNSUPPORTED when the stored region uses a geometry definition.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
+ *   is converted to status.
+ */
+MLN_API mln_status mln_runtime_offline_region_update_metadata(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  const uint8_t* metadata, size_t metadata_size,
+  mln_offline_region_snapshot** out_region
+) MLN_NOEXCEPT;
+
+/**
+ * Gets the current completed/download status for an offline region.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, out_status is
+ *   null, out_status->size is too small, or no region exists for id.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
+ *   is converted to status.
+ */
+MLN_API mln_status mln_runtime_offline_region_get_status(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  mln_offline_region_status* out_status
+) MLN_NOEXCEPT;
+
+/**
+ * Invalidates cached resources for an offline region.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, or no region
+ *   exists for id.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
+ *   is converted to status.
+ */
+MLN_API mln_status mln_runtime_offline_region_invalidate(
+  mln_runtime* runtime, mln_offline_region_id region_id
+) MLN_NOEXCEPT;
+
+/**
+ * Deletes an offline region.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, or no region
+ *   exists for id.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
+ *   is converted to status.
+ */
+MLN_API mln_status mln_runtime_offline_region_delete(
+  mln_runtime* runtime, mln_offline_region_id region_id
+) MLN_NOEXCEPT;
+
+/**
+ * Copies borrowed region data out of a snapshot handle.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when snapshot is null or not live, out_info is
+ *   null, or out_info->size is too small.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_offline_region_snapshot_get(
+  const mln_offline_region_snapshot* snapshot, mln_offline_region_info* out_info
+) MLN_NOEXCEPT;
+
+/** Destroys an offline region snapshot handle. Null is accepted as a no-op. */
+MLN_API void mln_offline_region_snapshot_destroy(
+  mln_offline_region_snapshot* snapshot
+) MLN_NOEXCEPT;
+
+/**
+ * Gets the number of regions in a list handle.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when list is null or not live, or out_count is
+ *   null.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_offline_region_list_count(
+  const mln_offline_region_list* list, size_t* out_count
+) MLN_NOEXCEPT;
+
+/**
+ * Copies borrowed region data for one list entry.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when list is null or not live, index is out of
+ *   range, out_info is null, or out_info->size is too small.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_offline_region_list_get(
+  const mln_offline_region_list* list, size_t index,
+  mln_offline_region_info* out_info
+) MLN_NOEXCEPT;
+
+/** Destroys an offline region list handle. Null is accepted as a no-op. */
+MLN_API void mln_offline_region_list_destroy(
+  mln_offline_region_list* list
+) MLN_NOEXCEPT;
 
 /** Screen-space point in logical map pixels. */
 typedef struct mln_screen_point {
@@ -2351,6 +2609,7 @@ MLN_API mln_status mln_vulkan_owned_texture_release_frame(
 // NOLINTEND(modernize-use-using)
 // NOLINTEND(modernize-use-trailing-return-type)
 // NOLINTEND(modernize-deprecated-headers)
+// NOLINTEND(cppcoreguidelines-pro-type-union-access)
 // NOLINTEND(cppcoreguidelines-pro-type-member-init)
 // NOLINTEND(cppcoreguidelines-use-enum-class)
 

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -920,6 +920,10 @@ typedef struct mln_offline_tile_pyramid_region_definition {
   const char* style_url;
   mln_lat_lng_bounds bounds;
   double min_zoom;
+  /**
+   * Maximum zoom. Positive infinity follows MapLibre Native behavior and lets
+   * each tile source use its own maximum zoom.
+   */
   double max_zoom;
   float pixel_ratio;
   bool include_ideographs;

--- a/offline-regions-api-design.tmp.md
+++ b/offline-regions-api-design.tmp.md
@@ -1,0 +1,97 @@
+# Offline Region C API Design
+
+This temporary design note is for contributors adding the first C ABI slice of
+MapLibre Native offline region management. It records the API boundary before
+implementation so the initial patch can stay focused on tile-pyramid regions.
+
+## Scope
+
+The first slice exposes tile-pyramid offline regions through the runtime. It
+does not expose geometry regions yet. Geometry region creation returns
+`MLN_STATUS_UNSUPPORTED` until the shared geometry/value ABI is designed in
+[#19](https://github.com/sargunv/maplibre-native-ffi/issues/19).
+
+The API uses runtime-owned event delivery because offline downloads are
+runtime-level operations. The prerequisite runtime event model was tracked in
+[#14](https://github.com/sargunv/maplibre-native-ffi/issues/14). Offline region
+coverage is tracked in
+[#13](https://github.com/sargunv/maplibre-native-ffi/issues/13).
+
+## Native References
+
+MapLibre Native provides the lower-level building blocks:
+
+- `mbgl::OfflineTilePyramidRegionDefinition`,
+  `mbgl::OfflineGeometryRegionDefinition`, `mbgl::OfflineRegionDefinition`,
+  `mbgl::OfflineRegionMetadata`, `mbgl::OfflineRegionStatus`,
+  `mbgl::OfflineRegionObserver`, and `mbgl::OfflineRegion` in
+  `third_party/maplibre-native/include/mbgl/storage/offline.hpp`.
+- `mbgl::DatabaseFileSource` asynchronous offline methods in
+  `third_party/maplibre-native/include/mbgl/storage/database_file_source.hpp`.
+- Default-platform database and download implementations in
+  `third_party/maplibre-native/platform/default/include/mbgl/storage/offline_database.hpp`
+  and
+  `third_party/maplibre-native/platform/default/include/mbgl/storage/offline_download.hpp`.
+
+## Public Model
+
+Offline management is a runtime feature. Region commands take an `mln_runtime*`,
+validate the runtime owner thread, and block until MapLibre's database callback
+reports completion when the native operation is asynchronous.
+
+Regions are addressed by stable `int64_t` IDs instead of live handles. Returned
+region data uses snapshot/list handles that own copied native values. Borrowed
+strings and metadata pointers inside a snapshot or list remain valid until that
+snapshot or list is destroyed.
+
+This avoids implying that a public region handle stays attached to live native
+download state. Download control uses the runtime plus region ID.
+
+## ABI Shape
+
+The public types should include:
+
+- `mln_offline_region_id` as `int64_t`;
+- `mln_offline_region_definition_type` with tile-pyramid and geometry values;
+- `mln_offline_region_download_state` with inactive and active values;
+- `mln_lat_lng_bounds` for tile-pyramid bounds;
+- `mln_offline_tile_pyramid_region_definition`;
+- `mln_offline_region_definition`, tagged by definition type;
+- `mln_offline_region_status` mirroring `mbgl::OfflineRegionStatus`;
+- opaque `mln_offline_region_snapshot` and `mln_offline_region_list` handles;
+- `mln_offline_region_info` for copied region data borrowed from those handles.
+
+The first implementation validates tile-pyramid definitions and returns
+`MLN_STATUS_UNSUPPORTED` for geometry definitions. A TODO comment in the
+geometry branch should point to
+`https://github.com/sargunv/maplibre-native-ffi/issues/19`.
+
+## Operations
+
+The first slice should expose database operations that can be validated without
+network downloads:
+
+- create a tile-pyramid offline region with opaque binary metadata;
+- get a region by ID;
+- list regions;
+- update metadata;
+- get completed status;
+- invalidate a region;
+- delete a region.
+
+`mergeDatabase` and active download control can be added after the basic storage
+surface is covered. Download progress/error events should use
+`mln_runtime_poll_event()` rather than host callbacks.
+
+## Validation
+
+C ABI tests should cover:
+
+- validation failures for null pointers, unknown definition types, undersized
+  structs, invalid zooms, invalid bounds, and unsupported geometry;
+- create/list/get/update metadata through a persistent cache path;
+- reload from the same cache path in a new runtime;
+- completed-status query for a newly-created region;
+- invalidate and delete operations.
+
+Use `mise run test` for the final verification pass.

--- a/src/c_api/runtime.cpp
+++ b/src/c_api/runtime.cpp
@@ -1,5 +1,6 @@
 #define MLN_BUILDING_C
 
+#include <cstddef>
 #include <cstdint>
 
 #include "runtime/runtime.hpp"
@@ -69,6 +70,110 @@ auto mln_runtime_run_ambient_cache_operation(
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::run_ambient_cache_operation(runtime, operation);
   });
+}
+
+auto mln_runtime_offline_region_create(
+  mln_runtime* runtime, const mln_offline_region_definition* definition,
+  const uint8_t* metadata, size_t metadata_size,
+  mln_offline_region_snapshot** out_region
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_create(
+      runtime, definition, metadata, metadata_size, out_region
+    );
+  });
+}
+
+auto mln_runtime_offline_region_get(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  mln_offline_region_snapshot** out_region, bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_get(
+      runtime, region_id, out_region, out_found
+    );
+  });
+}
+
+auto mln_runtime_offline_regions_list(
+  mln_runtime* runtime, mln_offline_region_list** out_regions
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_regions_list(runtime, out_regions);
+  });
+}
+
+auto mln_runtime_offline_region_update_metadata(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  const uint8_t* metadata, size_t metadata_size,
+  mln_offline_region_snapshot** out_region
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_update_metadata(
+      runtime, region_id, metadata, metadata_size, out_region
+    );
+  });
+}
+
+auto mln_runtime_offline_region_get_status(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  mln_offline_region_status* out_status
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_get_status(runtime, region_id, out_status);
+  });
+}
+
+auto mln_runtime_offline_region_invalidate(
+  mln_runtime* runtime, mln_offline_region_id region_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_invalidate(runtime, region_id);
+  });
+}
+
+auto mln_runtime_offline_region_delete(
+  mln_runtime* runtime, mln_offline_region_id region_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_delete(runtime, region_id);
+  });
+}
+
+auto mln_offline_region_snapshot_get(
+  const mln_offline_region_snapshot* snapshot, mln_offline_region_info* out_info
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_snapshot_get(snapshot, out_info);
+  });
+}
+
+auto mln_offline_region_snapshot_destroy(
+  mln_offline_region_snapshot* snapshot
+) noexcept -> void {
+  mln::core::offline_region_snapshot_destroy(snapshot);
+}
+
+auto mln_offline_region_list_count(
+  const mln_offline_region_list* list, size_t* out_count
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_list_count(list, out_count);
+  });
+}
+
+auto mln_offline_region_list_get(
+  const mln_offline_region_list* list, size_t index,
+  mln_offline_region_info* out_info
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::offline_region_list_get(list, index, out_info);
+  });
+}
+
+auto mln_offline_region_list_destroy(mln_offline_region_list* list) noexcept
+  -> void {
+  mln::core::offline_region_list_destroy(list);
 }
 
 auto mln_runtime_destroy(mln_runtime* runtime) noexcept -> mln_status {

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -342,32 +342,33 @@ auto register_offline_region_list(std::vector<OfflineRegionData> regions)
   return handle;
 }
 
-auto validate_snapshot_handle(const mln_offline_region_snapshot* snapshot)
-  -> const mln_offline_region_snapshot* {
+auto find_offline_region_snapshot_locked(
+  const mln_offline_region_snapshot* snapshot
+) -> const mln_offline_region_snapshot* {
   if (snapshot == nullptr) {
     mln::core::set_thread_error("offline region snapshot must not be null");
     return nullptr;
   }
-  const std::scoped_lock lock(offline_region_handle_mutex());
-  if (!offline_region_snapshots().contains(snapshot)) {
+  const auto found = offline_region_snapshots().find(snapshot);
+  if (found == offline_region_snapshots().end()) {
     mln::core::set_thread_error("offline region snapshot is not a live handle");
     return nullptr;
   }
-  return snapshot;
+  return found->second.get();
 }
 
-auto validate_list_handle(const mln_offline_region_list* list)
+auto find_offline_region_list_locked(const mln_offline_region_list* list)
   -> const mln_offline_region_list* {
   if (list == nullptr) {
     mln::core::set_thread_error("offline region list must not be null");
     return nullptr;
   }
-  const std::scoped_lock lock(offline_region_handle_mutex());
-  if (!offline_region_lists().contains(list)) {
+  const auto found = offline_region_lists().find(list);
+  if (found == offline_region_lists().end()) {
     mln::core::set_thread_error("offline region list is not a live handle");
     return nullptr;
   }
-  return list;
+  return found->second.get();
 }
 
 auto validate_runtime_options(const mln_runtime_options* options)
@@ -1001,7 +1002,8 @@ auto offline_region_delete(
 auto offline_region_snapshot_get(
   const mln_offline_region_snapshot* snapshot, mln_offline_region_info* out_info
 ) -> mln_status {
-  const auto* live_snapshot = validate_snapshot_handle(snapshot);
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  const auto* live_snapshot = find_offline_region_snapshot_locked(snapshot);
   if (live_snapshot == nullptr) {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
@@ -1021,7 +1023,8 @@ auto offline_region_snapshot_destroy(
 auto offline_region_list_count(
   const mln_offline_region_list* list, size_t* out_count
 ) -> mln_status {
-  const auto* live_list = validate_list_handle(list);
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  const auto* live_list = find_offline_region_list_locked(list);
   if (live_list == nullptr) {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
@@ -1037,7 +1040,8 @@ auto offline_region_list_get(
   const mln_offline_region_list* list, size_t index,
   mln_offline_region_info* out_info
 ) -> mln_status {
-  const auto* live_list = validate_list_handle(list);
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  const auto* live_list = find_offline_region_list_locked(list);
   if (live_list == nullptr) {
     return MLN_STATUS_INVALID_ARGUMENT;
   }

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -7,24 +8,51 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/storage/database_file_source.hpp>
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/file_source_manager.hpp>
+#include <mbgl/storage/offline.hpp>
 #include <mbgl/storage/resource_options.hpp>
 #include <mbgl/util/client_options.hpp>
+#include <mbgl/util/expected.hpp>
+#include <mbgl/util/geo.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 #include "runtime/runtime.hpp"
 
 #include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
+
+// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
+
+struct OfflineRegionData {
+  mln_offline_region_id id = 0;
+  uint32_t definition_type = 0;
+  std::string style_url;
+  mln_lat_lng_bounds bounds{};
+  double min_zoom = 0.0;
+  double max_zoom = 0.0;
+  float pixel_ratio = 0.0F;
+  bool include_ideographs = false;
+  std::vector<uint8_t> metadata;
+};
+
+struct mln_offline_region_snapshot {
+  OfflineRegionData data;
+};
+
+struct mln_offline_region_list {
+  std::vector<OfflineRegionData> regions;
+};
 
 namespace {
 using RuntimeRegistry =
@@ -38,6 +66,308 @@ auto runtime_registry_mutex() -> std::mutex& {
 auto runtime_registry() -> RuntimeRegistry& {
   static RuntimeRegistry value;
   return value;
+}
+
+using OfflineRegionSnapshotRegistry = std::unordered_map<
+  const mln_offline_region_snapshot*,
+  std::unique_ptr<mln_offline_region_snapshot>>;
+using OfflineRegionListRegistry = std::unordered_map<
+  const mln_offline_region_list*, std::unique_ptr<mln_offline_region_list>>;
+
+auto offline_region_handle_mutex() -> std::mutex& {
+  static std::mutex value;
+  return value;
+}
+
+auto offline_region_snapshots() -> OfflineRegionSnapshotRegistry& {
+  static OfflineRegionSnapshotRegistry value;
+  return value;
+}
+
+auto offline_region_lists() -> OfflineRegionListRegistry& {
+  static OfflineRegionListRegistry value;
+  return value;
+}
+
+auto set_status_from_exception(
+  std::exception_ptr exception, const char* fallback_message
+) -> mln_status {
+  if (exception) {
+    try {
+      std::rethrow_exception(exception);
+    } catch (const std::exception& caught) {
+      mln::core::set_thread_error(caught.what());
+    } catch (...) {
+      mln::core::set_thread_error(fallback_message);
+    }
+  } else {
+    mln::core::set_thread_error(fallback_message);
+  }
+  return MLN_STATUS_NATIVE_ERROR;
+}
+
+template <typename Result, typename Start>
+auto wait_for_database_result(Start start) -> Result {
+  auto mutex = std::mutex{};
+  auto condition = std::condition_variable{};
+  auto result = std::optional<Result>{};
+
+  start([&](Result value) -> void {
+    {
+      const std::scoped_lock lock(mutex);
+      result.emplace(std::move(value));
+    }
+    condition.notify_one();
+  });
+
+  auto lock = std::unique_lock{mutex};
+  condition.wait(lock, [&]() -> bool { return result.has_value(); });
+  if (!result.has_value()) {
+    std::terminate();
+  }
+  return std::move(result.value());
+}
+
+auto valid_coordinate(const mln_lat_lng& coordinate) -> bool {
+  return std::isfinite(coordinate.latitude) && coordinate.latitude >= -90.0 &&
+         coordinate.latitude <= 90.0 && std::isfinite(coordinate.longitude);
+}
+
+auto validate_tile_pyramid_definition(
+  const mln_offline_tile_pyramid_region_definition& definition
+) -> mln_status {
+  if (definition.size < sizeof(mln_offline_tile_pyramid_region_definition)) {
+    mln::core::set_thread_error(
+      "mln_offline_tile_pyramid_region_definition.size is too small"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (definition.style_url == nullptr) {
+    mln::core::set_thread_error("offline region style_url must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    !valid_coordinate(definition.bounds.southwest) ||
+    !valid_coordinate(definition.bounds.northeast) ||
+    definition.bounds.southwest.latitude >
+      definition.bounds.northeast.latitude ||
+    definition.bounds.southwest.longitude >
+      definition.bounds.northeast.longitude
+  ) {
+    mln::core::set_thread_error("offline region bounds are invalid");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    !std::isfinite(definition.min_zoom) || definition.min_zoom < 0.0 ||
+    std::isnan(definition.max_zoom) || definition.max_zoom < definition.min_zoom
+  ) {
+    mln::core::set_thread_error("offline region zoom range is invalid");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!std::isfinite(definition.pixel_ratio) || definition.pixel_ratio < 0.0F) {
+    mln::core::set_thread_error("offline region pixel_ratio is invalid");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_offline_region_definition(
+  const mln_offline_region_definition* definition
+) -> mln_status {
+  if (definition == nullptr) {
+    mln::core::set_thread_error("offline region definition must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (definition->size < sizeof(mln_offline_region_definition)) {
+    mln::core::set_thread_error(
+      "mln_offline_region_definition.size is too small"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  switch (definition->type) {
+    case MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID:
+      return validate_tile_pyramid_definition(definition->data.tile_pyramid);
+    case MLN_OFFLINE_REGION_DEFINITION_GEOMETRY:
+      // TODO: Support geometry regions after the shared geometry ABI lands:
+      // https://github.com/sargunv/maplibre-native-ffi/issues/19
+      mln::core::set_thread_error(
+        "offline geometry region definitions are not supported"
+      );
+      return MLN_STATUS_UNSUPPORTED;
+    default:
+      mln::core::set_thread_error("offline region definition type is invalid");
+      return MLN_STATUS_INVALID_ARGUMENT;
+  }
+}
+
+auto to_native_offline_region_definition(
+  const mln_offline_region_definition& definition
+) -> mbgl::OfflineRegionDefinition {
+  const auto& tile = definition.data.tile_pyramid;
+  auto bounds = mbgl::LatLngBounds::hull(
+    {tile.bounds.southwest.latitude, tile.bounds.southwest.longitude},
+    {tile.bounds.northeast.latitude, tile.bounds.northeast.longitude}
+  );
+  return mbgl::OfflineTilePyramidRegionDefinition{
+    std::string{tile.style_url},
+    bounds,
+    tile.min_zoom,
+    tile.max_zoom,
+    tile.pixel_ratio,
+    tile.include_ideographs
+  };
+}
+
+auto to_c_download_state(mbgl::OfflineRegionDownloadState state) -> uint32_t {
+  switch (state) {
+    case mbgl::OfflineRegionDownloadState::Inactive:
+      return MLN_OFFLINE_REGION_DOWNLOAD_INACTIVE;
+    case mbgl::OfflineRegionDownloadState::Active:
+      return MLN_OFFLINE_REGION_DOWNLOAD_ACTIVE;
+  }
+  return MLN_OFFLINE_REGION_DOWNLOAD_INACTIVE;
+}
+
+auto to_c_status(const mbgl::OfflineRegionStatus& status)
+  -> mln_offline_region_status {
+  return mln_offline_region_status{
+    .size = sizeof(mln_offline_region_status),
+    .download_state = to_c_download_state(status.downloadState),
+    .completed_resource_count = status.completedResourceCount,
+    .completed_resource_size = status.completedResourceSize,
+    .completed_tile_count = status.completedTileCount,
+    .required_tile_count = status.requiredTileCount,
+    .completed_tile_size = status.completedTileSize,
+    .required_resource_count = status.requiredResourceCount,
+    .required_resource_count_is_precise = status.requiredResourceCountIsPrecise,
+    .complete = status.complete()
+  };
+}
+
+auto to_c_region_data(const mbgl::OfflineRegion& region)
+  -> std::optional<OfflineRegionData> {
+  auto data = OfflineRegionData{
+    .id = region.getID(),
+    .definition_type = MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID,
+    .style_url = {},
+    .bounds = {},
+    .min_zoom = 0.0,
+    .max_zoom = 0.0,
+    .pixel_ratio = 0.0F,
+    .include_ideographs = false,
+    .metadata = region.getMetadata()
+  };
+
+  if (
+    const auto* tile = std::get_if<mbgl::OfflineTilePyramidRegionDefinition>(
+      &region.getDefinition()
+    )
+  ) {
+    data.style_url = tile->styleURL;
+    data.bounds = mln_lat_lng_bounds{
+      .southwest =
+        mln_lat_lng{
+          .latitude = tile->bounds.south(), .longitude = tile->bounds.west()
+        },
+      .northeast = mln_lat_lng{
+        .latitude = tile->bounds.north(), .longitude = tile->bounds.east()
+      }
+    };
+    data.min_zoom = tile->minZoom;
+    data.max_zoom = tile->maxZoom;
+    data.pixel_ratio = tile->pixelRatio;
+    data.include_ideographs = tile->includeIdeographs;
+    return data;
+  }
+
+  mln::core::set_thread_error(
+    "offline geometry region definitions are not supported"
+  );
+  return std::nullopt;
+}
+
+auto fill_region_info(
+  const OfflineRegionData& data, mln_offline_region_info* out_info
+) -> mln_status {
+  if (out_info == nullptr || out_info->size < sizeof(mln_offline_region_info)) {
+    mln::core::set_thread_error(
+      "out_info must not be null and must have a valid size"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_info = mln_offline_region_info{
+    .size = sizeof(mln_offline_region_info),
+    .id = data.id,
+    .definition =
+      mln_offline_region_definition{
+        .size = sizeof(mln_offline_region_definition),
+        .type = data.definition_type,
+        .data =
+          {.tile_pyramid =
+             mln_offline_tile_pyramid_region_definition{
+               .size = sizeof(mln_offline_tile_pyramid_region_definition),
+               .style_url = data.style_url.c_str(),
+               .bounds = data.bounds,
+               .min_zoom = data.min_zoom,
+               .max_zoom = data.max_zoom,
+               .pixel_ratio = data.pixel_ratio,
+               .include_ideographs = data.include_ideographs
+             }}
+      },
+    .metadata = data.metadata.empty() ? nullptr : data.metadata.data(),
+    .metadata_size = data.metadata.size()
+  };
+  return MLN_STATUS_OK;
+}
+
+auto register_offline_region_snapshot(OfflineRegionData data)
+  -> mln_offline_region_snapshot* {
+  auto owned = std::make_unique<mln_offline_region_snapshot>();
+  owned->data = std::move(data);
+  auto* handle = owned.get();
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  offline_region_snapshots().emplace(handle, std::move(owned));
+  return handle;
+}
+
+auto register_offline_region_list(std::vector<OfflineRegionData> regions)
+  -> mln_offline_region_list* {
+  auto owned = std::make_unique<mln_offline_region_list>();
+  owned->regions = std::move(regions);
+  auto* handle = owned.get();
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  offline_region_lists().emplace(handle, std::move(owned));
+  return handle;
+}
+
+auto validate_snapshot_handle(const mln_offline_region_snapshot* snapshot)
+  -> const mln_offline_region_snapshot* {
+  if (snapshot == nullptr) {
+    mln::core::set_thread_error("offline region snapshot must not be null");
+    return nullptr;
+  }
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  if (!offline_region_snapshots().contains(snapshot)) {
+    mln::core::set_thread_error("offline region snapshot is not a live handle");
+    return nullptr;
+  }
+  return snapshot;
+}
+
+auto validate_list_handle(const mln_offline_region_list* list)
+  -> const mln_offline_region_list* {
+  if (list == nullptr) {
+    mln::core::set_thread_error("offline region list must not be null");
+    return nullptr;
+  }
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  if (!offline_region_lists().contains(list)) {
+    mln::core::set_thread_error("offline region list is not a live handle");
+    return nullptr;
+  }
+  return list;
 }
 
 auto validate_runtime_options(const mln_runtime_options* options)
@@ -330,6 +660,403 @@ auto run_ambient_cache_operation(mln_runtime* runtime, uint32_t operation)
   }
 }
 
+auto offline_region_create(
+  mln_runtime* runtime, const mln_offline_region_definition* definition,
+  const uint8_t* metadata, size_t metadata_size,
+  mln_offline_region_snapshot** out_region
+) -> mln_status {
+  const auto runtime_status = validate_runtime(runtime);
+  if (runtime_status != MLN_STATUS_OK) {
+    return runtime_status;
+  }
+  const auto definition_status = validate_offline_region_definition(definition);
+  if (definition_status != MLN_STATUS_OK) {
+    return definition_status;
+  }
+  if (metadata == nullptr && metadata_size != 0) {
+    set_thread_error("offline region metadata must not be null when non-empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_region == nullptr || *out_region != nullptr) {
+    set_thread_error("out_region must point to a null handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto database = database_source_for_runtime(runtime);
+  if (database == nullptr) {
+    set_thread_error("database file source is unavailable");
+    return MLN_STATUS_NATIVE_ERROR;
+  }
+
+  const auto native_definition =
+    to_native_offline_region_definition(*definition);
+  auto native_metadata = mbgl::OfflineRegionMetadata{};
+  if (metadata_size != 0) {
+    native_metadata.resize(metadata_size);
+    std::memcpy(native_metadata.data(), metadata, metadata_size);
+  }
+  auto result = wait_for_database_result<
+    mbgl::expected<mbgl::OfflineRegion, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->createOfflineRegion(
+        native_definition, native_metadata, std::move(callback)
+      );
+    }
+  );
+  if (!result) {
+    return set_status_from_exception(
+      result.error(), "offline region creation failed"
+    );
+  }
+
+  auto data = to_c_region_data(result.value());
+  if (!data) {
+    return MLN_STATUS_UNSUPPORTED;
+  }
+  *out_region = register_offline_region_snapshot(std::move(*data));
+  return MLN_STATUS_OK;
+}
+
+auto offline_region_get(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  mln_offline_region_snapshot** out_region, bool* out_found
+) -> mln_status {
+  const auto runtime_status = validate_runtime(runtime);
+  if (runtime_status != MLN_STATUS_OK) {
+    return runtime_status;
+  }
+  if (out_region == nullptr || *out_region != nullptr || out_found == nullptr) {
+    set_thread_error(
+      "out_region must point to null and out_found must not be null"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto database = database_source_for_runtime(runtime);
+  if (database == nullptr) {
+    set_thread_error("database file source is unavailable");
+    return MLN_STATUS_NATIVE_ERROR;
+  }
+
+  auto result = wait_for_database_result<
+    mbgl::expected<std::optional<mbgl::OfflineRegion>, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->getOfflineRegion(region_id, std::move(callback));
+    }
+  );
+  if (!result) {
+    return set_status_from_exception(
+      result.error(), "offline region get failed"
+    );
+  }
+  if (!result.value()) {
+    *out_found = false;
+    return MLN_STATUS_OK;
+  }
+
+  auto data = to_c_region_data(*result.value());
+  if (!data) {
+    return MLN_STATUS_UNSUPPORTED;
+  }
+  *out_region = register_offline_region_snapshot(std::move(*data));
+  *out_found = true;
+  return MLN_STATUS_OK;
+}
+
+auto offline_regions_list(
+  mln_runtime* runtime, mln_offline_region_list** out_regions
+) -> mln_status {
+  const auto runtime_status = validate_runtime(runtime);
+  if (runtime_status != MLN_STATUS_OK) {
+    return runtime_status;
+  }
+  if (out_regions == nullptr || *out_regions != nullptr) {
+    set_thread_error("out_regions must point to a null handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto database = database_source_for_runtime(runtime);
+  if (database == nullptr) {
+    set_thread_error("database file source is unavailable");
+    return MLN_STATUS_NATIVE_ERROR;
+  }
+
+  auto result = wait_for_database_result<
+    mbgl::expected<mbgl::OfflineRegions, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->listOfflineRegions(std::move(callback));
+    }
+  );
+  if (!result) {
+    return set_status_from_exception(
+      result.error(), "offline region list failed"
+    );
+  }
+
+  auto regions = std::vector<OfflineRegionData>{};
+  regions.reserve(result.value().size());
+  for (const auto& region : result.value()) {
+    auto data = to_c_region_data(region);
+    if (!data) {
+      return MLN_STATUS_UNSUPPORTED;
+    }
+    regions.push_back(std::move(*data));
+  }
+  *out_regions = register_offline_region_list(std::move(regions));
+  return MLN_STATUS_OK;
+}
+
+auto offline_region_update_metadata(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  const uint8_t* metadata, size_t metadata_size,
+  mln_offline_region_snapshot** out_region
+) -> mln_status {
+  const auto runtime_status = validate_runtime(runtime);
+  if (runtime_status != MLN_STATUS_OK) {
+    return runtime_status;
+  }
+  if (metadata == nullptr && metadata_size != 0) {
+    set_thread_error("offline region metadata must not be null when non-empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_region == nullptr || *out_region != nullptr) {
+    set_thread_error("out_region must point to a null handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto database = database_source_for_runtime(runtime);
+  if (database == nullptr) {
+    set_thread_error("database file source is unavailable");
+    return MLN_STATUS_NATIVE_ERROR;
+  }
+
+  auto native_metadata = mbgl::OfflineRegionMetadata{};
+  if (metadata_size != 0) {
+    native_metadata.resize(metadata_size);
+    std::memcpy(native_metadata.data(), metadata, metadata_size);
+  }
+  auto update_result = wait_for_database_result<
+    mbgl::expected<mbgl::OfflineRegionMetadata, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->updateOfflineMetadata(
+        region_id, native_metadata, std::move(callback)
+      );
+    }
+  );
+  if (!update_result) {
+    return set_status_from_exception(
+      update_result.error(), "offline region metadata update failed"
+    );
+  }
+
+  auto get_result = wait_for_database_result<
+    mbgl::expected<std::optional<mbgl::OfflineRegion>, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->getOfflineRegion(region_id, std::move(callback));
+    }
+  );
+  if (!get_result) {
+    return set_status_from_exception(
+      get_result.error(), "offline region get failed"
+    );
+  }
+  if (!get_result.value()) {
+    set_thread_error("offline region not found");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto data = to_c_region_data(*get_result.value());
+  if (!data) {
+    return MLN_STATUS_UNSUPPORTED;
+  }
+  *out_region = register_offline_region_snapshot(std::move(*data));
+  return MLN_STATUS_OK;
+}
+
+auto offline_region_get_status(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  mln_offline_region_status* out_status
+) -> mln_status {
+  const auto runtime_status = validate_runtime(runtime);
+  if (runtime_status != MLN_STATUS_OK) {
+    return runtime_status;
+  }
+  if (
+    out_status == nullptr ||
+    out_status->size < sizeof(mln_offline_region_status)
+  ) {
+    set_thread_error("out_status must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto database = database_source_for_runtime(runtime);
+  if (database == nullptr) {
+    set_thread_error("database file source is unavailable");
+    return MLN_STATUS_NATIVE_ERROR;
+  }
+
+  auto get_result = wait_for_database_result<
+    mbgl::expected<std::optional<mbgl::OfflineRegion>, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->getOfflineRegion(region_id, std::move(callback));
+    }
+  );
+  if (!get_result) {
+    return set_status_from_exception(
+      get_result.error(), "offline region get failed"
+    );
+  }
+  if (!get_result.value()) {
+    set_thread_error("offline region not found");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto status_result = wait_for_database_result<
+    mbgl::expected<mbgl::OfflineRegionStatus, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->getOfflineRegionStatus(
+        *get_result.value(), std::move(callback)
+      );
+    }
+  );
+  if (!status_result) {
+    return set_status_from_exception(
+      status_result.error(), "offline region status query failed"
+    );
+  }
+  *out_status = to_c_status(status_result.value());
+  return MLN_STATUS_OK;
+}
+
+auto offline_region_invalidate(
+  mln_runtime* runtime, mln_offline_region_id region_id
+) -> mln_status {
+  const auto runtime_status = validate_runtime(runtime);
+  if (runtime_status != MLN_STATUS_OK) {
+    return runtime_status;
+  }
+
+  auto database = database_source_for_runtime(runtime);
+  if (database == nullptr) {
+    set_thread_error("database file source is unavailable");
+    return MLN_STATUS_NATIVE_ERROR;
+  }
+
+  auto get_result = wait_for_database_result<
+    mbgl::expected<std::optional<mbgl::OfflineRegion>, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->getOfflineRegion(region_id, std::move(callback));
+    }
+  );
+  if (!get_result) {
+    return set_status_from_exception(
+      get_result.error(), "offline region get failed"
+    );
+  }
+  if (!get_result.value()) {
+    set_thread_error("offline region not found");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  return wait_for_database_operation([&](auto callback) -> void {
+    database->invalidateOfflineRegion(*get_result.value(), std::move(callback));
+  });
+}
+
+auto offline_region_delete(
+  mln_runtime* runtime, mln_offline_region_id region_id
+) -> mln_status {
+  const auto runtime_status = validate_runtime(runtime);
+  if (runtime_status != MLN_STATUS_OK) {
+    return runtime_status;
+  }
+
+  auto database = database_source_for_runtime(runtime);
+  if (database == nullptr) {
+    set_thread_error("database file source is unavailable");
+    return MLN_STATUS_NATIVE_ERROR;
+  }
+
+  auto get_result = wait_for_database_result<
+    mbgl::expected<std::optional<mbgl::OfflineRegion>, std::exception_ptr>>(
+    [&](auto callback) -> void {
+      database->getOfflineRegion(region_id, std::move(callback));
+    }
+  );
+  if (!get_result) {
+    return set_status_from_exception(
+      get_result.error(), "offline region get failed"
+    );
+  }
+  if (!get_result.value()) {
+    set_thread_error("offline region not found");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  return wait_for_database_operation([&](auto callback) -> void {
+    database->deleteOfflineRegion(*get_result.value(), std::move(callback));
+  });
+}
+
+auto offline_region_snapshot_get(
+  const mln_offline_region_snapshot* snapshot, mln_offline_region_info* out_info
+) -> mln_status {
+  const auto* live_snapshot = validate_snapshot_handle(snapshot);
+  if (live_snapshot == nullptr) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return fill_region_info(live_snapshot->data, out_info);
+}
+
+auto offline_region_snapshot_destroy(
+  mln_offline_region_snapshot* snapshot
+) noexcept -> void {
+  if (snapshot == nullptr) {
+    return;
+  }
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  offline_region_snapshots().erase(snapshot);
+}
+
+auto offline_region_list_count(
+  const mln_offline_region_list* list, size_t* out_count
+) -> mln_status {
+  const auto* live_list = validate_list_handle(list);
+  if (live_list == nullptr) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_count == nullptr) {
+    set_thread_error("out_count must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_count = live_list->regions.size();
+  return MLN_STATUS_OK;
+}
+
+auto offline_region_list_get(
+  const mln_offline_region_list* list, size_t index,
+  mln_offline_region_info* out_info
+) -> mln_status {
+  const auto* live_list = validate_list_handle(list);
+  if (live_list == nullptr) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (index >= live_list->regions.size()) {
+    set_thread_error("offline region list index is out of range");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return fill_region_info(live_list->regions.at(index), out_info);
+}
+
+auto offline_region_list_destroy(mln_offline_region_list* list) noexcept
+  -> void {
+  if (list == nullptr) {
+    return;
+  }
+  const std::scoped_lock lock(offline_region_handle_mutex());
+  offline_region_lists().erase(list);
+}
+
 auto set_resource_provider(
   mln_runtime* runtime, const mln_resource_provider* provider
 ) -> mln_status {
@@ -610,3 +1337,5 @@ auto discard_runtime_map_events(mln_runtime* runtime, const mln_map* map)
 }
 
 }  // namespace mln::core
+
+// NOLINTEND(cppcoreguidelines-pro-type-union-access)

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -74,6 +74,48 @@ auto set_resource_transform(
 ) -> mln_status;
 auto run_ambient_cache_operation(mln_runtime* runtime, uint32_t operation)
   -> mln_status;
+auto offline_region_create(
+  mln_runtime* runtime, const mln_offline_region_definition* definition,
+  const uint8_t* metadata, size_t metadata_size,
+  mln_offline_region_snapshot** out_region
+) -> mln_status;
+auto offline_region_get(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  mln_offline_region_snapshot** out_region, bool* out_found
+) -> mln_status;
+auto offline_regions_list(
+  mln_runtime* runtime, mln_offline_region_list** out_regions
+) -> mln_status;
+auto offline_region_update_metadata(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  const uint8_t* metadata, size_t metadata_size,
+  mln_offline_region_snapshot** out_region
+) -> mln_status;
+auto offline_region_get_status(
+  mln_runtime* runtime, mln_offline_region_id region_id,
+  mln_offline_region_status* out_status
+) -> mln_status;
+auto offline_region_invalidate(
+  mln_runtime* runtime, mln_offline_region_id region_id
+) -> mln_status;
+auto offline_region_delete(
+  mln_runtime* runtime, mln_offline_region_id region_id
+) -> mln_status;
+auto offline_region_snapshot_get(
+  const mln_offline_region_snapshot* snapshot, mln_offline_region_info* out_info
+) -> mln_status;
+auto offline_region_snapshot_destroy(
+  mln_offline_region_snapshot* snapshot
+) noexcept -> void;
+auto offline_region_list_count(
+  const mln_offline_region_list* list, size_t* out_count
+) -> mln_status;
+auto offline_region_list_get(
+  const mln_offline_region_list* list, size_t index,
+  mln_offline_region_info* out_info
+) -> mln_status;
+auto offline_region_list_destroy(mln_offline_region_list* list) noexcept
+  -> void;
 auto retain_runtime_map(mln_runtime* runtime) -> mln_status;
 auto release_runtime_map(mln_runtime* runtime) noexcept -> void;
 auto validate_runtime(mln_runtime* runtime) -> mln_status;

--- a/tests/c/resources.zig
+++ b/tests/c/resources.zig
@@ -702,6 +702,14 @@ test "offline tile-pyramid regions validate inputs" {
     try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
 
     definition = offlineTileDefinition();
+    definition.data.tile_pyramid.max_zoom = std.math.inf(f64);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    if (snapshot) |handle| {
+        c.mln_offline_region_snapshot_destroy(handle);
+        snapshot = null;
+    }
+
+    definition = offlineTileDefinition();
     definition.type = c.MLN_OFFLINE_REGION_DEFINITION_GEOMETRY;
     definition.data.geometry = .{ .size = @sizeOf(c.mln_offline_geometry_region_definition) };
     try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));

--- a/tests/c/resources.zig
+++ b/tests/c/resources.zig
@@ -45,6 +45,49 @@ const pmtiles_style_json =
 const pmtiles_style_url = "custom://pmtiles-range-style.json";
 const pmtiles_archive_url = "http://example.invalid/test.pmtiles";
 
+const offline_style_url = "http://example.com/offline-style.json";
+
+fn offlineTileDefinition() c.mln_offline_region_definition {
+    var definition: c.mln_offline_region_definition = undefined;
+    definition.size = @sizeOf(c.mln_offline_region_definition);
+    definition.type = c.MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID;
+    definition.data.tile_pyramid = .{
+        .size = @sizeOf(c.mln_offline_tile_pyramid_region_definition),
+        .style_url = offline_style_url,
+        .bounds = .{
+            .southwest = .{ .latitude = 1.0, .longitude = 2.0 },
+            .northeast = .{ .latitude = 3.0, .longitude = 4.0 },
+        },
+        .min_zoom = 5.0,
+        .max_zoom = 6.0,
+        .pixel_ratio = 2.0,
+        .include_ideographs = true,
+    };
+    return definition;
+}
+
+fn offlineRegionInfo() c.mln_offline_region_info {
+    var info: c.mln_offline_region_info = undefined;
+    info.size = @sizeOf(c.mln_offline_region_info);
+    return info;
+}
+
+fn checkOfflineRegionInfo(info: *const c.mln_offline_region_info, expected_id: c.mln_offline_region_id, expected_metadata: []const u8) !void {
+    try testing.expectEqual(expected_id, info.id);
+    try testing.expectEqual(@as(u32, c.MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID), info.definition.type);
+    try testing.expectEqualStrings(offline_style_url, std.mem.span(info.definition.data.tile_pyramid.style_url));
+    try testing.expectEqual(@as(f64, 1.0), info.definition.data.tile_pyramid.bounds.southwest.latitude);
+    try testing.expectEqual(@as(f64, 2.0), info.definition.data.tile_pyramid.bounds.southwest.longitude);
+    try testing.expectEqual(@as(f64, 3.0), info.definition.data.tile_pyramid.bounds.northeast.latitude);
+    try testing.expectEqual(@as(f64, 4.0), info.definition.data.tile_pyramid.bounds.northeast.longitude);
+    try testing.expectEqual(@as(f64, 5.0), info.definition.data.tile_pyramid.min_zoom);
+    try testing.expectEqual(@as(f64, 6.0), info.definition.data.tile_pyramid.max_zoom);
+    try testing.expectEqual(@as(f32, 2.0), info.definition.data.tile_pyramid.pixel_ratio);
+    try testing.expect(info.definition.data.tile_pyramid.include_ideographs);
+    try testing.expectEqual(expected_metadata.len, info.metadata_size);
+    try testing.expectEqualSlices(u8, expected_metadata, info.metadata[0..info.metadata_size]);
+}
+
 const AsyncProviderState = struct {
     handle: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
     saw_style_kind: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -631,6 +674,130 @@ test "ambient cache operations validate cache configuration" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_ambient_cache_operation(runtime_handle, c.MLN_AMBIENT_CACHE_OPERATION_INVALIDATE));
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_ambient_cache_operation(runtime_handle, c.MLN_AMBIENT_CACHE_OPERATION_CLEAR));
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_ambient_cache_operation(runtime_handle, c.MLN_AMBIENT_CACHE_OPERATION_RESET_DATABASE));
+}
+
+test "offline tile-pyramid regions validate inputs" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    var definition = offlineTileDefinition();
+    const metadata = [_]u8{ 1, 2, 3 };
+    var snapshot: ?*c.mln_offline_region_snapshot = null;
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, null, metadata[0..].ptr, metadata.len, &snapshot));
+    try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+
+    definition.type = 999;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+
+    definition = offlineTileDefinition();
+    definition.data.tile_pyramid.style_url = null;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+
+    definition = offlineTileDefinition();
+    definition.data.tile_pyramid.min_zoom = 7.0;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+
+    definition = offlineTileDefinition();
+    definition.type = c.MLN_OFFLINE_REGION_DEFINITION_GEOMETRY;
+    definition.data.geometry = .{ .size = @sizeOf(c.mln_offline_geometry_region_definition) };
+    try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+}
+
+test "offline tile-pyramid regions persist and support metadata lifecycle" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(testing.io, testing.allocator);
+    defer testing.allocator.free(cwd);
+    const cache_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/.zig-cache/tmp/{s}/cache.db", .{ cwd, tmp.sub_path[0..] }, 0);
+    defer testing.allocator.free(cache_path);
+
+    const metadata = [_]u8{ 1, 2, 3 };
+    const updated_metadata = [_]u8{ 4, 5, 6, 7 };
+    var region_id: c.mln_offline_region_id = 0;
+
+    {
+        var runtime: ?*c.mln_runtime = null;
+        var options = c.mln_runtime_options_default();
+        options.cache_path = cache_path.ptr;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_create(&options, &runtime));
+        const runtime_handle = runtime orelse return error.RuntimeCreateFailed;
+        defer support.destroyRuntime(runtime_handle);
+
+        var definition = offlineTileDefinition();
+        var created: ?*c.mln_offline_region_snapshot = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_create(runtime_handle, &definition, metadata[0..].ptr, metadata.len, &created));
+        const created_handle = created orelse return error.RegionCreateFailed;
+        defer c.mln_offline_region_snapshot_destroy(created_handle);
+
+        var created_info = offlineRegionInfo();
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_snapshot_get(created_handle, &created_info));
+        try testing.expect(created_info.id > 0);
+        region_id = created_info.id;
+        try checkOfflineRegionInfo(&created_info, region_id, metadata[0..]);
+
+        var status: c.mln_offline_region_status = undefined;
+        status.size = @sizeOf(c.mln_offline_region_status);
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_get_status(runtime_handle, region_id, &status));
+        try testing.expectEqual(@as(u32, c.MLN_OFFLINE_REGION_DOWNLOAD_INACTIVE), status.download_state);
+
+        var list: ?*c.mln_offline_region_list = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_regions_list(runtime_handle, &list));
+        const list_handle = list orelse return error.RegionListFailed;
+        defer c.mln_offline_region_list_destroy(list_handle);
+
+        var count: usize = 0;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_list_count(list_handle, &count));
+        try testing.expectEqual(@as(usize, 1), count);
+        var list_info = offlineRegionInfo();
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_list_get(list_handle, 0, &list_info));
+        try checkOfflineRegionInfo(&list_info, region_id, metadata[0..]);
+
+        var updated: ?*c.mln_offline_region_snapshot = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_update_metadata(runtime_handle, region_id, updated_metadata[0..].ptr, updated_metadata.len, &updated));
+        const updated_handle = updated orelse return error.RegionUpdateFailed;
+        defer c.mln_offline_region_snapshot_destroy(updated_handle);
+
+        var updated_info = offlineRegionInfo();
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_snapshot_get(updated_handle, &updated_info));
+        try checkOfflineRegionInfo(&updated_info, region_id, updated_metadata[0..]);
+    }
+
+    {
+        var runtime: ?*c.mln_runtime = null;
+        var options = c.mln_runtime_options_default();
+        options.cache_path = cache_path.ptr;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_create(&options, &runtime));
+        const runtime_handle = runtime orelse return error.RuntimeCreateFailed;
+        defer support.destroyRuntime(runtime_handle);
+
+        var found = false;
+        var reloaded: ?*c.mln_offline_region_snapshot = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_get(runtime_handle, region_id, &reloaded, &found));
+        try testing.expect(found);
+        const reloaded_handle = reloaded orelse return error.RegionReloadFailed;
+        defer c.mln_offline_region_snapshot_destroy(reloaded_handle);
+
+        var reloaded_info = offlineRegionInfo();
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_snapshot_get(reloaded_handle, &reloaded_info));
+        try checkOfflineRegionInfo(&reloaded_info, region_id, updated_metadata[0..]);
+
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_invalidate(runtime_handle, region_id));
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_delete(runtime_handle, region_id));
+
+        var list: ?*c.mln_offline_region_list = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_regions_list(runtime_handle, &list));
+        const list_handle = list orelse return error.RegionListFailed;
+        defer c.mln_offline_region_list_destroy(list_handle);
+
+        var count: usize = 0;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_list_count(list_handle, &count));
+        try testing.expectEqual(@as(usize, 0), count);
+    }
 }
 
 test "http URL style loads through network provider" {


### PR DESCRIPTION
## Summary
- Adds the first C ABI slice for offline regions using tile-pyramid definitions, region IDs, and snapshot/list handles.
- Covers create, get, list, update metadata, get status, invalidate, and delete through the runtime database.
- Documents the staged design in a temporary note and marks offline region support as partial.

## Scope
- Related to #13, but does not resolve it.
- Geometry offline regions intentionally return `MLN_STATUS_UNSUPPORTED` until the shared geometry/value ABI from #19 exists.
- Download activation, progress/error runtime events, and database merge are left for later slices.

## Validation
- `mise run test`