### PR TITLE
Add offline geometry regions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks:
   - cert-*
   - cppcoreguidelines-*
   - -cppcoreguidelines-avoid-magic-numbers
+  - -cppcoreguidelines-pro-type-union-access
   - -readability-magic-numbers
 CheckOptions:
   - key: readability-braces-around-statements.ShortStatementLines

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -21,8 +21,6 @@
 // NOLINTBEGIN(cppcoreguidelines-use-enum-class)
 // Public C ABI structs.
 // NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
-// Public C ABI tagged union.
-// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
 // Public C ABI includes C headers.
 // NOLINTBEGIN(modernize-deprecated-headers)
 // Public C ABI return syntax.
@@ -1173,9 +1171,21 @@ typedef struct mln_offline_tile_pyramid_region_definition {
   bool include_ideographs;
 } mln_offline_tile_pyramid_region_definition;
 
-/** Placeholder for future offline geometry region definitions. */
+/** Geometry offline region definition. */
 typedef struct mln_offline_geometry_region_definition {
   uint32_t size;
+  /** Style URL. Copied during region creation. */
+  const char* style_url;
+  /** Geometry descriptor. Borrowed for the duration of region creation. */
+  const mln_geometry* geometry;
+  double min_zoom;
+  /**
+   * Maximum zoom. Positive infinity follows MapLibre Native behavior and lets
+   * each tile source use its own maximum zoom.
+   */
+  double max_zoom;
+  float pixel_ratio;
+  bool include_ideographs;
 } mln_offline_geometry_region_definition;
 
 /** Tagged offline region definition. */
