### PR TITLE
Audit clang-tidy suppressions

### DIFF
--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -17,13 +17,18 @@
 #ifndef MAPLIBRE_NATIVE_C_H
 #define MAPLIBRE_NATIVE_C_H
 
+// Public C ABI uses C enums.
 // NOLINTBEGIN(cppcoreguidelines-use-enum-class)
+// Public C ABI structs.
 // NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+// Public C ABI tagged union.
 // NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
+// Public C ABI includes C headers.
 // NOLINTBEGIN(modernize-deprecated-headers)
+// Public C ABI return syntax.
 // NOLINTBEGIN(modernize-use-trailing-return-type)
+// Public C ABI typedefs.
 // NOLINTBEGIN(modernize-use-using)
-// NOLINTBEGIN(readability-uppercase-literal-suffix)
 
 #ifndef __cplusplus
 #include <stdbool.h>
@@ -109,9 +114,9 @@ typedef enum mln_log_severity : uint32_t {
 
 /** Bitmask values for log severities dispatched asynchronously. */
 typedef enum mln_log_severity_mask : uint32_t {
-  MLN_LOG_SEVERITY_MASK_INFO = 1u << MLN_LOG_SEVERITY_INFO,
-  MLN_LOG_SEVERITY_MASK_WARNING = 1u << MLN_LOG_SEVERITY_WARNING,
-  MLN_LOG_SEVERITY_MASK_ERROR = 1u << MLN_LOG_SEVERITY_ERROR,
+  MLN_LOG_SEVERITY_MASK_INFO = 1U << MLN_LOG_SEVERITY_INFO,
+  MLN_LOG_SEVERITY_MASK_WARNING = 1U << MLN_LOG_SEVERITY_WARNING,
+  MLN_LOG_SEVERITY_MASK_ERROR = 1U << MLN_LOG_SEVERITY_ERROR,
   MLN_LOG_SEVERITY_MASK_DEFAULT =
     MLN_LOG_SEVERITY_MASK_INFO | MLN_LOG_SEVERITY_MASK_WARNING,
   MLN_LOG_SEVERITY_MASK_ALL = MLN_LOG_SEVERITY_MASK_INFO |
@@ -212,7 +217,7 @@ typedef enum mln_network_status : uint32_t {
 } mln_network_status;
 
 typedef enum mln_runtime_option_flag : uint32_t {
-  MLN_RUNTIME_OPTION_MAXIMUM_CACHE_SIZE = 1u << 0u,
+  MLN_RUNTIME_OPTION_MAXIMUM_CACHE_SIZE = 1U << 0U,
 } mln_runtime_option_flag;
 
 typedef enum mln_ambient_cache_operation : uint32_t {
@@ -840,28 +845,28 @@ MLN_API mln_status mln_runtime_poll_event(
 #pragma region Map types, lifecycle, and style
 /** Field mask values for mln_camera_options. */
 typedef enum mln_camera_option_field : uint32_t {
-  MLN_CAMERA_OPTION_CENTER = 1u << 0u,
-  MLN_CAMERA_OPTION_ZOOM = 1u << 1u,
-  MLN_CAMERA_OPTION_BEARING = 1u << 2u,
-  MLN_CAMERA_OPTION_PITCH = 1u << 3u,
+  MLN_CAMERA_OPTION_CENTER = 1U << 0U,
+  MLN_CAMERA_OPTION_ZOOM = 1U << 1U,
+  MLN_CAMERA_OPTION_BEARING = 1U << 2U,
+  MLN_CAMERA_OPTION_PITCH = 1U << 3U,
 } mln_camera_option_field;
 
 /** Field mask values for MapLibre axonometric rendering options. */
 typedef enum mln_projection_mode_field : uint32_t {
-  MLN_PROJECTION_MODE_AXONOMETRIC = 1u << 0u,
-  MLN_PROJECTION_MODE_X_SKEW = 1u << 1u,
-  MLN_PROJECTION_MODE_Y_SKEW = 1u << 2u,
+  MLN_PROJECTION_MODE_AXONOMETRIC = 1U << 0U,
+  MLN_PROJECTION_MODE_X_SKEW = 1U << 1U,
+  MLN_PROJECTION_MODE_Y_SKEW = 1U << 2U,
 } mln_projection_mode_field;
 
 /** Debug overlay mask values for mln_map_set_debug_options(). */
 typedef enum mln_map_debug_option : uint32_t {
-  MLN_MAP_DEBUG_TILE_BORDERS = 1u << 1u,
-  MLN_MAP_DEBUG_PARSE_STATUS = 1u << 2u,
-  MLN_MAP_DEBUG_TIMESTAMPS = 1u << 3u,
-  MLN_MAP_DEBUG_COLLISION = 1u << 4u,
-  MLN_MAP_DEBUG_OVERDRAW = 1u << 5u,
-  MLN_MAP_DEBUG_STENCIL_CLIP = 1u << 6u,
-  MLN_MAP_DEBUG_DEPTH_BUFFER = 1u << 7u,
+  MLN_MAP_DEBUG_TILE_BORDERS = 1U << 1U,
+  MLN_MAP_DEBUG_PARSE_STATUS = 1U << 2U,
+  MLN_MAP_DEBUG_TIMESTAMPS = 1U << 3U,
+  MLN_MAP_DEBUG_COLLISION = 1U << 4U,
+  MLN_MAP_DEBUG_OVERDRAW = 1U << 5U,
+  MLN_MAP_DEBUG_STENCIL_CLIP = 1U << 6U,
+  MLN_MAP_DEBUG_DEPTH_BUFFER = 1U << 7U,
 } mln_map_debug_option;
 
 /** Map north orientation values used by mln_map_viewport_options. */
@@ -888,10 +893,10 @@ typedef enum mln_viewport_mode : uint32_t {
 
 /** Field mask values for mln_map_viewport_options. */
 typedef enum mln_map_viewport_option_field : uint32_t {
-  MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION = 1u << 0u,
-  MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE = 1u << 1u,
-  MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE = 1u << 2u,
-  MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET = 1u << 3u,
+  MLN_MAP_VIEWPORT_OPTION_NORTH_ORIENTATION = 1U << 0U,
+  MLN_MAP_VIEWPORT_OPTION_CONSTRAIN_MODE = 1U << 1U,
+  MLN_MAP_VIEWPORT_OPTION_VIEWPORT_MODE = 1U << 2U,
+  MLN_MAP_VIEWPORT_OPTION_FRUSTUM_OFFSET = 1U << 3U,
 } mln_map_viewport_option_field;
 
 /** Tile LOD algorithms used by mln_map_tile_options. */
@@ -902,12 +907,12 @@ typedef enum mln_tile_lod_mode : uint32_t {
 
 /** Field mask values for mln_map_tile_options. */
 typedef enum mln_map_tile_option_field : uint32_t {
-  MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA = 1u << 0u,
-  MLN_MAP_TILE_OPTION_LOD_MIN_RADIUS = 1u << 1u,
-  MLN_MAP_TILE_OPTION_LOD_SCALE = 1u << 2u,
-  MLN_MAP_TILE_OPTION_LOD_PITCH_THRESHOLD = 1u << 3u,
-  MLN_MAP_TILE_OPTION_LOD_ZOOM_SHIFT = 1u << 4u,
-  MLN_MAP_TILE_OPTION_LOD_MODE = 1u << 5u,
+  MLN_MAP_TILE_OPTION_PREFETCH_ZOOM_DELTA = 1U << 0U,
+  MLN_MAP_TILE_OPTION_LOD_MIN_RADIUS = 1U << 1U,
+  MLN_MAP_TILE_OPTION_LOD_SCALE = 1U << 2U,
+  MLN_MAP_TILE_OPTION_LOD_PITCH_THRESHOLD = 1U << 3U,
+  MLN_MAP_TILE_OPTION_LOD_ZOOM_SHIFT = 1U << 4U,
+  MLN_MAP_TILE_OPTION_LOD_MODE = 1U << 5U,
 } mln_map_tile_option_field;
 
 /** Map rendering modes used when creating a map. */
@@ -2700,7 +2705,6 @@ MLN_API mln_status mln_vulkan_owned_texture_release_frame(
 }
 #endif
 
-// NOLINTEND(readability-uppercase-literal-suffix)
 // NOLINTEND(modernize-use-using)
 // NOLINTEND(modernize-use-trailing-return-type)
 // NOLINTEND(modernize-deprecated-headers)

--- a/src/c_api/runtime.cpp
+++ b/src/c_api/runtime.cpp
@@ -148,7 +148,9 @@ auto mln_runtime_offline_region_set_download_state(
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::offline_region_set_download_state(
-      runtime, region_id, state
+      runtime, mln::core::OfflineRegionDownloadStateRequest{
+                 .region_id = region_id, .state = state
+               }
     );
   });
 }

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -169,6 +169,7 @@ auto validate_vulkan_borrowed_descriptor(
 }
 
 auto finish_metal_render(mln_render_session* texture) -> mln_status {
+  // Metal sessions always store a Metal backend.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   auto& backend =
     static_cast<mln::core::MetalTextureBackend&>(*texture->texture.backend);

--- a/src/render/vulkan/vulkan_texture_backend.cpp
+++ b/src/render/vulkan/vulkan_texture_backend.cpp
@@ -52,8 +52,8 @@ class VulkanTextureBackend::VulkanTextureRenderableResource final
   void createPlatformSurface() override {}
   void bind() override {}
 
-  void init_sampled(uint32_t width, uint32_t height) {
-    init_sampled_color(width, height);
+  void init_sampled(vk::Extent2D sampled_extent) {
+    init_sampled_color(sampled_extent);
     create_color_image_views();
     initDepthStencil();
     create_render_pass(
@@ -109,29 +109,29 @@ class VulkanTextureBackend::VulkanTextureRenderableResource final
   }
 
  private:
-  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  void init_sampled_color(uint32_t width, uint32_t height) {
+  void init_sampled_color(vk::Extent2D sampled_extent) {
     const auto image_count = backend.getMaxFrames();
     colorAllocations.reserve(image_count);
     swapchainImages.reserve(image_count);
 
     colorFormat = vk::Format::eR8G8B8A8Unorm;
-    extent = vk::Extent2D(width, height);
+    extent = sampled_extent;
 
     const auto image_usage = vk::ImageUsageFlagBits::eColorAttachment |
                              vk::ImageUsageFlagBits::eSampled |
                              vk::ImageUsageFlagBits::eTransferSrc;
-    auto image_create_info = vk::ImageCreateInfo()
-                               .setImageType(vk::ImageType::e2D)
-                               .setFormat(colorFormat)
-                               .setExtent({width, height, 1})
-                               .setMipLevels(1)
-                               .setArrayLayers(1)
-                               .setSamples(vk::SampleCountFlagBits::e1)
-                               .setTiling(vk::ImageTiling::eOptimal)
-                               .setUsage(image_usage)
-                               .setSharingMode(vk::SharingMode::eExclusive)
-                               .setInitialLayout(vk::ImageLayout::eUndefined);
+    auto image_create_info =
+      vk::ImageCreateInfo()
+        .setImageType(vk::ImageType::e2D)
+        .setFormat(colorFormat)
+        .setExtent({sampled_extent.width, sampled_extent.height, 1})
+        .setMipLevels(1)
+        .setArrayLayers(1)
+        .setSamples(vk::SampleCountFlagBits::e1)
+        .setTiling(vk::ImageTiling::eOptimal)
+        .setUsage(image_usage)
+        .setSharingMode(vk::SharingMode::eExclusive)
+        .setInitialLayout(vk::ImageLayout::eUndefined);
 
     auto allocation_create_info = VmaAllocationCreateInfo{};
     allocation_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
@@ -369,7 +369,7 @@ auto VulkanTextureBackend::readStillImage() -> mbgl::PremultipliedImage {
   }
 
   auto& context_impl = static_cast<mbgl::vulkan::Context&>(getContext());
-  auto& resource_impl = rendered_resource();
+  auto& resource_impl = getResource<VulkanTextureRenderableResource>();
   const auto source_image = resource_impl.image();
   context_impl.waitFrame();
   context_impl.submitOneTimeCommand(
@@ -448,12 +448,6 @@ void VulkanTextureBackend::activate() {}
 
 void VulkanTextureBackend::deactivate() {}
 
-// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-auto VulkanTextureBackend::rendered_resource()
-  -> VulkanTextureRenderableResource& {
-  return getResource<VulkanTextureRenderableResource>();
-}
-
 void VulkanTextureBackend::prepareRenderResources() {
   if (allocator == nullptr) {
     initAllocator();
@@ -467,7 +461,7 @@ void VulkanTextureBackend::prepareRenderResources() {
 }
 
 auto VulkanTextureBackend::frame_resources() -> VulkanTextureFrameResources {
-  auto& rendered = rendered_resource();
+  auto& rendered = getResource<VulkanTextureRenderableResource>();
   return VulkanTextureFrameResources{
     .image = rendered.image(),
     .image_view = rendered.image_view(),
@@ -536,10 +530,11 @@ void VulkanTextureBackend::initSwapchain() {
       borrowed_descriptor_, size.width, size.height
     );
   } else {
-    renderable_resource.init_sampled(size.width, size.height);
+    renderable_resource.init_sampled(vk::Extent2D{size.width, size.height});
   }
 }
 
+// Base override requires a member function.
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 auto VulkanTextureBackend::getDeviceExtensions() -> std::vector<const char*> {
   return {};

--- a/src/render/vulkan/vulkan_texture_backend.hpp
+++ b/src/render/vulkan/vulkan_texture_backend.hpp
@@ -57,8 +57,6 @@ class VulkanTextureBackend final : public mbgl::vulkan::RendererBackend,
 
  private:
   void initSharedDevice();
-  auto rendered_resource() -> VulkanTextureRenderableResource&;
-
   mln_vulkan_owned_texture_descriptor descriptor_;
   mln_vulkan_borrowed_texture_descriptor borrowed_descriptor_{};
   bool uses_borrowed_texture_ = false;

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -217,7 +217,6 @@ auto validate_vulkan_handles(
 void prepare_vulkan_render_resources(mln_render_session* texture) {
   // Renderer::render creates the Vulkan context before requesting the default
   // renderable, so shared-device resources must be ready first.
-  // Vulkan sessions always store a Vulkan backend.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   static_cast<mln::core::VulkanTextureBackend&>(*texture->texture.backend)
     .prepareRenderResources();
@@ -419,7 +418,6 @@ auto vulkan_owned_texture_acquire_frame(
 
   // The Vulkan acquire path is only valid for owned Vulkan sessions, and this
   // Linux build only creates Vulkan sessions.
-  // api_kind validates the concrete backend type.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   auto& backend = static_cast<VulkanTextureBackend&>(*texture->texture.backend);
   const auto resources = backend.frame_resources();

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -217,6 +217,7 @@ auto validate_vulkan_handles(
 void prepare_vulkan_render_resources(mln_render_session* texture) {
   // Renderer::render creates the Vulkan context before requesting the default
   // renderable, so shared-device resources must be ready first.
+  // Vulkan sessions always store a Vulkan backend.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   static_cast<mln::core::VulkanTextureBackend&>(*texture->texture.backend)
     .prepareRenderResources();
@@ -418,6 +419,7 @@ auto vulkan_owned_texture_acquire_frame(
 
   // The Vulkan acquire path is only valid for owned Vulkan sessions, and this
   // Linux build only creates Vulkan sessions.
+  // api_kind validates the concrete backend type.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   auto& backend = static_cast<VulkanTextureBackend&>(*texture->texture.backend);
   const auto resources = backend.frame_resources();

--- a/src/resources/custom_resource_provider.cpp
+++ b/src/resources/custom_resource_provider.cpp
@@ -196,6 +196,7 @@ void release(mln_resource_request_handle* handle) noexcept {
     return;
   }
   if (handle->refs.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    // C handle uses manual intrusive refs.
     delete handle;  // NOLINT(cppcoreguidelines-owning-memory)
   }
 }

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -33,8 +33,6 @@
 #include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
-
 struct OfflineRegionData {
   mln_offline_region_id id = 0;
   uint32_t definition_type = 0;
@@ -195,6 +193,8 @@ auto validate_offline_region_definition(
 
   switch (definition->type) {
     case MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID:
+      // Tagged C ABI selects the active member.
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
       return validate_tile_pyramid_definition(definition->data.tile_pyramid);
     case MLN_OFFLINE_REGION_DEFINITION_GEOMETRY:
       // TODO: Support geometry regions after the shared geometry ABI lands:
@@ -212,6 +212,8 @@ auto validate_offline_region_definition(
 auto to_native_offline_region_definition(
   const mln_offline_region_definition& definition
 ) -> mbgl::OfflineRegionDefinition {
+  // Tagged C ABI selects the active member.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
   const auto& tile = definition.data.tile_pyramid;
   auto bounds = mbgl::LatLngBounds::hull(
     {tile.bounds.southwest.latitude, tile.bounds.southwest.longitude},
@@ -344,16 +346,18 @@ auto fill_region_info(
         .size = sizeof(mln_offline_region_definition),
         .type = data.definition_type,
         .data =
-          {.tile_pyramid =
-             mln_offline_tile_pyramid_region_definition{
-               .size = sizeof(mln_offline_tile_pyramid_region_definition),
-               .style_url = data.style_url.c_str(),
-               .bounds = data.bounds,
-               .min_zoom = data.min_zoom,
-               .max_zoom = data.max_zoom,
-               .pixel_ratio = data.pixel_ratio,
-               .include_ideographs = data.include_ideographs
-             }}
+          // Tagged C ABI selects the active member.
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+        {.tile_pyramid =
+           mln_offline_tile_pyramid_region_definition{
+             .size = sizeof(mln_offline_tile_pyramid_region_definition),
+             .style_url = data.style_url.c_str(),
+             .bounds = data.bounds,
+             .min_zoom = data.min_zoom,
+             .max_zoom = data.max_zoom,
+             .pixel_ratio = data.pixel_ratio,
+             .include_ideographs = data.include_ideographs
+           }}
       },
     .metadata = data.metadata.empty() ? nullptr : data.metadata.data(),
     .metadata_size = data.metadata.size()
@@ -1164,15 +1168,14 @@ auto offline_region_set_observed(
   return MLN_STATUS_OK;
 }
 
-// NOLINTBEGIN(bugprone-easily-swappable-parameters)
 auto offline_region_set_download_state(
-  mln_runtime* runtime, mln_offline_region_id region_id, uint32_t state
+  mln_runtime* runtime, OfflineRegionDownloadStateRequest request
 ) -> mln_status {
   const auto runtime_status = validate_runtime(runtime);
   if (runtime_status != MLN_STATUS_OK) {
     return runtime_status;
   }
-  const auto native_state = to_native_download_state(state);
+  const auto native_state = to_native_download_state(request.state);
   if (!native_state) {
     set_thread_error("offline region download state is invalid");
     return MLN_STATUS_INVALID_ARGUMENT;
@@ -1187,7 +1190,7 @@ auto offline_region_set_download_state(
   auto get_result = wait_for_database_result<
     mbgl::expected<std::optional<mbgl::OfflineRegion>, std::exception_ptr>>(
     [&](auto callback) -> void {
-      database->getOfflineRegion(region_id, std::move(callback));
+      database->getOfflineRegion(request.region_id, std::move(callback));
     }
   );
   if (!get_result) {
@@ -1203,7 +1206,6 @@ auto offline_region_set_download_state(
   database->setOfflineRegionDownloadState(*get_result.value(), *native_state);
   return MLN_STATUS_OK;
 }
-// NOLINTEND(bugprone-easily-swappable-parameters)
 
 auto offline_region_invalidate(
   mln_runtime* runtime, mln_offline_region_id region_id
@@ -1636,5 +1638,3 @@ auto discard_runtime_map_events(mln_runtime* runtime, const mln_map* map)
 }
 
 }  // namespace mln::core
-
-// NOLINTEND(cppcoreguidelines-pro-type-union-access)

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -117,8 +117,14 @@ auto offline_region_get_status(
 auto offline_region_set_observed(
   mln_runtime* runtime, mln_offline_region_id region_id, bool observed
 ) -> mln_status;
+
+struct OfflineRegionDownloadStateRequest {
+  mln_offline_region_id region_id;
+  uint32_t state;
+};
+
 auto offline_region_set_download_state(
-  mln_runtime* runtime, mln_offline_region_id region_id, uint32_t state
+  mln_runtime* runtime, OfflineRegionDownloadStateRequest request
 ) -> mln_status;
 auto offline_region_invalidate(
   mln_runtime* runtime, mln_offline_region_id region_id


### PR DESCRIPTION
## Summary
- Removes avoidable clang-tidy suppressions by fixing uppercase literal suffixes, Vulkan extent parameters, and an internal offline download-state helper signature.
- Narrows the runtime union-access suppression and adds concise rationale comments for remaining ABI/backend suppressions.

## Verification
- mise run check
- mise run test

Fixes #82