### PR TITLE
Add GeoJSON ABI descriptors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ add_library(
     src/c_api/texture.cpp
     src/c_api/version.cpp
     src/diagnostics/diagnostics.cpp
+    src/geojson/geojson.cpp
     src/logging/logging.cpp
     src/map/map.cpp
     src/render/render_session_common.cpp

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,7 +51,8 @@ fixed-size inline text buffers; expose borrowed ABI-owned text with a length or
 provide an explicit copy or drain API.
 
 Keep backend-native handles opaque as `void*`; document the backend type and
-ownership rules on the function or struct field.
+field-level requirements on the struct field. Document ownership and lifetime on
+the function that accepts or returns the struct.
 
 ## Errors And Diagnostics
 
@@ -82,6 +83,10 @@ asynchronous native failures through copied runtime events.
 ## Ownership And Lifetime
 
 Make ownership explicit at every boundary.
+
+Struct definitions describe data shape, required fields, and pointer validity.
+Function comments describe whether input pointers are borrowed, copied,
+retained, or consumed, and when returned views become invalid.
 
 Borrow host-provided strings and buffers for call-duration inputs. Copy
 host-provided strings and buffers that outlive the function or native callback.

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -955,6 +955,202 @@ typedef struct mln_lat_lng {
   double longitude;
 } mln_lat_lng;
 
+/** UTF-8 text view. The pointer may be null only when size is 0. */
+typedef struct mln_string_view {
+  /** UTF-8 bytes. Null only when size is 0. */
+  const char* data;
+  size_t size;
+} mln_string_view;
+
+typedef struct mln_json_value mln_json_value;
+typedef struct mln_geometry mln_geometry;
+
+/** Geometry variant tags used by mln_geometry. */
+typedef enum mln_geometry_type : uint32_t {
+  MLN_GEOMETRY_TYPE_EMPTY = 0,
+  MLN_GEOMETRY_TYPE_POINT = 1,
+  MLN_GEOMETRY_TYPE_LINE_STRING = 2,
+  MLN_GEOMETRY_TYPE_POLYGON = 3,
+  MLN_GEOMETRY_TYPE_MULTI_POINT = 4,
+  MLN_GEOMETRY_TYPE_MULTI_LINE_STRING = 5,
+  MLN_GEOMETRY_TYPE_MULTI_POLYGON = 6,
+  MLN_GEOMETRY_TYPE_GEOMETRY_COLLECTION = 7,
+} mln_geometry_type;
+
+/** Coordinate array view. Coordinates are latitude/longitude pairs. */
+typedef struct mln_coordinate_span {
+  /** Coordinates. Null only when coordinate_count is 0. */
+  const mln_lat_lng* coordinates;
+  size_t coordinate_count;
+} mln_coordinate_span;
+
+/** Polygon ring array view. Each ring is a coordinate span. */
+typedef struct mln_polygon_geometry {
+  /** Rings. Null only when ring_count is 0. */
+  const mln_coordinate_span* rings;
+  size_t ring_count;
+} mln_polygon_geometry;
+
+/** Multi-line geometry view. Each line is a coordinate span. */
+typedef struct mln_multi_line_geometry {
+  /** Lines. Null only when line_count is 0. */
+  const mln_coordinate_span* lines;
+  size_t line_count;
+} mln_multi_line_geometry;
+
+/** Multi-polygon geometry view. Each polygon contains ring views. */
+typedef struct mln_multi_polygon_geometry {
+  /** Polygons. Null only when polygon_count is 0. */
+  const mln_polygon_geometry* polygons;
+  size_t polygon_count;
+} mln_multi_polygon_geometry;
+
+/** Geometry collection view. */
+typedef struct mln_geometry_collection {
+  /** Child geometries. Null only when geometry_count is 0. */
+  const mln_geometry* geometries;
+  size_t geometry_count;
+} mln_geometry_collection;
+
+/**
+ * MapLibre geometry input descriptor graph.
+ *
+ * Geometry coordinates use mln_lat_lng for consistency with the rest of the C
+ * API. They are converted to native geometry points as longitude/latitude.
+ */
+typedef struct mln_geometry {
+  uint32_t size;
+  /** One of mln_geometry_type. */
+  uint32_t type;
+  union {
+    mln_lat_lng point;
+    mln_coordinate_span line_string;
+    mln_polygon_geometry polygon;
+    mln_coordinate_span multi_point;
+    mln_multi_line_geometry multi_line_string;
+    mln_multi_polygon_geometry multi_polygon;
+    mln_geometry_collection geometry_collection;
+  } data;
+} mln_geometry;
+
+/** JSON-like value variant tags used by mln_json_value. */
+typedef enum mln_json_value_type : uint32_t {
+  MLN_JSON_VALUE_TYPE_NULL = 0,
+  MLN_JSON_VALUE_TYPE_BOOL = 1,
+  MLN_JSON_VALUE_TYPE_UINT = 2,
+  MLN_JSON_VALUE_TYPE_INT = 3,
+  MLN_JSON_VALUE_TYPE_DOUBLE = 4,
+  MLN_JSON_VALUE_TYPE_STRING = 5,
+  MLN_JSON_VALUE_TYPE_ARRAY = 6,
+  MLN_JSON_VALUE_TYPE_OBJECT = 7,
+} mln_json_value_type;
+
+/** JSON value array view. */
+typedef struct mln_json_array {
+  /** Values. Null only when value_count is 0. */
+  const mln_json_value* values;
+  size_t value_count;
+} mln_json_array;
+
+/** JSON object member view. */
+typedef struct mln_json_member {
+  mln_string_view key;
+  /** Value descriptor. Must not be null. */
+  const mln_json_value* value;
+} mln_json_member;
+
+/** JSON object member array view. */
+typedef struct mln_json_object {
+  /** Members. Null only when member_count is 0. */
+  const mln_json_member* members;
+  size_t member_count;
+} mln_json_object;
+
+/**
+ * JSON-like value input descriptor graph used by feature properties/states.
+ *
+ * Input functions reject NaN and infinities for double values because JSON and
+ * GeoJSON numbers are finite.
+ */
+typedef struct mln_json_value {
+  uint32_t size;
+  /** One of mln_json_value_type. */
+  uint32_t type;
+  union {
+    bool bool_value;
+    uint64_t uint_value;
+    int64_t int_value;
+    double double_value;
+    mln_string_view string_value;
+    mln_json_array array_value;
+    mln_json_object object_value;
+  } data;
+} mln_json_value;
+
+/** Feature identifier variant tags used by mln_feature. */
+typedef enum mln_feature_identifier_type : uint32_t {
+  MLN_FEATURE_IDENTIFIER_TYPE_NULL = 0,
+  MLN_FEATURE_IDENTIFIER_TYPE_UINT = 1,
+  MLN_FEATURE_IDENTIFIER_TYPE_INT = 2,
+  MLN_FEATURE_IDENTIFIER_TYPE_DOUBLE = 3,
+  MLN_FEATURE_IDENTIFIER_TYPE_STRING = 4,
+} mln_feature_identifier_type;
+
+/** GeoJSON feature input descriptor graph. */
+typedef struct mln_feature {
+  uint32_t size;
+  /**
+   * Geometry descriptor. Must not be null. Use MLN_GEOMETRY_TYPE_EMPTY for an
+   * empty geometry.
+   */
+  const mln_geometry* geometry;
+  /** Property member views. May be null only when property_count is 0. */
+  const mln_json_member* properties;
+  size_t property_count;
+  /** One of mln_feature_identifier_type. */
+  uint32_t identifier_type;
+  union {
+    uint64_t uint_value;
+    int64_t int_value;
+    double double_value;
+    mln_string_view string_value;
+  } identifier;
+} mln_feature;
+
+/** GeoJSON variant tags used by mln_geojson. */
+typedef enum mln_geojson_type : uint32_t {
+  MLN_GEOJSON_TYPE_GEOMETRY = 1,
+  MLN_GEOJSON_TYPE_FEATURE = 2,
+  MLN_GEOJSON_TYPE_FEATURE_COLLECTION = 3,
+} mln_geojson_type;
+
+/** Feature collection view. */
+typedef struct mln_feature_collection {
+  /** Features. Null only when feature_count is 0. */
+  const mln_feature* features;
+  size_t feature_count;
+} mln_feature_collection;
+
+/** GeoJSON geometry, feature, or feature collection input descriptor graph. */
+typedef struct mln_geojson {
+  uint32_t size;
+  /** One of mln_geojson_type. */
+  uint32_t type;
+  union {
+    /**
+     * Geometry descriptor selected by MLN_GEOJSON_TYPE_GEOMETRY. Must not be
+     * null.
+     */
+    const mln_geometry* geometry;
+    /**
+     * Feature descriptor selected by MLN_GEOJSON_TYPE_FEATURE. Must not be
+     * null.
+     */
+    const mln_feature* feature;
+    mln_feature_collection feature_collection;
+  } data;
+} mln_geojson;
+
 /** Geographic bounds in degrees. */
 typedef struct mln_lat_lng_bounds {
   mln_lat_lng southwest;
@@ -977,7 +1173,7 @@ typedef struct mln_offline_tile_pyramid_region_definition {
   bool include_ideographs;
 } mln_offline_tile_pyramid_region_definition;
 
-/** Placeholder for future geometry offline region definitions. */
+/** Placeholder for future offline geometry region definitions. */
 typedef struct mln_offline_geometry_region_definition {
   uint32_t size;
 } mln_offline_geometry_region_definition;
@@ -993,12 +1189,12 @@ typedef struct mln_offline_region_definition {
   } data;
 } mln_offline_region_definition;
 
-/** Region data borrowed from a snapshot or list handle. */
+/** Region data view returned from a snapshot or list handle. */
 typedef struct mln_offline_region_info {
   uint32_t size;
   mln_offline_region_id id;
   mln_offline_region_definition definition;
-  /** Borrowed metadata bytes. Valid until the owner snapshot/list is destroyed.
+  /** Metadata bytes. Valid until the owner snapshot/list is destroyed.
    */
   const uint8_t* metadata;
   size_t metadata_size;
@@ -1008,8 +1204,8 @@ typedef struct mln_offline_region_info {
  * Creates a tile-pyramid offline region.
  *
  * The returned snapshot owns copied region data. Destroy it with
- * mln_offline_region_snapshot_destroy(). Geometry definitions are reserved for
- * future shared geometry ABI support and return MLN_STATUS_UNSUPPORTED.
+ * mln_offline_region_snapshot_destroy(). Geometry definitions are not wired to
+ * native offline storage yet and return MLN_STATUS_UNSUPPORTED.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -1201,7 +1397,10 @@ MLN_API mln_status mln_runtime_offline_region_delete(
 ) MLN_NOEXCEPT;
 
 /**
- * Copies borrowed region data out of a snapshot handle.
+ * Copies a region data view out of a snapshot handle.
+ *
+ * On success, out_info receives pointers into snapshot-owned storage. Those
+ * pointers remain valid until the snapshot is destroyed.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -1232,7 +1431,10 @@ MLN_API mln_status mln_offline_region_list_count(
 ) MLN_NOEXCEPT;
 
 /**
- * Copies borrowed region data for one list entry.
+ * Copies a region data view for one list entry.
+ *
+ * On success, out_info receives pointers into list-owned storage. Those
+ * pointers remain valid until the list is destroyed.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -1906,8 +2108,9 @@ MLN_API mln_status mln_map_projection_set_camera(
 /**
  * Updates a projection helper camera so coordinates are visible within padding.
  *
- * The caller owns coordinates. Use mln_map_projection_get_camera() after this
- * call to read the computed camera.
+ * The coordinates array is borrowed for the duration of this call and is not
+ * retained. Use mln_map_projection_get_camera() after this call to read the
+ * computed camera.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -1922,6 +2125,29 @@ MLN_API mln_status mln_map_projection_set_camera(
 MLN_API mln_status mln_map_projection_set_visible_coordinates(
   mln_map_projection* projection, const mln_lat_lng* coordinates,
   size_t coordinate_count, mln_edge_insets padding
+) MLN_NOEXCEPT;
+
+/**
+ * Updates a projection helper camera so geometry coordinates are visible.
+ *
+ * The geometry descriptor graph, including all nested pointers, is borrowed for
+ * the duration of this call and is not retained. Use
+ * mln_map_projection_get_camera() after this call to read the computed camera.
+ * Empty geometry objects and geometry collections with no coordinates are
+ * invalid for camera fitting.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when projection is null or not live, geometry
+ *   is null or invalid, padding contains negative or non-finite values, or the
+ *   geometry contains no coordinates.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the projection
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_projection_set_visible_geometry(
+  mln_map_projection* projection, const mln_geometry* geometry,
+  mln_edge_insets padding
 ) MLN_NOEXCEPT;
 
 /**

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -254,6 +254,17 @@ auto mln_map_projection_set_visible_coordinates(
   });
 }
 
+auto mln_map_projection_set_visible_geometry(
+  mln_map_projection* projection, const mln_geometry* geometry,
+  mln_edge_insets padding
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_projection_set_visible_geometry(
+      projection, geometry, padding
+    );
+  });
+}
+
 auto mln_map_projection_pixel_for_lat_lng(
   mln_map_projection* projection, mln_lat_lng coordinate,
   mln_screen_point* out_point

--- a/src/geojson/geojson.cpp
+++ b/src/geojson/geojson.cpp
@@ -1,0 +1,483 @@
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <mbgl/util/feature.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/geojson.hpp>
+#include <mbgl/util/geometry.hpp>
+
+#include <mapbox/geometry/geometry.hpp>
+
+#include "geojson/geojson.hpp"
+
+#include "diagnostics/diagnostics.hpp"
+#include "maplibre_native_c.h"
+
+// Public C ABI uses tagged unions.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
+
+namespace {
+
+constexpr std::size_t max_recursive_depth = 64;
+
+auto validate_depth(std::size_t depth) -> bool {
+  if (depth > max_recursive_depth) {
+    mln::core::set_thread_error("GeoJSON value nesting is too deep");
+    return false;
+  }
+  return true;
+}
+
+auto validate_string(mln_string_view string) -> bool {
+  if (string.size > 0 && string.data == nullptr) {
+    mln::core::set_thread_error("string data must not be null");
+    return false;
+  }
+  return true;
+}
+
+auto to_string(mln_string_view string) -> std::string {
+  if (string.size == 0) {
+    return {};
+  }
+  return std::string{string.data, string.size};
+}
+
+auto validate_coordinate(mln_lat_lng coordinate) -> bool {
+  if (
+    !std::isfinite(coordinate.latitude) || coordinate.latitude < -90.0 ||
+    coordinate.latitude > 90.0 || !std::isfinite(coordinate.longitude)
+  ) {
+    mln::core::set_thread_error(
+      "latitude must be finite and within [-90, 90], and longitude must be "
+      "finite"
+    );
+    return false;
+  }
+  return true;
+}
+
+auto to_native_point(mln_lat_lng coordinate) -> mbgl::Point<double> {
+  return mbgl::Point<double>{coordinate.longitude, coordinate.latitude};
+}
+
+auto convert_coordinate_span(mln_coordinate_span span)
+  -> std::optional<mbgl::LineString<double>> {
+  if (span.coordinate_count > 0 && span.coordinates == nullptr) {
+    mln::core::set_thread_error("coordinates must not be null");
+    return std::nullopt;
+  }
+
+  auto result = mbgl::LineString<double>{};
+  result.reserve(span.coordinate_count);
+  for (const auto coordinate :
+       std::span<const mln_lat_lng>{span.coordinates, span.coordinate_count}) {
+    if (!validate_coordinate(coordinate)) {
+      return std::nullopt;
+    }
+    result.emplace_back(to_native_point(coordinate));
+  }
+  return result;
+}
+
+auto convert_polygon(mln_polygon_geometry polygon)
+  -> std::optional<mbgl::Polygon<double>> {
+  if (polygon.ring_count > 0 && polygon.rings == nullptr) {
+    mln::core::set_thread_error("polygon rings must not be null");
+    return std::nullopt;
+  }
+
+  auto result = mbgl::Polygon<double>{};
+  result.reserve(polygon.ring_count);
+  for (const auto ring : std::span<const mln_coordinate_span>{
+         polygon.rings, polygon.ring_count
+       }) {
+    auto converted_ring = convert_coordinate_span(ring);
+    if (!converted_ring) {
+      return std::nullopt;
+    }
+    result.emplace_back(std::move(*converted_ring));
+  }
+  return result;
+}
+
+auto convert_multi_line(mln_multi_line_geometry multi_line)
+  -> std::optional<mbgl::MultiLineString<double>> {
+  if (multi_line.line_count > 0 && multi_line.lines == nullptr) {
+    mln::core::set_thread_error("multi-line strings must not be null");
+    return std::nullopt;
+  }
+
+  auto result = mbgl::MultiLineString<double>{};
+  result.reserve(multi_line.line_count);
+  for (const auto line : std::span<const mln_coordinate_span>{
+         multi_line.lines, multi_line.line_count
+       }) {
+    auto converted_line = convert_coordinate_span(line);
+    if (!converted_line) {
+      return std::nullopt;
+    }
+    result.emplace_back(std::move(*converted_line));
+  }
+  return result;
+}
+
+auto convert_multi_polygon(mln_multi_polygon_geometry multi_polygon)
+  -> std::optional<mbgl::MultiPolygon<double>> {
+  if (multi_polygon.polygon_count > 0 && multi_polygon.polygons == nullptr) {
+    mln::core::set_thread_error("multi-polygons must not be null");
+    return std::nullopt;
+  }
+
+  auto result = mbgl::MultiPolygon<double>{};
+  result.reserve(multi_polygon.polygon_count);
+  for (const auto polygon : std::span<const mln_polygon_geometry>{
+         multi_polygon.polygons, multi_polygon.polygon_count
+       }) {
+    auto converted_polygon = convert_polygon(polygon);
+    if (!converted_polygon) {
+      return std::nullopt;
+    }
+    result.emplace_back(std::move(*converted_polygon));
+  }
+  return result;
+}
+
+auto convert_geometry(const mln_geometry* geometry, std::size_t depth)
+  -> std::optional<mbgl::Geometry<double>> {
+  if (!validate_depth(depth)) {
+    return std::nullopt;
+  }
+  if (geometry == nullptr) {
+    mln::core::set_thread_error("geometry must not be null");
+    return std::nullopt;
+  }
+  if (geometry->size < sizeof(mln_geometry)) {
+    mln::core::set_thread_error("mln_geometry.size is too small");
+    return std::nullopt;
+  }
+
+  switch (geometry->type) {
+    case MLN_GEOMETRY_TYPE_EMPTY:
+      return mbgl::Geometry<double>{mbgl::EmptyGeometry{}};
+    case MLN_GEOMETRY_TYPE_POINT:
+      if (!validate_coordinate(geometry->data.point)) {
+        return std::nullopt;
+      }
+      return mbgl::Geometry<double>{to_native_point(geometry->data.point)};
+    case MLN_GEOMETRY_TYPE_LINE_STRING: {
+      auto line = convert_coordinate_span(geometry->data.line_string);
+      if (!line) {
+        return std::nullopt;
+      }
+      return mbgl::Geometry<double>{std::move(*line)};
+    }
+    case MLN_GEOMETRY_TYPE_POLYGON: {
+      auto polygon = convert_polygon(geometry->data.polygon);
+      if (!polygon) {
+        return std::nullopt;
+      }
+      return mbgl::Geometry<double>{std::move(*polygon)};
+    }
+    case MLN_GEOMETRY_TYPE_MULTI_POINT: {
+      auto points = convert_coordinate_span(geometry->data.multi_point);
+      if (!points) {
+        return std::nullopt;
+      }
+      return mbgl::Geometry<double>{mbgl::MultiPoint<double>{
+        std::make_move_iterator(points->begin()),
+        std::make_move_iterator(points->end())
+      }};
+    }
+    case MLN_GEOMETRY_TYPE_MULTI_LINE_STRING: {
+      auto multi_line = convert_multi_line(geometry->data.multi_line_string);
+      if (!multi_line) {
+        return std::nullopt;
+      }
+      return mbgl::Geometry<double>{std::move(*multi_line)};
+    }
+    case MLN_GEOMETRY_TYPE_MULTI_POLYGON: {
+      auto multi_polygon = convert_multi_polygon(geometry->data.multi_polygon);
+      if (!multi_polygon) {
+        return std::nullopt;
+      }
+      return mbgl::Geometry<double>{std::move(*multi_polygon)};
+    }
+    case MLN_GEOMETRY_TYPE_GEOMETRY_COLLECTION: {
+      const auto collection = geometry->data.geometry_collection;
+      if (collection.geometry_count > 0 && collection.geometries == nullptr) {
+        mln::core::set_thread_error("geometry collection must not be null");
+        return std::nullopt;
+      }
+
+      auto result = mapbox::geometry::geometry_collection<double>{};
+      result.reserve(collection.geometry_count);
+      for (const auto& child : std::span<const mln_geometry>{
+             collection.geometries, collection.geometry_count
+           }) {
+        auto converted_child = convert_geometry(&child, depth + 1);
+        if (!converted_child) {
+          return std::nullopt;
+        }
+        result.emplace_back(std::move(*converted_child));
+      }
+      return mbgl::Geometry<double>{std::move(result)};
+    }
+    default:
+      mln::core::set_thread_error("geometry type is invalid");
+      return std::nullopt;
+  }
+}
+
+auto convert_value(const mln_json_value* value, std::size_t depth)
+  -> std::optional<mbgl::Value>;
+
+auto convert_array_value(mln_json_array array, std::size_t depth)
+  -> std::optional<mbgl::Value> {
+  if (array.value_count > 0 && array.values == nullptr) {
+    mln::core::set_thread_error("array values must not be null");
+    return std::nullopt;
+  }
+
+  auto result = mbgl::Value::array_type{};
+  result.reserve(array.value_count);
+  for (const auto& child :
+       std::span<const mln_json_value>{array.values, array.value_count}) {
+    auto converted_child = convert_value(&child, depth + 1);
+    if (!converted_child) {
+      return std::nullopt;
+    }
+    result.emplace_back(std::move(*converted_child));
+  }
+  return mbgl::Value{std::move(result)};
+}
+
+auto convert_object_value(mln_json_object object, std::size_t depth)
+  -> std::optional<mbgl::Value> {
+  if (object.member_count > 0 && object.members == nullptr) {
+    mln::core::set_thread_error("object members must not be null");
+    return std::nullopt;
+  }
+
+  auto result = mbgl::Value::object_type{};
+  for (const auto& member :
+       std::span<const mln_json_member>{object.members, object.member_count}) {
+    if (!validate_string(member.key)) {
+      return std::nullopt;
+    }
+    auto converted_value = convert_value(member.value, depth + 1);
+    if (!converted_value) {
+      return std::nullopt;
+    }
+    result[to_string(member.key)] = std::move(*converted_value);
+  }
+  return mbgl::Value{std::move(result)};
+}
+
+auto convert_value(const mln_json_value* value, std::size_t depth)
+  -> std::optional<mbgl::Value> {
+  if (!validate_depth(depth)) {
+    return std::nullopt;
+  }
+  if (value == nullptr) {
+    mln::core::set_thread_error("value must not be null");
+    return std::nullopt;
+  }
+  if (value->size < sizeof(mln_json_value)) {
+    mln::core::set_thread_error("mln_json_value.size is too small");
+    return std::nullopt;
+  }
+
+  switch (value->type) {
+    case MLN_JSON_VALUE_TYPE_NULL:
+      return mbgl::Value{mbgl::NullValue{}};
+    case MLN_JSON_VALUE_TYPE_BOOL:
+      return mbgl::Value{value->data.bool_value};
+    case MLN_JSON_VALUE_TYPE_UINT:
+      return mbgl::Value{value->data.uint_value};
+    case MLN_JSON_VALUE_TYPE_INT:
+      return mbgl::Value{value->data.int_value};
+    case MLN_JSON_VALUE_TYPE_DOUBLE:
+      if (!std::isfinite(value->data.double_value)) {
+        mln::core::set_thread_error("double value must be finite");
+        return std::nullopt;
+      }
+      return mbgl::Value{value->data.double_value};
+    case MLN_JSON_VALUE_TYPE_STRING:
+      if (!validate_string(value->data.string_value)) {
+        return std::nullopt;
+      }
+      return mbgl::Value{to_string(value->data.string_value)};
+    case MLN_JSON_VALUE_TYPE_ARRAY:
+      return convert_array_value(value->data.array_value, depth);
+    case MLN_JSON_VALUE_TYPE_OBJECT:
+      return convert_object_value(value->data.object_value, depth);
+    default:
+      mln::core::set_thread_error("JSON value type is invalid");
+      return std::nullopt;
+  }
+}
+
+auto convert_identifier(const mln_feature& feature)
+  -> std::optional<mbgl::FeatureIdentifier> {
+  switch (feature.identifier_type) {
+    case MLN_FEATURE_IDENTIFIER_TYPE_NULL:
+      return mbgl::FeatureIdentifier{mbgl::NullValue{}};
+    case MLN_FEATURE_IDENTIFIER_TYPE_UINT:
+      return mbgl::FeatureIdentifier{feature.identifier.uint_value};
+    case MLN_FEATURE_IDENTIFIER_TYPE_INT:
+      return mbgl::FeatureIdentifier{feature.identifier.int_value};
+    case MLN_FEATURE_IDENTIFIER_TYPE_DOUBLE:
+      if (!std::isfinite(feature.identifier.double_value)) {
+        mln::core::set_thread_error("feature identifier double must be finite");
+        return std::nullopt;
+      }
+      return mbgl::FeatureIdentifier{feature.identifier.double_value};
+    case MLN_FEATURE_IDENTIFIER_TYPE_STRING:
+      if (!validate_string(feature.identifier.string_value)) {
+        return std::nullopt;
+      }
+      return mbgl::FeatureIdentifier{
+        to_string(feature.identifier.string_value)
+      };
+    default:
+      mln::core::set_thread_error("feature identifier type is invalid");
+      return std::nullopt;
+  }
+}
+
+auto convert_feature(const mln_feature* feature, std::size_t depth)
+  -> std::optional<mbgl::GeoJSONFeature> {
+  if (!validate_depth(depth)) {
+    return std::nullopt;
+  }
+  if (feature == nullptr) {
+    mln::core::set_thread_error("feature must not be null");
+    return std::nullopt;
+  }
+  if (feature->size < sizeof(mln_feature)) {
+    mln::core::set_thread_error("mln_feature.size is too small");
+    return std::nullopt;
+  }
+  if (feature->property_count > 0 && feature->properties == nullptr) {
+    mln::core::set_thread_error("feature properties must not be null");
+    return std::nullopt;
+  }
+
+  auto geometry = convert_geometry(feature->geometry, depth + 1);
+  if (!geometry) {
+    return std::nullopt;
+  }
+  auto identifier = convert_identifier(*feature);
+  if (!identifier) {
+    return std::nullopt;
+  }
+
+  auto properties = mbgl::PropertyMap{};
+  for (const auto& property : std::span<const mln_json_member>{
+         feature->properties, feature->property_count
+       }) {
+    if (!validate_string(property.key)) {
+      return std::nullopt;
+    }
+    auto value = convert_value(property.value, depth + 1);
+    if (!value) {
+      return std::nullopt;
+    }
+    properties[to_string(property.key)] = std::move(*value);
+  }
+
+  return mbgl::GeoJSONFeature{
+    std::move(*geometry), std::move(properties), std::move(*identifier)
+  };
+}
+
+}  // namespace
+
+namespace mln::core {
+
+auto to_native_geometry(const mln_geometry* geometry)
+  -> std::optional<mbgl::Geometry<double>> {
+  return convert_geometry(geometry, 0);
+}
+
+auto to_native_json_value(const mln_json_value* value)
+  -> std::optional<mbgl::Value> {
+  return convert_value(value, 0);
+}
+
+auto to_native_feature(const mln_feature* feature)
+  -> std::optional<mbgl::GeoJSONFeature> {
+  return convert_feature(feature, 0);
+}
+
+auto to_native_geojson(const mln_geojson* geojson)
+  -> std::optional<mbgl::GeoJSON> {
+  if (geojson == nullptr) {
+    set_thread_error("GeoJSON must not be null");
+    return std::nullopt;
+  }
+  if (geojson->size < sizeof(mln_geojson)) {
+    set_thread_error("mln_geojson.size is too small");
+    return std::nullopt;
+  }
+
+  switch (geojson->type) {
+    case MLN_GEOJSON_TYPE_GEOMETRY: {
+      auto geometry = to_native_geometry(geojson->data.geometry);
+      if (!geometry) {
+        return std::nullopt;
+      }
+      return mbgl::GeoJSON{std::move(*geometry)};
+    }
+    case MLN_GEOJSON_TYPE_FEATURE: {
+      auto feature = to_native_feature(geojson->data.feature);
+      if (!feature) {
+        return std::nullopt;
+      }
+      return mbgl::GeoJSON{std::move(*feature)};
+    }
+    case MLN_GEOJSON_TYPE_FEATURE_COLLECTION: {
+      const auto collection = geojson->data.feature_collection;
+      if (collection.feature_count > 0 && collection.features == nullptr) {
+        set_thread_error("feature collection must not be null");
+        return std::nullopt;
+      }
+
+      auto result = mbgl::FeatureCollection{};
+      result.reserve(collection.feature_count);
+      for (const auto& feature : std::span<const mln_feature>{
+             collection.features, collection.feature_count
+           }) {
+        auto converted_feature = convert_feature(&feature, 1);
+        if (!converted_feature) {
+          return std::nullopt;
+        }
+        result.emplace_back(std::move(*converted_feature));
+      }
+      return mbgl::GeoJSON{std::move(result)};
+    }
+    default:
+      set_thread_error("GeoJSON type is invalid");
+      return std::nullopt;
+  }
+}
+
+auto geometry_lat_lngs(const mbgl::Geometry<double>& geometry)
+  -> std::vector<mbgl::LatLng> {
+  auto result = std::vector<mbgl::LatLng>{};
+  mbgl::forEachPoint(geometry, [&](const mbgl::Point<double>& point) -> void {
+    result.emplace_back(point.y, point.x);
+  });
+  return result;
+}
+
+}  // namespace mln::core
+
+// NOLINTEND(cppcoreguidelines-pro-type-union-access)

--- a/src/geojson/geojson.hpp
+++ b/src/geojson/geojson.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <mbgl/util/feature.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/geojson.hpp>
+#include <mbgl/util/geometry.hpp>
+
+#include "maplibre_native_c.h"
+
+namespace mln::core {
+
+auto to_native_geometry(const mln_geometry* geometry)
+  -> std::optional<mbgl::Geometry<double>>;
+auto to_native_json_value(const mln_json_value* value)
+  -> std::optional<mbgl::Value>;
+auto to_native_feature(const mln_feature* feature)
+  -> std::optional<mbgl::GeoJSONFeature>;
+auto to_native_geojson(const mln_geojson* geojson)
+  -> std::optional<mbgl::GeoJSON>;
+auto geometry_lat_lngs(const mbgl::Geometry<double>& geometry)
+  -> std::vector<mbgl::LatLng>;
+
+}  // namespace mln::core

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -36,6 +36,7 @@
 #include "map/map.hpp"
 
 #include "diagnostics/diagnostics.hpp"
+#include "geojson/geojson.hpp"
 #include "maplibre_native_c.h"
 #include "runtime/runtime.hpp"
 
@@ -1801,6 +1802,34 @@ auto map_projection_set_visible_coordinates(
   projection->projection->setVisibleCoordinates(
     to_native_lat_lngs(coordinates, coordinate_count),
     to_native_edge_insets(padding)
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_projection_set_visible_geometry(
+  mln_map_projection* projection, const mln_geometry* geometry,
+  mln_edge_insets padding
+) -> mln_status {
+  const auto status = validate_map_projection(projection);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto padding_status = validate_edge_insets(padding);
+  if (padding_status != MLN_STATUS_OK) {
+    return padding_status;
+  }
+  auto native_geometry = to_native_geometry(geometry);
+  if (!native_geometry) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto coordinates = geometry_lat_lngs(*native_geometry);
+  if (coordinates.empty()) {
+    set_thread_error("geometry must contain at least one coordinate");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  projection->projection->setVisibleCoordinates(
+    coordinates, to_native_edge_insets(padding)
   );
   return MLN_STATUS_OK;
 }

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -79,6 +79,10 @@ auto map_projection_set_visible_coordinates(
   mln_map_projection* projection, const mln_lat_lng* coordinates,
   size_t coordinate_count, mln_edge_insets padding
 ) -> mln_status;
+auto map_projection_set_visible_geometry(
+  mln_map_projection* projection, const mln_geometry* geometry,
+  mln_edge_insets padding
+) -> mln_status;
 auto map_projection_pixel_for_lat_lng(
   mln_map_projection* projection, mln_lat_lng coordinate,
   mln_screen_point* out_point

--- a/tests/c/geojson.zig
+++ b/tests/c/geojson.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const testing = std.testing;
+const support = @import("support.zig");
+const c = support.c;
+
+test "GeoJSON ABI structs import and compose" {
+    const point = c.mln_geometry{
+        .size = @sizeOf(c.mln_geometry),
+        .type = c.MLN_GEOMETRY_TYPE_POINT,
+        .data = .{ .point = .{ .latitude = 37.7749, .longitude = -122.4194 } },
+    };
+    try testing.expectEqual(@as(u32, c.MLN_GEOMETRY_TYPE_POINT), point.type);
+
+    const name = "name";
+    const value = "San Francisco";
+    const name_value = c.mln_json_value{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_STRING,
+        .data = .{ .string_value = .{ .data = value.ptr, .size = value.len } },
+    };
+    const property = c.mln_json_member{
+        .key = .{ .data = name.ptr, .size = name.len },
+        .value = &name_value,
+    };
+    const feature = c.mln_feature{
+        .size = @sizeOf(c.mln_feature),
+        .geometry = &point,
+        .properties = &property,
+        .property_count = 1,
+        .identifier_type = c.MLN_FEATURE_IDENTIFIER_TYPE_NULL,
+        .identifier = .{ .uint_value = 0 },
+    };
+    const geojson = c.mln_geojson{
+        .size = @sizeOf(c.mln_geojson),
+        .type = c.MLN_GEOJSON_TYPE_FEATURE,
+        .data = .{ .feature = &feature },
+    };
+
+    try testing.expectEqual(@as(u32, c.MLN_JSON_VALUE_TYPE_STRING), name_value.type);
+    try testing.expectEqual(@as(usize, 1), feature.property_count);
+    try testing.expectEqual(@as(u32, c.MLN_GEOJSON_TYPE_FEATURE), geojson.type);
+}

--- a/tests/c/main.zig
+++ b/tests/c/main.zig
@@ -3,6 +3,7 @@ comptime {
     _ = @import("map_lifecycle.zig");
     _ = @import("style.zig");
     _ = @import("resources.zig");
+    _ = @import("geojson.zig");
     _ = @import("camera.zig");
     _ = @import("projection.zig");
     _ = @import("map_tuning.zig");

--- a/tests/c/projection.zig
+++ b/tests/c/projection.zig
@@ -183,6 +183,16 @@ test "standalone projection converts and updates camera" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_get_camera(helper, &snapshot));
     try testing.expect((snapshot.fields & c.MLN_CAMERA_OPTION_CENTER) != 0);
     try testing.expect((snapshot.fields & c.MLN_CAMERA_OPTION_ZOOM) != 0);
+
+    const line = c.mln_geometry{
+        .size = @sizeOf(c.mln_geometry),
+        .type = c.MLN_GEOMETRY_TYPE_LINE_STRING,
+        .data = .{ .line_string = .{ .coordinates = visible[0..].ptr, .coordinate_count = visible.len } },
+    };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_set_visible_geometry(helper, &line, padding));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_projection_get_camera(helper, &snapshot));
+    try testing.expect((snapshot.fields & c.MLN_CAMERA_OPTION_CENTER) != 0);
+    try testing.expect((snapshot.fields & c.MLN_CAMERA_OPTION_ZOOM) != 0);
 }
 
 test "standalone projection rejects invalid arguments" {
@@ -212,6 +222,17 @@ test "standalone projection rejects invalid arguments" {
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_coordinates(helper, null, 0, padding));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_coordinates(helper, null, 1, padding));
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_coordinates(helper, &center, 1, .{ .top = -1.0, .left = 0.0, .bottom = 0.0, .right = 0.0 }));
+
+    var empty_geometry = c.mln_geometry{
+        .size = @sizeOf(c.mln_geometry),
+        .type = c.MLN_GEOMETRY_TYPE_EMPTY,
+        .data = .{ .point = center },
+    };
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_geometry(helper, null, padding));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_geometry(helper, &empty_geometry, padding));
+    empty_geometry.type = c.MLN_GEOMETRY_TYPE_POINT;
+    empty_geometry.data.point = .{ .latitude = std.math.inf(f64), .longitude = 0.0 };
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_projection_set_visible_geometry(helper, &empty_geometry, padding));
 
     var point: c.mln_screen_point = undefined;
     var coordinate: c.mln_lat_lng = undefined;


### PR DESCRIPTION
## Summary
- Add C ABI descriptor structs for MapLibre geometry, JSON values, features, and GeoJSON.
- Add native conversion helpers and wire geometry descriptors into projection camera fitting.
- Clarify ownership/lifetime documentation for descriptor structs and returned region views.

## Tests
- `mise run test`
- pre-commit: dprint, zig-ast-check, clang-tidy

Closes #19