@@ -1204,15 +1214,14 @@ typedef struct mln_offline_region_info {
  * Creates a tile-pyramid offline region.
  *
  * The returned snapshot owns copied region data. Destroy it with
- * mln_offline_region_snapshot_destroy(). Geometry definitions are not wired to
- * native offline storage yet and return MLN_STATUS_UNSUPPORTED.
+ * mln_offline_region_snapshot_destroy(). Input strings, geometry descriptors,
+ * and metadata are borrowed for the duration of this call and are not retained.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, definition is
  *   null or invalid, metadata is null with a non-zero size, out_region is null,
  *   or *out_region is not null.
- * - MLN_STATUS_UNSUPPORTED when definition is a geometry region.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
@@ -1234,7 +1243,6 @@ MLN_API mln_status mln_runtime_offline_region_create(
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, out_region is
  *   null, *out_region is not null, or out_found is null.
- * - MLN_STATUS_UNSUPPORTED when the stored region uses a geometry definition.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
@@ -1252,7 +1260,6 @@ MLN_API mln_status mln_runtime_offline_region_get(
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live,
  *   out_regions is null, or *out_regions is not null.
- * - MLN_STATUS_UNSUPPORTED when any stored region uses a geometry definition.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
@@ -1274,7 +1281,6 @@ MLN_API mln_status mln_runtime_offline_regions_list(
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live,
  *   side_database_path is null, out_regions is null, or *out_regions is not
  *   null.
- * - MLN_STATUS_UNSUPPORTED when any returned region uses a geometry definition.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
@@ -1295,7 +1301,6 @@ MLN_API mln_status mln_runtime_offline_regions_merge_database(
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not live, metadata is
  *   null with a non-zero size, out_region is null, *out_region is not null, or
  *   no region exists for id.
- * - MLN_STATUS_UNSUPPORTED when the stored region uses a geometry definition.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the runtime
  *   owner thread.
  * - MLN_STATUS_NATIVE_ERROR when a native database error or internal exception
@@ -2934,7 +2939,6 @@ MLN_API mln_status mln_vulkan_owned_texture_release_frame(
 // NOLINTEND(modernize-use-using)
 // NOLINTEND(modernize-use-trailing-return-type)
 // NOLINTEND(modernize-deprecated-headers)
-// NOLINTEND(cppcoreguidelines-pro-type-union-access)
 // NOLINTEND(cppcoreguidelines-pro-type-member-init)
 // NOLINTEND(cppcoreguidelines-use-enum-class)
 

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -1015,6 +1015,9 @@ typedef struct mln_geometry_collection {
  *
  * Geometry coordinates use mln_lat_lng for consistency with the rest of the C
  * API. They are converted to native geometry points as longitude/latitude.
+ * A root geometry descriptor starts at nesting depth 0. Status-returning
+ * functions reject geometry collection children past depth 64 with
+ * MLN_STATUS_INVALID_ARGUMENT.
  */
 typedef struct mln_geometry {
   uint32_t size;
@@ -1069,6 +1072,9 @@ typedef struct mln_json_object {
  *
  * Input functions reject NaN and infinities for double values because JSON and
  * GeoJSON numbers are finite.
+ * A root JSON value descriptor starts at nesting depth 0. Status-returning
+ * functions reject array/object children past depth 64 with
+ * MLN_STATUS_INVALID_ARGUMENT.
  */
 typedef struct mln_json_value {
   uint32_t size;
@@ -1129,7 +1135,11 @@ typedef struct mln_feature_collection {
   size_t feature_count;
 } mln_feature_collection;
 
-/** GeoJSON geometry, feature, or feature collection input descriptor graph. */
+/**
+ * GeoJSON geometry, feature, or feature collection input descriptor graph.
+ * Nested geometry and property descriptors share the 64-depth descriptor limit
+ * documented on mln_geometry and mln_json_value.
+ */
 typedef struct mln_geojson {
   uint32_t size;
   /** One of mln_geojson_type. */

--- a/src/geojson/geojson.cpp
+++ b/src/geojson/geojson.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -38,6 +39,12 @@ auto validate_depth(std::size_t depth) -> bool {
     return false;
   }
   return true;
+}
+
+auto validate_export_depth(std::size_t depth) -> void {
+  if (depth > max_recursive_depth) {
+    throw std::runtime_error("GeoJSON value nesting is too deep");
+  }
 }
 
 auto validate_string(mln_string_view string) -> bool {
@@ -426,11 +433,13 @@ auto coordinate_span(const std::vector<mln_lat_lng>& coordinates)
   };
 }
 
-auto make_geometry_descriptor(const mbgl::Geometry<double>& geometry)
-  -> GeometryDescriptorPtr;
+auto make_geometry_descriptor(
+  const mbgl::Geometry<double>& geometry, std::size_t depth
+) -> GeometryDescriptorPtr;
 
 auto make_geometry_descriptor(
-  const mapbox::geometry::geometry_collection<double>& collection
+  const mapbox::geometry::geometry_collection<double>& collection,
+  std::size_t depth
 ) -> GeometryDescriptorPtr {
   auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
   result->root = mln_geometry{
@@ -441,7 +450,7 @@ auto make_geometry_descriptor(
   result->children.reserve(collection.size());
   result->child_geometries.reserve(collection.size());
   for (const auto& child : collection) {
-    result->children.emplace_back(make_geometry_descriptor(child));
+    result->children.emplace_back(make_geometry_descriptor(child, depth + 1));
   }
   for (const auto& child : result->children) {
     result->child_geometries.emplace_back(child->root);
@@ -550,8 +559,10 @@ auto make_multi_polygon_descriptor(
   return result;
 }
 
-auto make_geometry_descriptor(const mbgl::Geometry<double>& geometry)
-  -> GeometryDescriptorPtr {
+auto make_geometry_descriptor(
+  const mbgl::Geometry<double>& geometry, std::size_t depth
+) -> GeometryDescriptorPtr {
+  validate_export_depth(depth);
   return geometry.match(
     Overloaded{
       [](const mbgl::EmptyGeometry&) -> GeometryDescriptorPtr {
@@ -607,9 +618,9 @@ auto make_geometry_descriptor(const mbgl::Geometry<double>& geometry)
         -> GeometryDescriptorPtr {
         return make_multi_polygon_descriptor(multi_polygon);
       },
-      [](const mapbox::geometry::geometry_collection<double>& collection)
+      [depth](const mapbox::geometry::geometry_collection<double>& collection)
         -> GeometryDescriptorPtr {
-        return make_geometry_descriptor(collection);
+        return make_geometry_descriptor(collection, depth);
       }
     }
   );
@@ -626,7 +637,7 @@ auto to_native_geometry(const mln_geometry* geometry)
 
 auto to_c_geometry(const mbgl::Geometry<double>& geometry)
   -> std::unique_ptr<OwnedGeometryDescriptor> {
-  return make_geometry_descriptor(geometry);
+  return make_geometry_descriptor(geometry, 0);
 }
 
 auto to_native_json_value(const mln_json_value* value)

--- a/src/geojson/geojson.cpp
+++ b/src/geojson/geojson.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iterator>
+#include <memory>
 #include <optional>
 #include <span>
 #include <string>
@@ -19,12 +20,17 @@
 #include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
 
-// Public C ABI uses tagged unions.
-// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
-
 namespace {
 
 constexpr std::size_t max_recursive_depth = 64;
+
+template <class... Ts>
+struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+
+using GeometryDescriptorPtr =
+  std::unique_ptr<mln::core::OwnedGeometryDescriptor>;
 
 auto validate_depth(std::size_t depth) -> bool {
   if (depth > max_recursive_depth) {
@@ -65,6 +71,10 @@ auto validate_coordinate(mln_lat_lng coordinate) -> bool {
 
 auto to_native_point(mln_lat_lng coordinate) -> mbgl::Point<double> {
   return mbgl::Point<double>{coordinate.longitude, coordinate.latitude};
+}
+
+auto from_native_point(const mbgl::Point<double>& point) -> mln_lat_lng {
+  return mln_lat_lng{.latitude = point.y, .longitude = point.x};
 }
 
 auto convert_coordinate_span(mln_coordinate_span span)
@@ -398,6 +408,213 @@ auto convert_feature(const mln_feature* feature, std::size_t depth)
   };
 }
 
+template <typename PointList>
+auto to_coordinate_list(const PointList& points) -> std::vector<mln_lat_lng> {
+  auto result = std::vector<mln_lat_lng>{};
+  result.reserve(points.size());
+  for (const auto& point : points) {
+    result.emplace_back(from_native_point(point));
+  }
+  return result;
+}
+
+auto coordinate_span(const std::vector<mln_lat_lng>& coordinates)
+  -> mln_coordinate_span {
+  return mln_coordinate_span{
+    .coordinates = coordinates.empty() ? nullptr : coordinates.data(),
+    .coordinate_count = coordinates.size()
+  };
+}
+
+auto make_geometry_descriptor(const mbgl::Geometry<double>& geometry)
+  -> GeometryDescriptorPtr;
+
+auto make_geometry_descriptor(
+  const mapbox::geometry::geometry_collection<double>& collection
+) -> GeometryDescriptorPtr {
+  auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
+  result->root = mln_geometry{
+    .size = sizeof(mln_geometry),
+    .type = MLN_GEOMETRY_TYPE_GEOMETRY_COLLECTION,
+    .data = {.geometry_collection = {}}
+  };
+  result->children.reserve(collection.size());
+  result->child_geometries.reserve(collection.size());
+  for (const auto& child : collection) {
+    result->children.emplace_back(make_geometry_descriptor(child));
+  }
+  for (const auto& child : result->children) {
+    result->child_geometries.emplace_back(child->root);
+  }
+  result->root.data.geometry_collection = mln_geometry_collection{
+    .geometries = result->child_geometries.empty()
+                    ? nullptr
+                    : result->child_geometries.data(),
+    .geometry_count = result->child_geometries.size()
+  };
+  return result;
+}
+
+auto make_polygon_descriptor(const mbgl::Polygon<double>& polygon)
+  -> GeometryDescriptorPtr {
+  auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
+  result->coordinate_lists.reserve(polygon.size());
+  result->coordinate_spans.reserve(polygon.size());
+  for (const auto& ring : polygon) {
+    result->coordinate_lists.emplace_back(to_coordinate_list(ring));
+  }
+  for (const auto& coordinates : result->coordinate_lists) {
+    result->coordinate_spans.emplace_back(coordinate_span(coordinates));
+  }
+  result->root = mln_geometry{
+    .size = sizeof(mln_geometry),
+    .type = MLN_GEOMETRY_TYPE_POLYGON,
+    .data = {
+      .polygon = {
+        .rings = result->coordinate_spans.empty()
+                   ? nullptr
+                   : result->coordinate_spans.data(),
+        .ring_count = result->coordinate_spans.size()
+      }
+    }
+  };
+  return result;
+}
+
+auto make_multi_line_descriptor(const mbgl::MultiLineString<double>& multi_line)
+  -> GeometryDescriptorPtr {
+  auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
+  result->coordinate_lists.reserve(multi_line.size());
+  result->coordinate_spans.reserve(multi_line.size());
+  for (const auto& line : multi_line) {
+    result->coordinate_lists.emplace_back(to_coordinate_list(line));
+  }
+  for (const auto& coordinates : result->coordinate_lists) {
+    result->coordinate_spans.emplace_back(coordinate_span(coordinates));
+  }
+  result->root = mln_geometry{
+    .size = sizeof(mln_geometry),
+    .type = MLN_GEOMETRY_TYPE_MULTI_LINE_STRING,
+    .data = {
+      .multi_line_string = {
+        .lines = result->coordinate_spans.empty()
+                   ? nullptr
+                   : result->coordinate_spans.data(),
+        .line_count = result->coordinate_spans.size()
+      }
+    }
+  };
+  return result;
+}
+
+auto make_multi_polygon_descriptor(
+  const mbgl::MultiPolygon<double>& multi_polygon
+) -> GeometryDescriptorPtr {
+  auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
+  auto ring_count = std::size_t{0};
+  for (const auto& polygon : multi_polygon) {
+    ring_count += polygon.size();
+  }
+  result->coordinate_lists.reserve(ring_count);
+  result->coordinate_spans.reserve(ring_count);
+  result->polygons.reserve(multi_polygon.size());
+
+  for (const auto& polygon : multi_polygon) {
+    const auto first_ring = result->coordinate_spans.size();
+    for (const auto& ring : polygon) {
+      result->coordinate_lists.emplace_back(to_coordinate_list(ring));
+      result->coordinate_spans.emplace_back(
+        coordinate_span(result->coordinate_lists.back())
+      );
+    }
+    result->polygons.emplace_back(
+      mln_polygon_geometry{
+        .rings =
+          polygon.empty() ? nullptr : &result->coordinate_spans.at(first_ring),
+        .ring_count = polygon.size()
+      }
+    );
+  }
+
+  result->root = mln_geometry{
+    .size = sizeof(mln_geometry),
+    .type = MLN_GEOMETRY_TYPE_MULTI_POLYGON,
+    .data = {
+      .multi_polygon = {
+        .polygons =
+          result->polygons.empty() ? nullptr : result->polygons.data(),
+        .polygon_count = result->polygons.size()
+      }
+    }
+  };
+  return result;
+}
+
+auto make_geometry_descriptor(const mbgl::Geometry<double>& geometry)
+  -> GeometryDescriptorPtr {
+  return geometry.match(
+    Overloaded{
+      [](const mbgl::EmptyGeometry&) -> GeometryDescriptorPtr {
+        auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
+        result->root = mln_geometry{
+          .size = sizeof(mln_geometry),
+          .type = MLN_GEOMETRY_TYPE_EMPTY,
+          .data = {.point = {}}
+        };
+        return result;
+      },
+      [](const mbgl::Point<double>& point) -> GeometryDescriptorPtr {
+        auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
+        result->root = mln_geometry{
+          .size = sizeof(mln_geometry),
+          .type = MLN_GEOMETRY_TYPE_POINT,
+          .data = {.point = from_native_point(point)}
+        };
+        return result;
+      },
+      [](const mbgl::LineString<double>& line) -> GeometryDescriptorPtr {
+        auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
+        result->coordinate_lists.emplace_back(to_coordinate_list(line));
+        result->root = mln_geometry{
+          .size = sizeof(mln_geometry),
+          .type = MLN_GEOMETRY_TYPE_LINE_STRING,
+          .data = {
+            .line_string = coordinate_span(result->coordinate_lists.front())
+          }
+        };
+        return result;
+      },
+      [](const mbgl::Polygon<double>& polygon) -> GeometryDescriptorPtr {
+        return make_polygon_descriptor(polygon);
+      },
+      [](const mbgl::MultiPoint<double>& points) -> GeometryDescriptorPtr {
+        auto result = std::make_unique<mln::core::OwnedGeometryDescriptor>();
+        result->coordinate_lists.emplace_back(to_coordinate_list(points));
+        result->root = mln_geometry{
+          .size = sizeof(mln_geometry),
+          .type = MLN_GEOMETRY_TYPE_MULTI_POINT,
+          .data = {
+            .multi_point = coordinate_span(result->coordinate_lists.front())
+          }
+        };
+        return result;
+      },
+      [](const mbgl::MultiLineString<double>& multi_line)
+        -> GeometryDescriptorPtr {
+        return make_multi_line_descriptor(multi_line);
+      },
+      [](const mbgl::MultiPolygon<double>& multi_polygon)
+        -> GeometryDescriptorPtr {
+        return make_multi_polygon_descriptor(multi_polygon);
+      },
+      [](const mapbox::geometry::geometry_collection<double>& collection)
+        -> GeometryDescriptorPtr {
+        return make_geometry_descriptor(collection);
+      }
+    }
+  );
+}
+
 }  // namespace
 
 namespace mln::core {
@@ -405,6 +622,11 @@ namespace mln::core {
 auto to_native_geometry(const mln_geometry* geometry)
   -> std::optional<mbgl::Geometry<double>> {
   return convert_geometry(geometry, 0);
+}
+
+auto to_c_geometry(const mbgl::Geometry<double>& geometry)
+  -> std::unique_ptr<OwnedGeometryDescriptor> {
+  return make_geometry_descriptor(geometry);
 }
 
 auto to_native_json_value(const mln_json_value* value)
@@ -479,5 +701,3 @@ auto geometry_lat_lngs(const mbgl::Geometry<double>& geometry)
 }
 
 }  // namespace mln::core
-
-// NOLINTEND(cppcoreguidelines-pro-type-union-access)

--- a/src/geojson/geojson.hpp
+++ b/src/geojson/geojson.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -12,8 +13,19 @@
 
 namespace mln::core {
 
+struct OwnedGeometryDescriptor {
+  mln_geometry root{};
+  std::vector<std::vector<mln_lat_lng>> coordinate_lists;
+  std::vector<mln_coordinate_span> coordinate_spans;
+  std::vector<mln_polygon_geometry> polygons;
+  std::vector<std::unique_ptr<OwnedGeometryDescriptor>> children;
+  std::vector<mln_geometry> child_geometries;
+};
+
 auto to_native_geometry(const mln_geometry* geometry)
   -> std::optional<mbgl::Geometry<double>>;
+auto to_c_geometry(const mbgl::Geometry<double>& geometry)
+  -> std::unique_ptr<OwnedGeometryDescriptor>;
 auto to_native_json_value(const mln_json_value* value)
   -> std::optional<mbgl::Value>;
 auto to_native_feature(const mln_feature* feature)

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -31,6 +31,7 @@
 #include "runtime/runtime.hpp"
 
 #include "diagnostics/diagnostics.hpp"
+#include "geojson/geojson.hpp"
 #include "maplibre_native_c.h"
 
 struct OfflineRegionData {
@@ -42,6 +43,7 @@ struct OfflineRegionData {
   double max_zoom = 0.0;
   float pixel_ratio = 0.0F;
   bool include_ideographs = false;
+  std::unique_ptr<mln::core::OwnedGeometryDescriptor> geometry;
   std::vector<uint8_t> metadata;
 };
 
@@ -177,6 +179,48 @@ auto validate_tile_pyramid_definition(
   return MLN_STATUS_OK;
 }
 
+auto validate_geometry_definition(
+  const mln_offline_geometry_region_definition& definition
+) -> mln_status {
+  if (definition.size < sizeof(mln_offline_geometry_region_definition)) {
+    mln::core::set_thread_error(
+      "mln_offline_geometry_region_definition.size is too small"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (definition.style_url == nullptr) {
+    mln::core::set_thread_error("offline region style_url must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (definition.geometry == nullptr) {
+    mln::core::set_thread_error("offline region geometry must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    !std::isfinite(definition.min_zoom) || definition.min_zoom < 0.0 ||
+    std::isnan(definition.max_zoom) || definition.max_zoom < definition.min_zoom
+  ) {
+    mln::core::set_thread_error("offline region zoom range is invalid");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!std::isfinite(definition.pixel_ratio) || definition.pixel_ratio < 0.0F) {
+    mln::core::set_thread_error("offline region pixel_ratio is invalid");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto geometry = mln::core::to_native_geometry(definition.geometry);
+  if (!geometry) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (mln::core::geometry_lat_lngs(*geometry).empty()) {
+    mln::core::set_thread_error(
+      "offline region geometry must contain at least one coordinate"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
 auto validate_offline_region_definition(
   const mln_offline_region_definition* definition
 ) -> mln_status {
@@ -193,16 +237,9 @@ auto validate_offline_region_definition(
 
   switch (definition->type) {
     case MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID:
-      // Tagged C ABI selects the active member.
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
       return validate_tile_pyramid_definition(definition->data.tile_pyramid);
     case MLN_OFFLINE_REGION_DEFINITION_GEOMETRY:
-      // TODO: Support geometry regions after the shared geometry ABI lands:
-      // https://github.com/sargunv/maplibre-native-ffi/issues/19
-      mln::core::set_thread_error(
-        "offline geometry region definitions are not supported"
-      );
-      return MLN_STATUS_UNSUPPORTED;
+      return validate_geometry_definition(definition->data.geometry);
     default:
       mln::core::set_thread_error("offline region definition type is invalid");
       return MLN_STATUS_INVALID_ARGUMENT;
@@ -212,21 +249,40 @@ auto validate_offline_region_definition(
 auto to_native_offline_region_definition(
   const mln_offline_region_definition& definition
 ) -> mbgl::OfflineRegionDefinition {
-  // Tagged C ABI selects the active member.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
-  const auto& tile = definition.data.tile_pyramid;
-  auto bounds = mbgl::LatLngBounds::hull(
-    {tile.bounds.southwest.latitude, tile.bounds.southwest.longitude},
-    {tile.bounds.northeast.latitude, tile.bounds.northeast.longitude}
-  );
-  return mbgl::OfflineTilePyramidRegionDefinition{
-    std::string{tile.style_url},
-    bounds,
-    tile.min_zoom,
-    tile.max_zoom,
-    tile.pixel_ratio,
-    tile.include_ideographs
-  };
+  switch (definition.type) {
+    case MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID: {
+      const auto& tile = definition.data.tile_pyramid;
+      auto bounds = mbgl::LatLngBounds::hull(
+        {tile.bounds.southwest.latitude, tile.bounds.southwest.longitude},
+        {tile.bounds.northeast.latitude, tile.bounds.northeast.longitude}
+      );
+      return mbgl::OfflineTilePyramidRegionDefinition{
+        std::string{tile.style_url},
+        bounds,
+        tile.min_zoom,
+        tile.max_zoom,
+        tile.pixel_ratio,
+        tile.include_ideographs
+      };
+    }
+    case MLN_OFFLINE_REGION_DEFINITION_GEOMETRY: {
+      const auto& geometry = definition.data.geometry;
+      auto native_geometry = mln::core::to_native_geometry(geometry.geometry);
+      if (!native_geometry) {
+        std::terminate();
+      }
+      return mbgl::OfflineGeometryRegionDefinition{
+        std::string{geometry.style_url},
+        std::move(native_geometry.value()),
+        geometry.min_zoom,
+        geometry.max_zoom,
+        geometry.pixel_ratio,
+        geometry.include_ideographs
+      };
+    }
+    default:
+      std::terminate();
+  }
 }
 
 auto to_c_download_state(mbgl::OfflineRegionDownloadState state) -> uint32_t {
@@ -297,6 +353,7 @@ auto to_c_region_data(const mbgl::OfflineRegion& region)
     .max_zoom = 0.0,
     .pixel_ratio = 0.0F,
     .include_ideographs = false,
+    .geometry = nullptr,
     .metadata = region.getMetadata()
   };
 
@@ -322,9 +379,22 @@ auto to_c_region_data(const mbgl::OfflineRegion& region)
     return data;
   }
 
-  mln::core::set_thread_error(
-    "offline geometry region definitions are not supported"
-  );
+  if (
+    const auto* geometry = std::get_if<mbgl::OfflineGeometryRegionDefinition>(
+      &region.getDefinition()
+    )
+  ) {
+    data.definition_type = MLN_OFFLINE_REGION_DEFINITION_GEOMETRY;
+    data.style_url = geometry->styleURL;
+    data.min_zoom = geometry->minZoom;
+    data.max_zoom = geometry->maxZoom;
+    data.pixel_ratio = geometry->pixelRatio;
+    data.include_ideographs = geometry->includeIdeographs;
+    data.geometry = mln::core::to_c_geometry(geometry->geometry);
+    return data;
+  }
+
+  mln::core::set_thread_error("offline region definition type is unsupported");
   return std::nullopt;
 }
 
@@ -338,27 +408,47 @@ auto fill_region_info(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
+  auto definition = mln_offline_region_definition{
+    .size = sizeof(mln_offline_region_definition),
+    .type = data.definition_type,
+    .data = {}
+  };
+  switch (data.definition_type) {
+    case MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID:
+      definition.data.tile_pyramid = mln_offline_tile_pyramid_region_definition{
+        .size = sizeof(mln_offline_tile_pyramid_region_definition),
+        .style_url = data.style_url.c_str(),
+        .bounds = data.bounds,
+        .min_zoom = data.min_zoom,
+        .max_zoom = data.max_zoom,
+        .pixel_ratio = data.pixel_ratio,
+        .include_ideographs = data.include_ideographs
+      };
+      break;
+    case MLN_OFFLINE_REGION_DEFINITION_GEOMETRY:
+      if (!data.geometry) {
+        mln::core::set_thread_error("offline region geometry is missing");
+        return MLN_STATUS_NATIVE_ERROR;
+      }
+      definition.data.geometry = mln_offline_geometry_region_definition{
+        .size = sizeof(mln_offline_geometry_region_definition),
+        .style_url = data.style_url.c_str(),
+        .geometry = &data.geometry->root,
+        .min_zoom = data.min_zoom,
+        .max_zoom = data.max_zoom,
+        .pixel_ratio = data.pixel_ratio,
+        .include_ideographs = data.include_ideographs
+      };
+      break;
+    default:
+      mln::core::set_thread_error("offline region definition type is invalid");
+      return MLN_STATUS_NATIVE_ERROR;
+  }
+
   *out_info = mln_offline_region_info{
     .size = sizeof(mln_offline_region_info),
     .id = data.id,
-    .definition =
-      mln_offline_region_definition{
-        .size = sizeof(mln_offline_region_definition),
-        .type = data.definition_type,
-        .data =
-          // Tagged C ABI selects the active member.
-          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
-        {.tile_pyramid =
-           mln_offline_tile_pyramid_region_definition{
-             .size = sizeof(mln_offline_tile_pyramid_region_definition),
-             .style_url = data.style_url.c_str(),
-             .bounds = data.bounds,
-             .min_zoom = data.min_zoom,
-             .max_zoom = data.max_zoom,
-             .pixel_ratio = data.pixel_ratio,
-             .include_ideographs = data.include_ideographs
-           }}
-      },
+    .definition = definition,
     .metadata = data.metadata.empty() ? nullptr : data.metadata.data(),
     .metadata_size = data.metadata.size()
   };

--- a/tests/c/resources.zig
+++ b/tests/c/resources.zig
@@ -785,6 +785,26 @@ test "offline tile-pyramid regions validate inputs" {
     definition = offlineGeometryDefinition(&geometry);
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
     try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+
+    var nested_geometries: [66]c.mln_geometry = undefined;
+    nested_geometries[nested_geometries.len - 1] = .{
+        .size = @sizeOf(c.mln_geometry),
+        .type = c.MLN_GEOMETRY_TYPE_POINT,
+        .data = .{ .point = .{ .latitude = 1.0, .longitude = 2.0 } },
+    };
+    var nested_index = nested_geometries.len - 1;
+    while (nested_index > 0) {
+        nested_index -= 1;
+        nested_geometries[nested_index] = .{
+            .size = @sizeOf(c.mln_geometry),
+            .type = c.MLN_GEOMETRY_TYPE_GEOMETRY_COLLECTION,
+            .data = .{ .geometry_collection = .{ .geometries = &nested_geometries[nested_index + 1], .geometry_count = 1 } },
+        };
+    }
+    definition = offlineGeometryDefinition(&nested_geometries[0]);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+    try testing.expectEqualStrings("GeoJSON value nesting is too deep", std.mem.span(c.mln_thread_last_error_message()));
 }
 
 test "offline tile-pyramid regions persist and support metadata lifecycle" {

--- a/tests/c/resources.zig
+++ b/tests/c/resources.zig
@@ -66,6 +66,22 @@ fn offlineTileDefinition() c.mln_offline_region_definition {
     return definition;
 }
 
+fn offlineGeometryDefinition(geometry: *const c.mln_geometry) c.mln_offline_region_definition {
+    var definition: c.mln_offline_region_definition = undefined;
+    definition.size = @sizeOf(c.mln_offline_region_definition);
+    definition.type = c.MLN_OFFLINE_REGION_DEFINITION_GEOMETRY;
+    definition.data.geometry = .{
+        .size = @sizeOf(c.mln_offline_geometry_region_definition),
+        .style_url = offline_style_url,
+        .geometry = geometry,
+        .min_zoom = 5.0,
+        .max_zoom = 6.0,
+        .pixel_ratio = 2.0,
+        .include_ideographs = true,
+    };
+    return definition;
+}
+
 fn offlineRegionInfo() c.mln_offline_region_info {
     var info: c.mln_offline_region_info = undefined;
     info.size = @sizeOf(c.mln_offline_region_info);
@@ -84,6 +100,28 @@ fn checkOfflineRegionInfo(info: *const c.mln_offline_region_info, expected_id: c
     try testing.expectEqual(@as(f64, 6.0), info.definition.data.tile_pyramid.max_zoom);
     try testing.expectEqual(@as(f32, 2.0), info.definition.data.tile_pyramid.pixel_ratio);
     try testing.expect(info.definition.data.tile_pyramid.include_ideographs);
+    try testing.expectEqual(expected_metadata.len, info.metadata_size);
+    try testing.expectEqualSlices(u8, expected_metadata, info.metadata[0..info.metadata_size]);
+}
+
+fn checkOfflineGeometryRegionInfo(info: *const c.mln_offline_region_info, expected_id: c.mln_offline_region_id, expected_metadata: []const u8) !void {
+    try testing.expectEqual(expected_id, info.id);
+    try testing.expectEqual(@as(u32, c.MLN_OFFLINE_REGION_DEFINITION_GEOMETRY), info.definition.type);
+    const definition = info.definition.data.geometry;
+    try testing.expectEqualStrings(offline_style_url, std.mem.span(definition.style_url));
+    try testing.expectEqual(@as(f64, 5.0), definition.min_zoom);
+    try testing.expectEqual(@as(f64, 6.0), definition.max_zoom);
+    try testing.expectEqual(@as(f32, 2.0), definition.pixel_ratio);
+    try testing.expect(definition.include_ideographs);
+    const geometry = definition.geometry orelse return error.MissingGeometry;
+    try testing.expectEqual(@as(u32, c.MLN_GEOMETRY_TYPE_LINE_STRING), geometry[0].type);
+    const line = geometry[0].data.line_string;
+    try testing.expectEqual(@as(usize, 2), line.coordinate_count);
+    try testing.expect(line.coordinates != null);
+    try testing.expectEqual(@as(f64, 1.0), line.coordinates[0].latitude);
+    try testing.expectEqual(@as(f64, 2.0), line.coordinates[0].longitude);
+    try testing.expectEqual(@as(f64, 3.0), line.coordinates[1].latitude);
+    try testing.expectEqual(@as(f64, 4.0), line.coordinates[1].longitude);
     try testing.expectEqual(expected_metadata.len, info.metadata_size);
     try testing.expectEqualSlices(u8, expected_metadata, info.metadata[0..info.metadata_size]);
 }
@@ -724,10 +762,28 @@ test "offline tile-pyramid regions validate inputs" {
         snapshot = null;
     }
 
-    definition = offlineTileDefinition();
-    definition.type = c.MLN_OFFLINE_REGION_DEFINITION_GEOMETRY;
-    definition.data.geometry = .{ .size = @sizeOf(c.mln_offline_geometry_region_definition) };
-    try testing.expectEqual(c.MLN_STATUS_UNSUPPORTED, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    var coordinates = [_]c.mln_lat_lng{
+        .{ .latitude = 1.0, .longitude = 2.0 },
+        .{ .latitude = 3.0, .longitude = 4.0 },
+    };
+    var geometry = c.mln_geometry{
+        .size = @sizeOf(c.mln_geometry),
+        .type = c.MLN_GEOMETRY_TYPE_LINE_STRING,
+        .data = .{ .line_string = .{ .coordinates = coordinates[0..].ptr, .coordinate_count = coordinates.len } },
+    };
+    definition = offlineGeometryDefinition(&geometry);
+    definition.data.geometry.style_url = null;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+
+    definition = offlineGeometryDefinition(&geometry);
+    definition.data.geometry.geometry = null;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
+    try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
+
+    geometry.type = c.MLN_GEOMETRY_TYPE_EMPTY;
+    definition = offlineGeometryDefinition(&geometry);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_runtime_offline_region_create(runtime, &definition, metadata[0..].ptr, metadata.len, &snapshot));
     try testing.expectEqual(@as(?*c.mln_offline_region_snapshot, null), snapshot);
 }
 
@@ -820,6 +876,81 @@ test "offline tile-pyramid regions persist and support metadata lifecycle" {
         var count: usize = 0;
         try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_list_count(list_handle, &count));
         try testing.expectEqual(@as(usize, 0), count);
+    }
+}
+
+test "offline geometry regions persist and expose geometry views" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const cwd = try std.process.currentPathAlloc(testing.io, testing.allocator);
+    defer testing.allocator.free(cwd);
+    const cache_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/.zig-cache/tmp/{s}/cache.db", .{ cwd, tmp.sub_path[0..] }, 0);
+    defer testing.allocator.free(cache_path);
+
+    const metadata = [_]u8{ 7, 8, 9 };
+    var region_id: c.mln_offline_region_id = 0;
+
+    {
+        var runtime: ?*c.mln_runtime = null;
+        var options = c.mln_runtime_options_default();
+        options.cache_path = cache_path.ptr;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_create(&options, &runtime));
+        const runtime_handle = runtime orelse return error.RuntimeCreateFailed;
+        defer support.destroyRuntime(runtime_handle);
+
+        var coordinates = [_]c.mln_lat_lng{
+            .{ .latitude = 1.0, .longitude = 2.0 },
+            .{ .latitude = 3.0, .longitude = 4.0 },
+        };
+        const geometry = c.mln_geometry{
+            .size = @sizeOf(c.mln_geometry),
+            .type = c.MLN_GEOMETRY_TYPE_LINE_STRING,
+            .data = .{ .line_string = .{ .coordinates = coordinates[0..].ptr, .coordinate_count = coordinates.len } },
+        };
+        var definition = offlineGeometryDefinition(&geometry);
+        var created: ?*c.mln_offline_region_snapshot = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_create(runtime_handle, &definition, metadata[0..].ptr, metadata.len, &created));
+        const created_handle = created orelse return error.RegionCreateFailed;
+        defer c.mln_offline_region_snapshot_destroy(created_handle);
+
+        var created_info = offlineRegionInfo();
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_snapshot_get(created_handle, &created_info));
+        try testing.expect(created_info.id > 0);
+        region_id = created_info.id;
+        try checkOfflineGeometryRegionInfo(&created_info, region_id, metadata[0..]);
+
+        var list: ?*c.mln_offline_region_list = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_regions_list(runtime_handle, &list));
+        const list_handle = list orelse return error.RegionListFailed;
+        defer c.mln_offline_region_list_destroy(list_handle);
+        var count: usize = 0;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_list_count(list_handle, &count));
+        try testing.expectEqual(@as(usize, 1), count);
+        var list_info = offlineRegionInfo();
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_list_get(list_handle, 0, &list_info));
+        try checkOfflineGeometryRegionInfo(&list_info, region_id, metadata[0..]);
+    }
+
+    {
+        var runtime: ?*c.mln_runtime = null;
+        var options = c.mln_runtime_options_default();
+        options.cache_path = cache_path.ptr;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_create(&options, &runtime));
+        const runtime_handle = runtime orelse return error.RuntimeCreateFailed;
+        defer support.destroyRuntime(runtime_handle);
+
+        var found = false;
+        var reloaded: ?*c.mln_offline_region_snapshot = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_get(runtime_handle, region_id, &reloaded, &found));
+        try testing.expect(found);
+        const reloaded_handle = reloaded orelse return error.RegionReloadFailed;
+        defer c.mln_offline_region_snapshot_destroy(reloaded_handle);
+
+        var reloaded_info = offlineRegionInfo();
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_offline_region_snapshot_get(reloaded_handle, &reloaded_info));
+        try checkOfflineGeometryRegionInfo(&reloaded_info, region_id, metadata[0..]);
+
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_offline_region_delete(runtime_handle, region_id));
     }
 }
 


### PR DESCRIPTION
## Summary
- Add geometry offline region definitions through the C ABI now that GeoJSON descriptors are available.
- Convert native offline geometry regions back into snapshot/list-owned descriptor views.
- Disable the C-unfriendly union-access clang-tidy check and remove local suppressions.

## Tests
- `mise run test`
- pre-commit: dprint, zig-ast-check, clang-tidy

Closes #13