### PR TITLE
Add camera animation and fitting APIs

### DIFF
--- a/examples/swift-map/Sources/SwiftMap/InputController.swift
+++ b/examples/swift-map/Sources/SwiftMap/InputController.swift
@@ -1,6 +1,10 @@
 import AppKit
 import CMapLibreNativeC
 
+private let keyboardAnimationDurationMS = 160.0
+private let resetAnimationDurationMS = 220.0
+private let preciseScrollDeltaPerWheelStep = 10.0
+
 @MainActor
 final class InputController {
   enum DragMode {
@@ -53,7 +57,8 @@ final class InputController {
   }
 
   func scrollWheel(_ event: NSEvent, map: OpaquePointer?, in view: NSView) throws -> Bool {
-    let delta = -Double(event.scrollingDeltaY)
+    let rawDelta = -Double(event.scrollingDeltaY)
+    let delta = event.hasPreciseScrollingDeltas ? rawDelta / preciseScrollDeltaPerWheelStep : rawDelta
     if delta == 0 { return true }
 
     let location = view.convert(event.locationInWindow, from: nil)
@@ -68,6 +73,7 @@ final class InputController {
     let zoomStep = 1.25
     let bearingStep = 10.0
     let pitchStep = 5.0
+    var animation = cameraAnimation(durationMS: keyboardAnimationDurationMS)
     var center = mln_screen_point(
       x: Double(viewport.logicalWidth) / 2.0,
       y: Double(viewport.logicalHeight) / 2.0
@@ -75,27 +81,28 @@ final class InputController {
 
     switch event.keyCode {
     case 123, 0:
-      try checkCAPI(mln_map_move_by(map, panStep, 0), "keyboard pan failed")
+      try checkCAPI(mln_map_move_by_animated(map, panStep, 0, &animation), "keyboard pan failed")
     case 124, 2:
-      try checkCAPI(mln_map_move_by(map, -panStep, 0), "keyboard pan failed")
+      try checkCAPI(mln_map_move_by_animated(map, -panStep, 0, &animation), "keyboard pan failed")
     case 126, 13:
-      try checkCAPI(mln_map_move_by(map, 0, panStep), "keyboard pan failed")
+      try checkCAPI(mln_map_move_by_animated(map, 0, panStep, &animation), "keyboard pan failed")
     case 125, 1:
-      try checkCAPI(mln_map_move_by(map, 0, -panStep), "keyboard pan failed")
+      try checkCAPI(mln_map_move_by_animated(map, 0, -panStep, &animation), "keyboard pan failed")
     case 24, 69:
-      try checkCAPI(mln_map_scale_by(map, zoomStep, &center), "keyboard zoom failed")
+      try checkCAPI(mln_map_scale_by_animated(map, zoomStep, &center, &animation), "keyboard zoom failed")
     case 27, 78:
-      try checkCAPI(mln_map_scale_by(map, 1.0 / zoomStep, &center), "keyboard zoom failed")
+      try checkCAPI(mln_map_scale_by_animated(map, 1.0 / zoomStep, &center, &animation), "keyboard zoom failed")
     case 12:
-      try adjustBearing(map, -bearingStep)
+      try adjustBearingAnimated(map, -bearingStep, animation: &animation)
     case 14:
-      try adjustBearing(map, bearingStep)
+      try adjustBearingAnimated(map, bearingStep, animation: &animation)
     case 116, 30:
-      try adjustPitch(map, pitchStep)
+      try adjustPitchAnimated(map, pitchStep, animation: &animation)
     case 121, 33:
-      try adjustPitch(map, -pitchStep)
+      try adjustPitchAnimated(map, -pitchStep, animation: &animation)
     case 29:
-      try resetPitchAndBearing(map)
+      var resetAnimation = cameraAnimation(durationMS: resetAnimationDurationMS)
+      try resetPitchAndBearingAnimated(map, animation: &resetAnimation)
     default:
       return false
     }
@@ -109,6 +116,17 @@ final class InputController {
     try checkCAPI(mln_map_jump_to(map, &camera), "keyboard rotate failed")
   }
 
+  private func adjustBearingAnimated(
+    _ map: OpaquePointer?,
+    _ delta: Double,
+    animation: UnsafePointer<mln_animation_options>
+  ) throws {
+    var camera = try currentCamera(map)
+    camera.fields = MLN_CAMERA_OPTION_BEARING.rawValue
+    camera.bearing += delta
+    try checkCAPI(mln_map_ease_to(map, &camera, animation), "keyboard rotate failed")
+  }
+
   private func adjustPitch(_ map: OpaquePointer?, _ delta: Double) throws {
     var camera = try currentCamera(map)
     camera.fields = MLN_CAMERA_OPTION_PITCH.rawValue
@@ -116,17 +134,38 @@ final class InputController {
     try checkCAPI(mln_map_jump_to(map, &camera), "keyboard pitch failed")
   }
 
-  private func resetPitchAndBearing(_ map: OpaquePointer?) throws {
+  private func adjustPitchAnimated(
+    _ map: OpaquePointer?,
+    _ delta: Double,
+    animation: UnsafePointer<mln_animation_options>
+  ) throws {
+    var camera = try currentCamera(map)
+    camera.fields = MLN_CAMERA_OPTION_PITCH.rawValue
+    camera.pitch = min(max(camera.pitch + delta, 0.0), 60.0)
+    try checkCAPI(mln_map_ease_to(map, &camera, animation), "keyboard pitch failed")
+  }
+
+  private func resetPitchAndBearingAnimated(
+    _ map: OpaquePointer?,
+    animation: UnsafePointer<mln_animation_options>
+  ) throws {
     var camera = mln_camera_options_default()
     camera.fields = MLN_CAMERA_OPTION_BEARING.rawValue | MLN_CAMERA_OPTION_PITCH.rawValue
     camera.bearing = 0
     camera.pitch = 0
-    try checkCAPI(mln_map_jump_to(map, &camera), "camera reset failed")
+    try checkCAPI(mln_map_ease_to(map, &camera, animation), "camera reset failed")
   }
 
   private func currentCamera(_ map: OpaquePointer?) throws -> mln_camera_options {
     var camera = mln_camera_options_default()
     try checkCAPI(mln_map_get_camera(map, &camera), "camera snapshot failed")
     return camera
+  }
+
+  private func cameraAnimation(durationMS: Double) -> mln_animation_options {
+    var animation = mln_animation_options_default()
+    animation.fields = MLN_ANIMATION_OPTION_DURATION.rawValue
+    animation.duration_ms = durationMS
+    return animation
   }
 }

--- a/examples/zig-map/input.zig
+++ b/examples/zig-map/input.zig
@@ -11,6 +11,9 @@ const DragMode = enum {
     pitch,
 };
 
+const keyboard_animation_ms = 160.0;
+const reset_animation_ms = 220.0;
+
 pub const Result = struct {
     handled: bool = false,
     camera_changed: bool = false,
@@ -136,6 +139,7 @@ fn handleKeyDown(
     const zoom_step = 1.25;
     const bearing_step = 10.0;
     const pitch_step = 5.0;
+    var animation = cameraAnimation(keyboard_animation_ms);
     const center = point(
         @as(f64, @floatFromInt(current_viewport.logical_width)) / 2.0,
         @as(f64, @floatFromInt(current_viewport.logical_height)) / 2.0,
@@ -143,32 +147,35 @@ fn handleKeyDown(
 
     switch (key.scancode) {
         scancode(c.SDL_SCANCODE_LEFT), scancode(c.SDL_SCANCODE_A) => {
-            try expectCameraStatus(c.mln_map_move_by(map, pan_step, 0), "keyboard pan failed");
+            try expectCameraStatus(c.mln_map_move_by_animated(map, pan_step, 0, &animation), "keyboard pan failed");
         },
         scancode(c.SDL_SCANCODE_RIGHT), scancode(c.SDL_SCANCODE_D) => {
-            try expectCameraStatus(c.mln_map_move_by(map, -pan_step, 0), "keyboard pan failed");
+            try expectCameraStatus(c.mln_map_move_by_animated(map, -pan_step, 0, &animation), "keyboard pan failed");
         },
         scancode(c.SDL_SCANCODE_UP), scancode(c.SDL_SCANCODE_W) => {
-            try expectCameraStatus(c.mln_map_move_by(map, 0, pan_step), "keyboard pan failed");
+            try expectCameraStatus(c.mln_map_move_by_animated(map, 0, pan_step, &animation), "keyboard pan failed");
         },
         scancode(c.SDL_SCANCODE_DOWN), scancode(c.SDL_SCANCODE_S) => {
-            try expectCameraStatus(c.mln_map_move_by(map, 0, -pan_step), "keyboard pan failed");
+            try expectCameraStatus(c.mln_map_move_by_animated(map, 0, -pan_step, &animation), "keyboard pan failed");
         },
         scancode(c.SDL_SCANCODE_EQUALS), scancode(c.SDL_SCANCODE_KP_PLUS) => {
-            try expectCameraStatus(c.mln_map_scale_by(map, zoom_step, &center), "keyboard zoom failed");
+            try expectCameraStatus(c.mln_map_scale_by_animated(map, zoom_step, &center, &animation), "keyboard zoom failed");
         },
         scancode(c.SDL_SCANCODE_MINUS), scancode(c.SDL_SCANCODE_KP_MINUS) => {
-            try expectCameraStatus(c.mln_map_scale_by(map, 1.0 / zoom_step, &center), "keyboard zoom failed");
+            try expectCameraStatus(c.mln_map_scale_by_animated(map, 1.0 / zoom_step, &center, &animation), "keyboard zoom failed");
         },
-        scancode(c.SDL_SCANCODE_Q) => try adjustBearing(map, -bearing_step),
-        scancode(c.SDL_SCANCODE_E) => try adjustBearing(map, bearing_step),
+        scancode(c.SDL_SCANCODE_Q) => try adjustBearingAnimated(map, -bearing_step, &animation),
+        scancode(c.SDL_SCANCODE_E) => try adjustBearingAnimated(map, bearing_step, &animation),
         scancode(c.SDL_SCANCODE_PAGEUP), scancode(c.SDL_SCANCODE_RIGHTBRACKET) => {
-            try adjustPitch(map, pitch_step);
+            try adjustPitchAnimated(map, pitch_step, &animation);
         },
         scancode(c.SDL_SCANCODE_PAGEDOWN), scancode(c.SDL_SCANCODE_LEFTBRACKET) => {
-            try adjustPitch(map, -pitch_step);
+            try adjustPitchAnimated(map, -pitch_step, &animation);
         },
-        scancode(c.SDL_SCANCODE_0) => try resetPitchAndBearing(map),
+        scancode(c.SDL_SCANCODE_0) => {
+            var reset_animation = cameraAnimation(reset_animation_ms);
+            try resetPitchAndBearingAnimated(map, &reset_animation);
+        },
         else => return .{},
     }
 
@@ -191,6 +198,13 @@ fn adjustBearing(map: *c.mln_map, delta: f64) !void {
     try expectCameraStatus(c.mln_map_jump_to(map, &camera), "keyboard rotate failed");
 }
 
+fn adjustBearingAnimated(map: *c.mln_map, delta: f64, animation: *const c.mln_animation_options) !void {
+    var camera = try currentCamera(map);
+    camera.fields = c.MLN_CAMERA_OPTION_BEARING;
+    camera.bearing += delta;
+    try expectCameraStatus(c.mln_map_ease_to(map, &camera, animation), "keyboard rotate failed");
+}
+
 fn adjustPitch(map: *c.mln_map, delta: f64) !void {
     var camera = try currentCamera(map);
     camera.fields = c.MLN_CAMERA_OPTION_PITCH;
@@ -198,12 +212,19 @@ fn adjustPitch(map: *c.mln_map, delta: f64) !void {
     try expectCameraStatus(c.mln_map_jump_to(map, &camera), "keyboard pitch failed");
 }
 
-fn resetPitchAndBearing(map: *c.mln_map) !void {
+fn adjustPitchAnimated(map: *c.mln_map, delta: f64, animation: *const c.mln_animation_options) !void {
+    var camera = try currentCamera(map);
+    camera.fields = c.MLN_CAMERA_OPTION_PITCH;
+    camera.pitch = clamp(camera.pitch + delta, 0.0, 60.0);
+    try expectCameraStatus(c.mln_map_ease_to(map, &camera, animation), "keyboard pitch failed");
+}
+
+fn resetPitchAndBearingAnimated(map: *c.mln_map, animation: *const c.mln_animation_options) !void {
     var camera = c.mln_camera_options_default();
     camera.fields = c.MLN_CAMERA_OPTION_BEARING | c.MLN_CAMERA_OPTION_PITCH;
     camera.bearing = 0;
     camera.pitch = 0;
-    try expectCameraStatus(c.mln_map_jump_to(map, &camera), "camera reset failed");
+    try expectCameraStatus(c.mln_map_ease_to(map, &camera, animation), "camera reset failed");
 }
 
 fn currentCamera(map: *c.mln_map) !c.mln_camera_options {
@@ -220,6 +241,13 @@ fn expectCameraStatus(status: c.mln_status, message: []const u8) !void {
 
 fn point(x: f64, y: f64) c.mln_screen_point {
     return .{ .x = x, .y = y };
+}
+
+fn cameraAnimation(duration_ms: f64) c.mln_animation_options {
+    var animation = c.mln_animation_options_default();
+    animation.fields = c.MLN_ANIMATION_OPTION_DURATION;
+    animation.duration_ms = duration_ms;
+    return animation;
 }
 
 fn scancode(value: c_int) c.SDL_Scancode {

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -1012,7 +1012,10 @@ typedef struct mln_unit_bezier {
 typedef struct mln_animation_options {
   uint32_t size;
   uint32_t fields;
-  /** Duration in milliseconds. Must fit the native duration range. */
+  /**
+   * Duration in milliseconds. Must be finite and non-negative. Values that
+   * would overflow MapLibre Native's internal duration are invalid.
+   */
   double duration_ms;
   /** Average flyTo velocity in screenfuls per second. Must be positive. */
   double velocity;

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -1012,8 +1012,7 @@ typedef struct mln_unit_bezier {
 typedef struct mln_animation_options {
   uint32_t size;
   uint32_t fields;
-  /** Duration in milliseconds. Must be finite and greater than or equal to 0.
-   */
+  /** Duration in milliseconds. Must fit the native duration range. */
   double duration_ms;
   /** Average flyTo velocity in screenfuls per second. Must be positive. */
   double velocity;

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -849,7 +849,42 @@ typedef enum mln_camera_option_field : uint32_t {
   MLN_CAMERA_OPTION_ZOOM = 1U << 1U,
   MLN_CAMERA_OPTION_BEARING = 1U << 2U,
   MLN_CAMERA_OPTION_PITCH = 1U << 3U,
+  MLN_CAMERA_OPTION_CENTER_ALTITUDE = 1U << 4U,
+  MLN_CAMERA_OPTION_PADDING = 1U << 5U,
+  MLN_CAMERA_OPTION_ANCHOR = 1U << 6U,
+  MLN_CAMERA_OPTION_ROLL = 1U << 7U,
+  MLN_CAMERA_OPTION_FOV = 1U << 8U,
 } mln_camera_option_field;
+
+/** Field mask values for mln_animation_options. */
+typedef enum mln_animation_option_field : uint32_t {
+  MLN_ANIMATION_OPTION_DURATION = 1U << 0U,
+  MLN_ANIMATION_OPTION_VELOCITY = 1U << 1U,
+  MLN_ANIMATION_OPTION_MIN_ZOOM = 1U << 2U,
+  MLN_ANIMATION_OPTION_EASING = 1U << 3U,
+} mln_animation_option_field;
+
+/** Field mask values for mln_camera_fit_options. */
+typedef enum mln_camera_fit_option_field : uint32_t {
+  MLN_CAMERA_FIT_OPTION_PADDING = 1U << 0U,
+  MLN_CAMERA_FIT_OPTION_BEARING = 1U << 1U,
+  MLN_CAMERA_FIT_OPTION_PITCH = 1U << 2U,
+} mln_camera_fit_option_field;
+
+/** Field mask values for mln_bound_options. */
+typedef enum mln_bound_option_field : uint32_t {
+  MLN_BOUND_OPTION_BOUNDS = 1U << 0U,
+  MLN_BOUND_OPTION_MIN_ZOOM = 1U << 1U,
+  MLN_BOUND_OPTION_MAX_ZOOM = 1U << 2U,
+  MLN_BOUND_OPTION_MIN_PITCH = 1U << 3U,
+  MLN_BOUND_OPTION_MAX_PITCH = 1U << 4U,
+} mln_bound_option_field;
+
+/** Field mask values for mln_free_camera_options. */
+typedef enum mln_free_camera_option_field : uint32_t {
+  MLN_FREE_CAMERA_OPTION_POSITION = 1U << 0U,
+  MLN_FREE_CAMERA_OPTION_ORIENTATION = 1U << 1U,
+} mln_free_camera_option_field;
 
 /** Field mask values for MapLibre axonometric rendering options. */
 typedef enum mln_projection_mode_field : uint32_t {
@@ -935,16 +970,89 @@ typedef struct mln_map_options {
   uint32_t map_mode;
 } mln_map_options;
 
+/** Screen-space point in logical map pixels. */
+typedef struct mln_screen_point {
+  double x;
+  double y;
+} mln_screen_point;
+
+/** Screen-space inset in logical map pixels. */
+typedef struct mln_edge_insets {
+  double top;
+  double left;
+  double bottom;
+  double right;
+} mln_edge_insets;
+
 /** Camera fields used for snapshots and camera commands. */
 typedef struct mln_camera_options {
   uint32_t size;
   uint32_t fields;
   double latitude;
   double longitude;
+  double center_altitude;
+  mln_edge_insets padding;
+  mln_screen_point anchor;
   double zoom;
   double bearing;
   double pitch;
+  double roll;
+  double field_of_view;
 } mln_camera_options;
+
+/** Cubic easing curve for animated camera transitions. */
+typedef struct mln_unit_bezier {
+  double x1;
+  double y1;
+  double x2;
+  double y2;
+} mln_unit_bezier;
+
+/** Optional animation controls for camera transitions. */
+typedef struct mln_animation_options {
+  uint32_t size;
+  uint32_t fields;
+  /** Duration in milliseconds. Must be finite and greater than or equal to 0.
+   */
+  double duration_ms;
+  /** Average flyTo velocity in screenfuls per second. Must be positive. */
+  double velocity;
+  /** Peak zoom for flyTo transitions. */
+  double min_zoom;
+  mln_unit_bezier easing;
+} mln_animation_options;
+
+/** Optional fitting controls for camera-for-viewport queries. */
+typedef struct mln_camera_fit_options {
+  uint32_t size;
+  uint32_t fields;
+  mln_edge_insets padding;
+  double bearing;
+  double pitch;
+} mln_camera_fit_options;
+
+/** Three-component vector used by free camera options. */
+typedef struct mln_vec3 {
+  double x;
+  double y;
+  double z;
+} mln_vec3;
+
+/** Quaternion stored as x, y, z, w components. */
+typedef struct mln_quaternion {
+  double x;
+  double y;
+  double z;
+  double w;
+} mln_quaternion;
+
+/** Free camera position and orientation in MapLibre Native camera space. */
+typedef struct mln_free_camera_options {
+  uint32_t size;
+  uint32_t fields;
+  mln_vec3 position;
+  mln_quaternion orientation;
+} mln_free_camera_options;
 
 /** Geographic coordinate in degrees used by map and projection APIs. */
 typedef struct mln_lat_lng {
@@ -1156,6 +1264,17 @@ typedef struct mln_lat_lng_bounds {
   mln_lat_lng southwest;
   mln_lat_lng northeast;
 } mln_lat_lng_bounds;
+
+/** Optional map camera constraint fields. */
+typedef struct mln_bound_options {
+  uint32_t size;
+  uint32_t fields;
+  mln_lat_lng_bounds bounds;
+  double min_zoom;
+  double max_zoom;
+  double min_pitch;
+  double max_pitch;
+} mln_bound_options;
 
 /** Tile-pyramid offline region definition. */
 typedef struct mln_offline_tile_pyramid_region_definition {
@@ -1452,20 +1571,6 @@ MLN_API void mln_offline_region_list_destroy(
   mln_offline_region_list* list
 ) MLN_NOEXCEPT;
 
-/** Screen-space point in logical map pixels. */
-typedef struct mln_screen_point {
-  double x;
-  double y;
-} mln_screen_point;
-
-/** Screen-space inset in logical map pixels. */
-typedef struct mln_edge_insets {
-  double top;
-  double left;
-  double bottom;
-  double right;
-} mln_edge_insets;
-
 /**
  * Lower-level Spherical Mercator projected-meter coordinate.
  *
@@ -1650,6 +1755,20 @@ mln_map_set_style_json(mln_map* map, const char* json) MLN_NOEXCEPT;
  * Returns empty camera options initialized for this C API version.
  */
 MLN_API mln_camera_options mln_camera_options_default(void) MLN_NOEXCEPT;
+
+/** Returns empty animation options initialized for this C API version. */
+MLN_API mln_animation_options mln_animation_options_default(void) MLN_NOEXCEPT;
+
+/** Returns empty camera fitting options initialized for this C API version. */
+MLN_API mln_camera_fit_options
+mln_camera_fit_options_default(void) MLN_NOEXCEPT;
+
+/** Returns empty map bound options initialized for this C API version. */
+MLN_API mln_bound_options mln_bound_options_default(void) MLN_NOEXCEPT;
+
+/** Returns empty free camera options initialized for this C API version. */
+MLN_API mln_free_camera_options
+mln_free_camera_options_default(void) MLN_NOEXCEPT;
 
 /**
  * Returns empty axonometric rendering options initialized for this C API
@@ -1844,7 +1963,8 @@ mln_map_get_camera(mln_map* map, mln_camera_options* out_camera) MLN_NOEXCEPT;
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, camera is null,
- *   camera->size is too small, or camera->fields contains unknown bits.
+ *   camera->size is too small, camera->fields contains unknown bits, or an
+ *   enabled camera field is invalid.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
@@ -1853,11 +1973,54 @@ MLN_API mln_status
 mln_map_jump_to(mln_map* map, const mln_camera_options* camera) MLN_NOEXCEPT;
 
 /**
+ * Applies a camera ease transition command.
+ *
+ * Only fields indicated by camera->fields affect the map. Passing a null
+ * animation uses MapLibre Native's default animation options.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, camera is null,
+ *   camera->size is too small, camera->fields contains unknown bits, an enabled
+ *   camera field is invalid, animation->size is too small, animation->fields
+ *   contains unknown bits, or an enabled animation field is invalid.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_ease_to(
+  mln_map* map, const mln_camera_options* camera,
+  const mln_animation_options* animation
+) MLN_NOEXCEPT;
+
+/**
+ * Applies a camera fly transition command.
+ *
+ * Only fields indicated by camera->fields affect the map. Passing a null
+ * animation uses MapLibre Native's default animation options.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, camera is null,
+ *   camera->size is too small, camera->fields contains unknown bits, an enabled
+ *   camera field is invalid, animation->size is too small, animation->fields
+ *   contains unknown bits, or an enabled animation field is invalid.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_fly_to(
+  mln_map* map, const mln_camera_options* camera,
+  const mln_animation_options* animation
+) MLN_NOEXCEPT;
+
+/**
  * Applies a screen-space pan command.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, or a delta value
+ *   is non-finite.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
@@ -1866,13 +2029,33 @@ MLN_API mln_status
 mln_map_move_by(mln_map* map, double delta_x, double delta_y) MLN_NOEXCEPT;
 
 /**
+ * Applies an animated screen-space pan command.
+ *
+ * Passing a null animation uses MapLibre Native's default animation options.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, a delta value is
+ *   non-finite, animation->size is too small, animation->fields contains
+ *   unknown bits, or an enabled animation field is invalid.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_move_by_animated(
+  mln_map* map, double delta_x, double delta_y,
+  const mln_animation_options* animation
+) MLN_NOEXCEPT;
+
+/**
  * Applies a screen-space zoom command.
  *
  * Passing a null anchor uses MapLibre Native's default zoom anchor.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, scale is
+ *   non-positive or non-finite, or anchor contains non-finite values.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
@@ -1882,11 +2065,33 @@ MLN_API mln_status mln_map_scale_by(
 ) MLN_NOEXCEPT;
 
 /**
+ * Applies an animated screen-space zoom command.
+ *
+ * Passing a null anchor uses MapLibre Native's default zoom anchor. Passing a
+ * null animation uses MapLibre Native's default animation options.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, scale is
+ *   non-positive or non-finite, anchor contains non-finite values,
+ *   animation->size is too small, animation->fields contains unknown bits, or
+ *   an enabled animation field is invalid.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_scale_by_animated(
+  mln_map* map, double scale, const mln_screen_point* anchor,
+  const mln_animation_options* animation
+) MLN_NOEXCEPT;
+
+/**
  * Applies a screen-space rotate command.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, or a point
+ *   contains non-finite values.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
@@ -1896,16 +2101,54 @@ MLN_API mln_status mln_map_rotate_by(
 ) MLN_NOEXCEPT;
 
 /**
+ * Applies an animated screen-space rotate command.
+ *
+ * Passing a null animation uses MapLibre Native's default animation options.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, a point contains
+ *   non-finite values, animation->size is too small, animation->fields contains
+ *   unknown bits, or an enabled animation field is invalid.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_rotate_by_animated(
+  mln_map* map, mln_screen_point first, mln_screen_point second,
+  const mln_animation_options* animation
+) MLN_NOEXCEPT;
+
+/**
  * Applies a pitch delta command.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
- * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, or pitch is
+ *   non-finite.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_map_pitch_by(mln_map* map, double pitch) MLN_NOEXCEPT;
+
+/**
+ * Applies an animated pitch delta command.
+ *
+ * Passing a null animation uses MapLibre Native's default animation options.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, pitch is
+ *   non-finite, animation->size is too small, animation->fields contains
+ *   unknown bits, or an enabled animation field is invalid.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_pitch_by_animated(
+  mln_map* map, double pitch, const mln_animation_options* animation
+) MLN_NOEXCEPT;
 
 /**
  * Cancels active camera transitions.
@@ -1918,6 +2161,172 @@ MLN_API mln_status mln_map_pitch_by(mln_map* map, double pitch) MLN_NOEXCEPT;
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_map_cancel_transitions(mln_map* map) MLN_NOEXCEPT;
+
+/**
+ * Computes a camera that fits geographic bounds in the current viewport.
+ *
+ * Passing null fit_options uses zero padding with no bearing or pitch override.
+ * On success, *out_camera is overwritten.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, bounds are
+ *   invalid, fit_options is invalid, out_camera is null, or out_camera->size is
+ *   too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_camera_for_lat_lng_bounds(
+  mln_map* map, mln_lat_lng_bounds bounds,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) MLN_NOEXCEPT;
+
+/**
+ * Computes a camera that fits geographic coordinates in the current viewport.
+ *
+ * The coordinates array is borrowed for the duration of this call and is not
+ * retained. Passing null fit_options uses zero padding with no bearing or pitch
+ * override. On success, *out_camera is overwritten.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, coordinates is
+ *   null, coordinate_count is 0, any coordinate is invalid, fit_options is
+ *   invalid, out_camera is null, or out_camera->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_camera_for_lat_lngs(
+  mln_map* map, const mln_lat_lng* coordinates, size_t coordinate_count,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) MLN_NOEXCEPT;
+
+/**
+ * Computes a camera that fits a geometry in the current viewport.
+ *
+ * The geometry descriptor graph is borrowed for the duration of this call and
+ * is not retained. Empty geometry objects and geometry collections with no
+ * coordinates are invalid for camera fitting. Passing null fit_options uses
+ * zero padding with no bearing or pitch override. On success, *out_camera is
+ * overwritten.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, geometry is null
+ *   or invalid, geometry contains no coordinates, fit_options is invalid,
+ *   out_camera is null, or out_camera->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_camera_for_geometry(
+  mln_map* map, const mln_geometry* geometry,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) MLN_NOEXCEPT;
+
+/**
+ * Computes wrapped geographic bounds for a camera in the current viewport.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, camera is null or
+ *   invalid, or out_bounds is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_lat_lng_bounds_for_camera(
+  mln_map* map, const mln_camera_options* camera, mln_lat_lng_bounds* out_bounds
+) MLN_NOEXCEPT;
+
+/**
+ * Computes unwrapped geographic bounds for a camera in the current viewport.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, camera is null or
+ *   invalid, or out_bounds is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_lat_lng_bounds_for_camera_unwrapped(
+  mln_map* map, const mln_camera_options* camera, mln_lat_lng_bounds* out_bounds
+) MLN_NOEXCEPT;
+
+/**
+ * Copies map camera constraint options.
+ *
+ * On success, *out_options is overwritten and all known fields are marked.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_options is
+ *   null, or out_options->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_map_get_bounds(mln_map* map, mln_bound_options* out_options) MLN_NOEXCEPT;
+
+/**
+ * Applies selected map camera constraint options.
+ *
+ * Only fields indicated by options->fields affect the map.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, options is null,
+ *   options->size is too small, options->fields contains unknown bits, bounds
+ *   are invalid, a numeric field is non-finite, or paired min/max fields are
+ *   inconsistent.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status
+mln_map_set_bounds(mln_map* map, const mln_bound_options* options) MLN_NOEXCEPT;
+
+/**
+ * Copies the current free camera position and orientation.
+ *
+ * On success, *out_options is overwritten.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_options is
+ *   null, or out_options->size is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_free_camera_options(
+  mln_map* map, mln_free_camera_options* out_options
+) MLN_NOEXCEPT;
+
+/**
+ * Applies selected free camera position and orientation fields.
+ *
+ * Position uses MapLibre Native's modified Web Mercator camera space.
+ * Orientation is a quaternion stored as x, y, z, w. Only fields indicated by
+ * options->fields affect the map.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, options is null,
+ *   options->size is too small, options->fields contains unknown bits, position
+ *   contains non-finite values, or orientation contains non-finite values or is
+ *   zero length.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_free_camera_options(
+  mln_map* map, const mln_free_camera_options* options
+) MLN_NOEXCEPT;
 
 /**
  * Copies the current axonometric rendering options.

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -16,6 +16,22 @@ auto mln_camera_options_default(void) noexcept -> mln_camera_options {
   return mln::core::camera_options_default();
 }
 
+auto mln_animation_options_default(void) noexcept -> mln_animation_options {
+  return mln::core::animation_options_default();
+}
+
+auto mln_camera_fit_options_default(void) noexcept -> mln_camera_fit_options {
+  return mln::core::camera_fit_options_default();
+}
+
+auto mln_bound_options_default(void) noexcept -> mln_bound_options {
+  return mln::core::bound_options_default();
+}
+
+auto mln_free_camera_options_default(void) noexcept -> mln_free_camera_options {
+  return mln::core::free_camera_options_default();
+}
+
 auto mln_projection_mode_default(void) noexcept -> mln_projection_mode {
   return mln::core::projection_mode_default();
 }
@@ -80,6 +96,24 @@ auto mln_map_jump_to(mln_map* map, const mln_camera_options* camera) noexcept
   -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_jump_to(map, camera);
+  });
+}
+
+auto mln_map_ease_to(
+  mln_map* map, const mln_camera_options* camera,
+  const mln_animation_options* animation
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_ease_to(map, camera, animation);
+  });
+}
+
+auto mln_map_fly_to(
+  mln_map* map, const mln_camera_options* camera,
+  const mln_animation_options* animation
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_fly_to(map, camera, animation);
   });
 }
 
@@ -310,11 +344,29 @@ auto mln_map_move_by(mln_map* map, double delta_x, double delta_y) noexcept
   });
 }
 
+auto mln_map_move_by_animated(
+  mln_map* map, double delta_x, double delta_y,
+  const mln_animation_options* animation
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_move_by_animated(map, delta_x, delta_y, animation);
+  });
+}
+
 auto mln_map_scale_by(
   mln_map* map, double scale, const mln_screen_point* anchor
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_scale_by(map, scale, anchor);
+  });
+}
+
+auto mln_map_scale_by_animated(
+  mln_map* map, double scale, const mln_screen_point* anchor,
+  const mln_animation_options* animation
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_scale_by_animated(map, scale, anchor, animation);
   });
 }
 
@@ -326,14 +378,112 @@ auto mln_map_rotate_by(
   });
 }
 
+auto mln_map_rotate_by_animated(
+  mln_map* map, mln_screen_point first, mln_screen_point second,
+  const mln_animation_options* animation
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_rotate_by_animated(map, first, second, animation);
+  });
+}
+
 auto mln_map_pitch_by(mln_map* map, double pitch) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_pitch_by(map, pitch);
   });
 }
 
+auto mln_map_pitch_by_animated(
+  mln_map* map, double pitch, const mln_animation_options* animation
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_pitch_by_animated(map, pitch, animation);
+  });
+}
+
 auto mln_map_cancel_transitions(mln_map* map) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_cancel_transitions(map);
+  });
+}
+
+auto mln_map_camera_for_lat_lng_bounds(
+  mln_map* map, mln_lat_lng_bounds bounds,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_camera_for_lat_lng_bounds(
+      map, bounds, fit_options, out_camera
+    );
+  });
+}
+
+auto mln_map_camera_for_lat_lngs(
+  mln_map* map, const mln_lat_lng* coordinates, size_t coordinate_count,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_camera_for_lat_lngs(
+      map, coordinates, coordinate_count, fit_options, out_camera
+    );
+  });
+}
+
+auto mln_map_camera_for_geometry(
+  mln_map* map, const mln_geometry* geometry,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_camera_for_geometry(
+      map, geometry, fit_options, out_camera
+    );
+  });
+}
+
+auto mln_map_lat_lng_bounds_for_camera(
+  mln_map* map, const mln_camera_options* camera, mln_lat_lng_bounds* out_bounds
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_lat_lng_bounds_for_camera(map, camera, out_bounds);
+  });
+}
+
+auto mln_map_lat_lng_bounds_for_camera_unwrapped(
+  mln_map* map, const mln_camera_options* camera, mln_lat_lng_bounds* out_bounds
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_lat_lng_bounds_for_camera_unwrapped(
+      map, camera, out_bounds
+    );
+  });
+}
+
+auto mln_map_get_bounds(mln_map* map, mln_bound_options* out_options) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_bounds(map, out_options);
+  });
+}
+
+auto mln_map_set_bounds(mln_map* map, const mln_bound_options* options) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_bounds(map, options);
+  });
+}
+
+auto mln_map_get_free_camera_options(
+  mln_map* map, mln_free_camera_options* out_options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_free_camera_options(map, out_options);
+  });
+}
+
+auto mln_map_set_free_camera_options(
+  mln_map* map, const mln_free_camera_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_free_camera_options(map, options);
   });
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -7,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <ratio>
 #include <span>
 #include <string>
 #include <thread>
@@ -16,6 +18,7 @@
 
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/gfx/rendering_stats.hpp>
+#include <mbgl/map/bound_options.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_observer.hpp>
@@ -29,9 +32,11 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/tile/tile_operation.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/size.hpp>
+#include <mbgl/util/vectors.hpp>
 
 #include "map/map.hpp"
 
@@ -399,6 +404,11 @@ auto exception_message(std::exception_ptr error) -> std::string {
   }
 }
 
+auto validate_lat_lng(mln_lat_lng coordinate) -> mln_status;
+auto validate_lat_lng_bounds(mln_lat_lng_bounds bounds) -> mln_status;
+auto validate_edge_insets(mln_edge_insets padding) -> mln_status;
+auto validate_screen_point(mln_screen_point point) -> mln_status;
+
 auto validate_camera_options(const mln_camera_options* camera) -> mln_status {
   if (camera == nullptr) {
     mln::core::set_thread_error("camera must not be null");
@@ -412,7 +422,9 @@ auto validate_camera_options(const mln_camera_options* camera) -> mln_status {
 
   constexpr auto known_fields =
     static_cast<uint32_t>(MLN_CAMERA_OPTION_CENTER) | MLN_CAMERA_OPTION_ZOOM |
-    MLN_CAMERA_OPTION_BEARING | MLN_CAMERA_OPTION_PITCH;
+    MLN_CAMERA_OPTION_BEARING | MLN_CAMERA_OPTION_PITCH |
+    MLN_CAMERA_OPTION_CENTER_ALTITUDE | MLN_CAMERA_OPTION_PADDING |
+    MLN_CAMERA_OPTION_ANCHOR | MLN_CAMERA_OPTION_ROLL | MLN_CAMERA_OPTION_FOV;
   if ((camera->fields & ~known_fields) != 0U) {
     mln::core::set_thread_error(
       "mln_camera_options.fields contains unknown bits"
@@ -420,6 +432,272 @@ auto validate_camera_options(const mln_camera_options* camera) -> mln_status {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
+  if ((camera->fields & MLN_CAMERA_OPTION_CENTER) != 0U) {
+    const auto status = validate_lat_lng(
+      mln_lat_lng{.latitude = camera->latitude, .longitude = camera->longitude}
+    );
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  if (
+    ((camera->fields & MLN_CAMERA_OPTION_CENTER_ALTITUDE) != 0U &&
+     !std::isfinite(camera->center_altitude)) ||
+    ((camera->fields & MLN_CAMERA_OPTION_ZOOM) != 0U &&
+     !std::isfinite(camera->zoom)) ||
+    ((camera->fields & MLN_CAMERA_OPTION_BEARING) != 0U &&
+     !std::isfinite(camera->bearing)) ||
+    ((camera->fields & MLN_CAMERA_OPTION_PITCH) != 0U &&
+     !std::isfinite(camera->pitch)) ||
+    ((camera->fields & MLN_CAMERA_OPTION_ROLL) != 0U &&
+     !std::isfinite(camera->roll)) ||
+    ((camera->fields & MLN_CAMERA_OPTION_FOV) != 0U &&
+     !std::isfinite(camera->field_of_view))
+  ) {
+    mln::core::set_thread_error("enabled camera numeric fields must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if ((camera->fields & MLN_CAMERA_OPTION_PADDING) != 0U) {
+    const auto status = validate_edge_insets(camera->padding);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  if ((camera->fields & MLN_CAMERA_OPTION_ANCHOR) != 0U) {
+    const auto status = validate_screen_point(camera->anchor);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+
+  return MLN_STATUS_OK;
+}
+
+auto validate_animation_options(const mln_animation_options* animation)
+  -> mln_status {
+  if (animation == nullptr) {
+    return MLN_STATUS_OK;
+  }
+  if (animation->size < sizeof(mln_animation_options)) {
+    mln::core::set_thread_error("mln_animation_options.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_ANIMATION_OPTION_DURATION) |
+    MLN_ANIMATION_OPTION_VELOCITY | MLN_ANIMATION_OPTION_MIN_ZOOM |
+    MLN_ANIMATION_OPTION_EASING;
+  if ((animation->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_animation_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    (animation->fields & MLN_ANIMATION_OPTION_DURATION) != 0U &&
+    (!std::isfinite(animation->duration_ms) || animation->duration_ms < 0.0)
+  ) {
+    mln::core::set_thread_error(
+      "animation duration_ms must be finite and greater than or equal to 0"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    (animation->fields & MLN_ANIMATION_OPTION_VELOCITY) != 0U &&
+    (!std::isfinite(animation->velocity) || animation->velocity <= 0.0)
+  ) {
+    mln::core::set_thread_error(
+      "animation velocity must be positive and finite"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    (animation->fields & MLN_ANIMATION_OPTION_MIN_ZOOM) != 0U &&
+    !std::isfinite(animation->min_zoom)
+  ) {
+    mln::core::set_thread_error("animation min_zoom must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if ((animation->fields & MLN_ANIMATION_OPTION_EASING) != 0U) {
+    const auto easing = animation->easing;
+    if (
+      !std::isfinite(easing.x1) || !std::isfinite(easing.y1) ||
+      !std::isfinite(easing.x2) || !std::isfinite(easing.y2) ||
+      easing.x1 < 0.0 || easing.x1 > 1.0 || easing.x2 < 0.0 || easing.x2 > 1.0
+    ) {
+      mln::core::set_thread_error(
+        "animation easing x values must be within [0, 1] and all easing values "
+        "must be finite"
+      );
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_camera_fit_options(const mln_camera_fit_options* options)
+  -> mln_status {
+  if (options == nullptr) {
+    return MLN_STATUS_OK;
+  }
+  if (options->size < sizeof(mln_camera_fit_options)) {
+    mln::core::set_thread_error("mln_camera_fit_options.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_CAMERA_FIT_OPTION_PADDING) |
+    MLN_CAMERA_FIT_OPTION_BEARING | MLN_CAMERA_FIT_OPTION_PITCH;
+  if ((options->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_camera_fit_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if ((options->fields & MLN_CAMERA_FIT_OPTION_PADDING) != 0U) {
+    const auto status = validate_edge_insets(options->padding);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  if (
+    ((options->fields & MLN_CAMERA_FIT_OPTION_BEARING) != 0U &&
+     !std::isfinite(options->bearing)) ||
+    ((options->fields & MLN_CAMERA_FIT_OPTION_PITCH) != 0U &&
+     !std::isfinite(options->pitch))
+  ) {
+    mln::core::set_thread_error("camera fit bearing and pitch must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_bound_options(const mln_bound_options* options) -> mln_status {
+  if (options == nullptr) {
+    mln::core::set_thread_error("bound options must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (options->size < sizeof(mln_bound_options)) {
+    mln::core::set_thread_error("mln_bound_options.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_BOUND_OPTION_BOUNDS) | MLN_BOUND_OPTION_MIN_ZOOM |
+    MLN_BOUND_OPTION_MAX_ZOOM | MLN_BOUND_OPTION_MIN_PITCH |
+    MLN_BOUND_OPTION_MAX_PITCH;
+  if ((options->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_bound_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if ((options->fields & MLN_BOUND_OPTION_BOUNDS) != 0U) {
+    const auto status = validate_lat_lng_bounds(options->bounds);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  if (
+    ((options->fields & MLN_BOUND_OPTION_MIN_ZOOM) != 0U &&
+     !std::isfinite(options->min_zoom)) ||
+    ((options->fields & MLN_BOUND_OPTION_MAX_ZOOM) != 0U &&
+     !std::isfinite(options->max_zoom)) ||
+    ((options->fields & MLN_BOUND_OPTION_MIN_PITCH) != 0U &&
+     !std::isfinite(options->min_pitch)) ||
+    ((options->fields & MLN_BOUND_OPTION_MAX_PITCH) != 0U &&
+     !std::isfinite(options->max_pitch))
+  ) {
+    mln::core::set_thread_error("bound numeric fields must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    (options->fields & MLN_BOUND_OPTION_MIN_ZOOM) != 0U &&
+    (options->fields & MLN_BOUND_OPTION_MAX_ZOOM) != 0U &&
+    options->min_zoom > options->max_zoom
+  ) {
+    mln::core::set_thread_error(
+      "min_zoom must be less than or equal to max_zoom"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    (options->fields & MLN_BOUND_OPTION_MIN_PITCH) != 0U &&
+    (options->fields & MLN_BOUND_OPTION_MAX_PITCH) != 0U &&
+    options->min_pitch > options->max_pitch
+  ) {
+    mln::core::set_thread_error(
+      "min_pitch must be less than or equal to max_pitch"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_vec3(mln_vec3 value, const char* name) -> mln_status {
+  if (
+    !std::isfinite(value.x) || !std::isfinite(value.y) ||
+    !std::isfinite(value.z)
+  ) {
+    mln::core::set_thread_error(name);
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_quaternion(mln_quaternion value) -> mln_status {
+  if (
+    !std::isfinite(value.x) || !std::isfinite(value.y) ||
+    !std::isfinite(value.z) || !std::isfinite(value.w)
+  ) {
+    mln::core::set_thread_error(
+      "free camera orientation values must be finite"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (value.x == 0.0 && value.y == 0.0 && value.z == 0.0 && value.w == 0.0) {
+    mln::core::set_thread_error(
+      "free camera orientation must not be zero length"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_free_camera_options(const mln_free_camera_options* options)
+  -> mln_status {
+  if (options == nullptr) {
+    mln::core::set_thread_error("free camera options must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (options->size < sizeof(mln_free_camera_options)) {
+    mln::core::set_thread_error("mln_free_camera_options.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_FREE_CAMERA_OPTION_POSITION) |
+    MLN_FREE_CAMERA_OPTION_ORIENTATION;
+  if ((options->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_free_camera_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if ((options->fields & MLN_FREE_CAMERA_OPTION_POSITION) != 0U) {
+    const auto status = validate_vec3(
+      options->position, "free camera position values must be finite"
+    );
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  if ((options->fields & MLN_FREE_CAMERA_OPTION_ORIENTATION) != 0U) {
+    const auto status = validate_quaternion(options->orientation);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
   return MLN_STATUS_OK;
 }
 
@@ -621,6 +899,27 @@ auto validate_lat_lng(mln_lat_lng coordinate) -> mln_status {
   return MLN_STATUS_OK;
 }
 
+auto validate_lat_lng_bounds(mln_lat_lng_bounds bounds) -> mln_status {
+  const auto southwest_status = validate_lat_lng(bounds.southwest);
+  if (southwest_status != MLN_STATUS_OK) {
+    return southwest_status;
+  }
+  const auto northeast_status = validate_lat_lng(bounds.northeast);
+  if (northeast_status != MLN_STATUS_OK) {
+    return northeast_status;
+  }
+  if (
+    bounds.southwest.latitude > bounds.northeast.latitude ||
+    bounds.southwest.longitude > bounds.northeast.longitude
+  ) {
+    mln::core::set_thread_error(
+      "bounds southwest must be less than or equal to northeast"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
 auto validate_lat_lng_array(
   const mln_lat_lng* coordinates, size_t coordinate_count, bool allow_empty
 ) -> mln_status {
@@ -702,10 +1001,25 @@ auto validate_projected_meters(mln_projected_meters meters) -> mln_status {
   return MLN_STATUS_OK;
 }
 
+auto to_native_screen_point(mln_screen_point point) -> mbgl::ScreenCoordinate;
+auto from_native_screen_point(const mbgl::ScreenCoordinate& point)
+  -> mln_screen_point;
+auto to_native_edge_insets(mln_edge_insets padding) -> mbgl::EdgeInsets;
+auto from_native_edge_insets(const mbgl::EdgeInsets& insets) -> mln_edge_insets;
+
 auto to_native_camera(const mln_camera_options& camera) -> mbgl::CameraOptions {
   auto result = mbgl::CameraOptions{};
   if ((camera.fields & MLN_CAMERA_OPTION_CENTER) != 0U) {
     result.withCenter(mbgl::LatLng{camera.latitude, camera.longitude});
+  }
+  if ((camera.fields & MLN_CAMERA_OPTION_CENTER_ALTITUDE) != 0U) {
+    result.withCenterAltitude(camera.center_altitude);
+  }
+  if ((camera.fields & MLN_CAMERA_OPTION_PADDING) != 0U) {
+    result.withPadding(to_native_edge_insets(camera.padding));
+  }
+  if ((camera.fields & MLN_CAMERA_OPTION_ANCHOR) != 0U) {
+    result.withAnchor(to_native_screen_point(camera.anchor));
   }
   if ((camera.fields & MLN_CAMERA_OPTION_ZOOM) != 0U) {
     result.withZoom(camera.zoom);
@@ -715,6 +1029,12 @@ auto to_native_camera(const mln_camera_options& camera) -> mbgl::CameraOptions {
   }
   if ((camera.fields & MLN_CAMERA_OPTION_PITCH) != 0U) {
     result.withPitch(camera.pitch);
+  }
+  if ((camera.fields & MLN_CAMERA_OPTION_ROLL) != 0U) {
+    result.withRoll(camera.roll);
+  }
+  if ((camera.fields & MLN_CAMERA_OPTION_FOV) != 0U) {
+    result.withFov(camera.field_of_view);
   }
   return result;
 }
@@ -726,6 +1046,18 @@ auto from_native_camera(const mbgl::CameraOptions& camera)
     result.fields |= MLN_CAMERA_OPTION_CENTER;
     result.latitude = camera.center->latitude();
     result.longitude = camera.center->longitude();
+  }
+  if (camera.centerAltitude) {
+    result.fields |= MLN_CAMERA_OPTION_CENTER_ALTITUDE;
+    result.center_altitude = *camera.centerAltitude;
+  }
+  if (camera.padding) {
+    result.fields |= MLN_CAMERA_OPTION_PADDING;
+    result.padding = from_native_edge_insets(*camera.padding);
+  }
+  if (camera.anchor) {
+    result.fields |= MLN_CAMERA_OPTION_ANCHOR;
+    result.anchor = from_native_screen_point(*camera.anchor);
   }
   if (camera.zoom) {
     result.fields |= MLN_CAMERA_OPTION_ZOOM;
@@ -739,7 +1071,71 @@ auto from_native_camera(const mbgl::CameraOptions& camera)
     result.fields |= MLN_CAMERA_OPTION_PITCH;
     result.pitch = *camera.pitch;
   }
+  if (camera.roll) {
+    result.fields |= MLN_CAMERA_OPTION_ROLL;
+    result.roll = *camera.roll;
+  }
+  if (camera.fov) {
+    result.fields |= MLN_CAMERA_OPTION_FOV;
+    result.field_of_view = *camera.fov;
+  }
   return result;
+}
+
+auto to_native_animation(const mln_animation_options* animation)
+  -> mbgl::AnimationOptions {
+  auto result = mbgl::AnimationOptions{};
+  if (animation == nullptr) {
+    return result;
+  }
+  if ((animation->fields & MLN_ANIMATION_OPTION_DURATION) != 0U) {
+    result.duration = std::chrono::duration_cast<mbgl::Duration>(
+      std::chrono::duration<double, std::milli>{animation->duration_ms}
+    );
+  }
+  if ((animation->fields & MLN_ANIMATION_OPTION_VELOCITY) != 0U) {
+    result.velocity = animation->velocity;
+  }
+  if ((animation->fields & MLN_ANIMATION_OPTION_MIN_ZOOM) != 0U) {
+    result.minZoom = animation->min_zoom;
+  }
+  if ((animation->fields & MLN_ANIMATION_OPTION_EASING) != 0U) {
+    const auto easing = animation->easing;
+    result.easing.emplace(easing.x1, easing.y1, easing.x2, easing.y2);
+  }
+  return result;
+}
+
+auto camera_fit_padding(const mln_camera_fit_options* options)
+  -> mbgl::EdgeInsets {
+  if (
+    options == nullptr ||
+    (options->fields & MLN_CAMERA_FIT_OPTION_PADDING) == 0U
+  ) {
+    return mbgl::EdgeInsets{};
+  }
+  return to_native_edge_insets(options->padding);
+}
+
+auto camera_fit_bearing(const mln_camera_fit_options* options)
+  -> std::optional<double> {
+  if (
+    options == nullptr ||
+    (options->fields & MLN_CAMERA_FIT_OPTION_BEARING) == 0U
+  ) {
+    return std::nullopt;
+  }
+  return options->bearing;
+}
+
+auto camera_fit_pitch(const mln_camera_fit_options* options)
+  -> std::optional<double> {
+  if (
+    options == nullptr || (options->fields & MLN_CAMERA_FIT_OPTION_PITCH) == 0U
+  ) {
+    return std::nullopt;
+  }
+  return options->pitch;
 }
 
 auto to_native_projection_mode(const mln_projection_mode& mode)
@@ -901,6 +1297,22 @@ auto from_native_lat_lng(const mbgl::LatLng& coordinate) -> mln_lat_lng {
   };
 }
 
+auto to_native_lat_lng_bounds(mln_lat_lng_bounds bounds) -> mbgl::LatLngBounds {
+  return mbgl::LatLngBounds::hull(
+    to_native_lat_lng(bounds.southwest), to_native_lat_lng(bounds.northeast)
+  );
+}
+
+auto from_native_lat_lng_bounds(const mbgl::LatLngBounds& bounds)
+  -> mln_lat_lng_bounds {
+  return mln_lat_lng_bounds{
+    .southwest =
+      mln_lat_lng{.latitude = bounds.south(), .longitude = bounds.west()},
+    .northeast =
+      mln_lat_lng{.latitude = bounds.north(), .longitude = bounds.east()}
+  };
+}
+
 auto to_native_lat_lngs(const mln_lat_lng* coordinates, size_t coordinate_count)
   -> std::vector<mbgl::LatLng> {
   auto result = std::vector<mbgl::LatLng>{};
@@ -938,6 +1350,99 @@ auto to_native_edge_insets(mln_edge_insets padding) -> mbgl::EdgeInsets {
   return mbgl::EdgeInsets{
     padding.top, padding.left, padding.bottom, padding.right
   };
+}
+
+auto to_native_bound_options(const mln_bound_options& options)
+  -> mbgl::BoundOptions {
+  auto result = mbgl::BoundOptions{};
+  if ((options.fields & MLN_BOUND_OPTION_BOUNDS) != 0U) {
+    result.withLatLngBounds(to_native_lat_lng_bounds(options.bounds));
+  }
+  if ((options.fields & MLN_BOUND_OPTION_MIN_ZOOM) != 0U) {
+    result.withMinZoom(options.min_zoom);
+  }
+  if ((options.fields & MLN_BOUND_OPTION_MAX_ZOOM) != 0U) {
+    result.withMaxZoom(options.max_zoom);
+  }
+  if ((options.fields & MLN_BOUND_OPTION_MIN_PITCH) != 0U) {
+    result.withMinPitch(options.min_pitch);
+  }
+  if ((options.fields & MLN_BOUND_OPTION_MAX_PITCH) != 0U) {
+    result.withMaxPitch(options.max_pitch);
+  }
+  return result;
+}
+
+auto from_native_bound_options(const mbgl::BoundOptions& options)
+  -> mln_bound_options {
+  auto result = mln::core::bound_options_default();
+  if (options.bounds) {
+    result.fields |= MLN_BOUND_OPTION_BOUNDS;
+    result.bounds = from_native_lat_lng_bounds(*options.bounds);
+  }
+  if (options.minZoom) {
+    result.fields |= MLN_BOUND_OPTION_MIN_ZOOM;
+    result.min_zoom = *options.minZoom;
+  }
+  if (options.maxZoom) {
+    result.fields |= MLN_BOUND_OPTION_MAX_ZOOM;
+    result.max_zoom = *options.maxZoom;
+  }
+  if (options.minPitch) {
+    result.fields |= MLN_BOUND_OPTION_MIN_PITCH;
+    result.min_pitch = *options.minPitch;
+  }
+  if (options.maxPitch) {
+    result.fields |= MLN_BOUND_OPTION_MAX_PITCH;
+    result.max_pitch = *options.maxPitch;
+  }
+  return result;
+}
+
+auto to_native_vec3(mln_vec3 value) -> mbgl::vec3 {
+  return mbgl::vec3{{value.x, value.y, value.z}};
+}
+
+auto from_native_vec3(const mbgl::vec3& value) -> mln_vec3 {
+  const auto [x_component, y_component, z_component] = value;
+  return mln_vec3{.x = x_component, .y = y_component, .z = z_component};
+}
+
+auto to_native_vec4(mln_quaternion value) -> mbgl::vec4 {
+  return mbgl::vec4{{value.x, value.y, value.z, value.w}};
+}
+
+auto from_native_vec4(const mbgl::vec4& value) -> mln_quaternion {
+  const auto [x_component, y_component, z_component, w_component] = value;
+  return mln_quaternion{
+    .x = x_component, .y = y_component, .z = z_component, .w = w_component
+  };
+}
+
+auto to_native_free_camera(const mln_free_camera_options& options)
+  -> mbgl::FreeCameraOptions {
+  auto result = mbgl::FreeCameraOptions{};
+  if ((options.fields & MLN_FREE_CAMERA_OPTION_POSITION) != 0U) {
+    result.position = to_native_vec3(options.position);
+  }
+  if ((options.fields & MLN_FREE_CAMERA_OPTION_ORIENTATION) != 0U) {
+    result.orientation = to_native_vec4(options.orientation);
+  }
+  return result;
+}
+
+auto from_native_free_camera(const mbgl::FreeCameraOptions& options)
+  -> mln_free_camera_options {
+  auto result = mln::core::free_camera_options_default();
+  if (options.position) {
+    result.fields |= MLN_FREE_CAMERA_OPTION_POSITION;
+    result.position = from_native_vec3(*options.position);
+  }
+  if (options.orientation) {
+    result.fields |= MLN_FREE_CAMERA_OPTION_ORIENTATION;
+    result.orientation = from_native_vec4(*options.orientation);
+  }
+  return result;
 }
 
 auto screen_point(mln_screen_point point) -> mbgl::ScreenCoordinate {
@@ -1019,9 +1524,58 @@ auto camera_options_default() noexcept -> mln_camera_options {
     .fields = 0,
     .latitude = 0,
     .longitude = 0,
+    .center_altitude = 0,
+    .padding = {.top = 0, .left = 0, .bottom = 0, .right = 0},
+    .anchor = {.x = 0, .y = 0},
     .zoom = 0,
     .bearing = 0,
+    .pitch = 0,
+    .roll = 0,
+    .field_of_view = 0
+  };
+}
+
+auto animation_options_default() noexcept -> mln_animation_options {
+  return mln_animation_options{
+    .size = sizeof(mln_animation_options),
+    .fields = 0,
+    .duration_ms = 0,
+    .velocity = 0,
+    .min_zoom = 0,
+    .easing = {.x1 = 0, .y1 = 0, .x2 = 0.25, .y2 = 1}
+  };
+}
+
+auto camera_fit_options_default() noexcept -> mln_camera_fit_options {
+  return mln_camera_fit_options{
+    .size = sizeof(mln_camera_fit_options),
+    .fields = 0,
+    .padding = {.top = 0, .left = 0, .bottom = 0, .right = 0},
+    .bearing = 0,
     .pitch = 0
+  };
+}
+
+auto bound_options_default() noexcept -> mln_bound_options {
+  return mln_bound_options{
+    .size = sizeof(mln_bound_options),
+    .fields = 0,
+    .bounds =
+      {.southwest = {.latitude = 0, .longitude = 0},
+       .northeast = {.latitude = 0, .longitude = 0}},
+    .min_zoom = 0,
+    .max_zoom = 0,
+    .min_pitch = 0,
+    .max_pitch = 0
+  };
+}
+
+auto free_camera_options_default() noexcept -> mln_free_camera_options {
+  return mln_free_camera_options{
+    .size = sizeof(mln_free_camera_options),
+    .fields = 0,
+    .position = {.x = 0, .y = 0, .z = 0},
+    .orientation = {.x = 0, .y = 0, .z = 0, .w = 1}
   };
 }
 
@@ -1360,6 +1914,48 @@ auto map_jump_to(mln_map* map, const mln_camera_options* camera) -> mln_status {
     return camera_status;
   }
   map->map->jumpTo(to_native_camera(*camera));
+  return MLN_STATUS_OK;
+}
+
+auto map_ease_to(
+  mln_map* map, const mln_camera_options* camera,
+  const mln_animation_options* animation
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto camera_status = validate_camera_options(camera);
+  if (camera_status != MLN_STATUS_OK) {
+    return camera_status;
+  }
+  const auto animation_status = validate_animation_options(animation);
+  if (animation_status != MLN_STATUS_OK) {
+    return animation_status;
+  }
+
+  map->map->easeTo(to_native_camera(*camera), to_native_animation(animation));
+  return MLN_STATUS_OK;
+}
+
+auto map_fly_to(
+  mln_map* map, const mln_camera_options* camera,
+  const mln_animation_options* animation
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto camera_status = validate_camera_options(camera);
+  if (camera_status != MLN_STATUS_OK) {
+    return camera_status;
+  }
+  const auto animation_status = validate_animation_options(animation);
+  if (animation_status != MLN_STATUS_OK) {
+    return animation_status;
+  }
+
+  map->map->flyTo(to_native_camera(*camera), to_native_animation(animation));
   return MLN_STATUS_OK;
 }
 
@@ -1921,45 +2517,120 @@ auto lat_lng_for_projected_meters(
 }
 
 auto map_move_by(mln_map* map, double delta_x, double delta_y) -> mln_status {
+  return map_move_by_animated(map, delta_x, delta_y, nullptr);
+}
+
+auto map_move_by_animated(
+  mln_map* map, double delta_x, double delta_y,
+  const mln_animation_options* animation
+) -> mln_status {
   const auto status = validate_map(map);
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  map->map->moveBy(mbgl::ScreenCoordinate{delta_x, delta_y});
+  if (!std::isfinite(delta_x) || !std::isfinite(delta_y)) {
+    set_thread_error("move deltas must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto animation_status = validate_animation_options(animation);
+  if (animation_status != MLN_STATUS_OK) {
+    return animation_status;
+  }
+
+  map->map->moveBy(
+    mbgl::ScreenCoordinate{delta_x, delta_y}, to_native_animation(animation)
+  );
   return MLN_STATUS_OK;
 }
 
 auto map_scale_by(mln_map* map, double scale, const mln_screen_point* anchor)
   -> mln_status {
+  return map_scale_by_animated(map, scale, anchor, nullptr);
+}
+
+auto map_scale_by_animated(
+  mln_map* map, double scale, const mln_screen_point* anchor,
+  const mln_animation_options* animation
+) -> mln_status {
   const auto status = validate_map(map);
   if (status != MLN_STATUS_OK) {
     return status;
   }
+  if (!std::isfinite(scale) || scale <= 0.0) {
+    set_thread_error("scale must be positive and finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
   auto native_anchor = std::optional<mbgl::ScreenCoordinate>{};
   if (anchor != nullptr) {
+    const auto anchor_status = validate_screen_point(*anchor);
+    if (anchor_status != MLN_STATUS_OK) {
+      return anchor_status;
+    }
     native_anchor = screen_point(*anchor);
   }
-  map->map->scaleBy(scale, native_anchor);
+  const auto animation_status = validate_animation_options(animation);
+  if (animation_status != MLN_STATUS_OK) {
+    return animation_status;
+  }
+
+  map->map->scaleBy(scale, native_anchor, to_native_animation(animation));
   return MLN_STATUS_OK;
 }
 
 auto map_rotate_by(
   mln_map* map, mln_screen_point first, mln_screen_point second
 ) -> mln_status {
+  return map_rotate_by_animated(map, first, second, nullptr);
+}
+
+auto map_rotate_by_animated(
+  mln_map* map, mln_screen_point first, mln_screen_point second,
+  const mln_animation_options* animation
+) -> mln_status {
   const auto status = validate_map(map);
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  map->map->rotateBy(screen_point(first), screen_point(second));
+  const auto first_status = validate_screen_point(first);
+  if (first_status != MLN_STATUS_OK) {
+    return first_status;
+  }
+  const auto second_status = validate_screen_point(second);
+  if (second_status != MLN_STATUS_OK) {
+    return second_status;
+  }
+  const auto animation_status = validate_animation_options(animation);
+  if (animation_status != MLN_STATUS_OK) {
+    return animation_status;
+  }
+
+  map->map->rotateBy(
+    screen_point(first), screen_point(second), to_native_animation(animation)
+  );
   return MLN_STATUS_OK;
 }
 
 auto map_pitch_by(mln_map* map, double pitch) -> mln_status {
+  return map_pitch_by_animated(map, pitch, nullptr);
+}
+
+auto map_pitch_by_animated(
+  mln_map* map, double pitch, const mln_animation_options* animation
+) -> mln_status {
   const auto status = validate_map(map);
   if (status != MLN_STATUS_OK) {
     return status;
   }
-  map->map->pitchBy(pitch);
+  if (!std::isfinite(pitch)) {
+    set_thread_error("pitch must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto animation_status = validate_animation_options(animation);
+  if (animation_status != MLN_STATUS_OK) {
+    return animation_status;
+  }
+
+  map->map->pitchBy(pitch, to_native_animation(animation));
   return MLN_STATUS_OK;
 }
 
@@ -1969,6 +2640,213 @@ auto map_cancel_transitions(mln_map* map) -> mln_status {
     return status;
   }
   map->map->cancelTransitions();
+  return MLN_STATUS_OK;
+}
+
+auto validate_camera_output(mln_camera_options* out_camera) -> mln_status {
+  if (out_camera == nullptr || out_camera->size < sizeof(mln_camera_options)) {
+    set_thread_error("out_camera must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_camera_for_lat_lng_bounds(
+  mln_map* map, mln_lat_lng_bounds bounds,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto bounds_status = validate_lat_lng_bounds(bounds);
+  if (bounds_status != MLN_STATUS_OK) {
+    return bounds_status;
+  }
+  const auto fit_status = validate_camera_fit_options(fit_options);
+  if (fit_status != MLN_STATUS_OK) {
+    return fit_status;
+  }
+  const auto output_status = validate_camera_output(out_camera);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+
+  *out_camera = from_native_camera(map->map->cameraForLatLngBounds(
+    to_native_lat_lng_bounds(bounds), camera_fit_padding(fit_options),
+    camera_fit_bearing(fit_options), camera_fit_pitch(fit_options)
+  ));
+  return MLN_STATUS_OK;
+}
+
+auto map_camera_for_lat_lngs(
+  mln_map* map, const mln_lat_lng* coordinates, size_t coordinate_count,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto coordinates_status =
+    validate_lat_lng_array(coordinates, coordinate_count, false);
+  if (coordinates_status != MLN_STATUS_OK) {
+    return coordinates_status;
+  }
+  const auto fit_status = validate_camera_fit_options(fit_options);
+  if (fit_status != MLN_STATUS_OK) {
+    return fit_status;
+  }
+  const auto output_status = validate_camera_output(out_camera);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+
+  *out_camera = from_native_camera(map->map->cameraForLatLngs(
+    to_native_lat_lngs(coordinates, coordinate_count),
+    camera_fit_padding(fit_options), camera_fit_bearing(fit_options),
+    camera_fit_pitch(fit_options)
+  ));
+  return MLN_STATUS_OK;
+}
+
+auto map_camera_for_geometry(
+  mln_map* map, const mln_geometry* geometry,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  auto native_geometry = to_native_geometry(geometry);
+  if (!native_geometry) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (geometry_lat_lngs(*native_geometry).empty()) {
+    set_thread_error("geometry must contain at least one coordinate");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto fit_status = validate_camera_fit_options(fit_options);
+  if (fit_status != MLN_STATUS_OK) {
+    return fit_status;
+  }
+  const auto output_status = validate_camera_output(out_camera);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+
+  *out_camera = from_native_camera(map->map->cameraForGeometry(
+    *native_geometry, camera_fit_padding(fit_options),
+    camera_fit_bearing(fit_options), camera_fit_pitch(fit_options)
+  ));
+  return MLN_STATUS_OK;
+}
+
+auto map_lat_lng_bounds_for_camera(
+  mln_map* map, const mln_camera_options* camera, mln_lat_lng_bounds* out_bounds
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto camera_status = validate_camera_options(camera);
+  if (camera_status != MLN_STATUS_OK) {
+    return camera_status;
+  }
+  if (out_bounds == nullptr) {
+    set_thread_error("out_bounds must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_bounds = from_native_lat_lng_bounds(
+    map->map->latLngBoundsForCamera(to_native_camera(*camera))
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_lat_lng_bounds_for_camera_unwrapped(
+  mln_map* map, const mln_camera_options* camera, mln_lat_lng_bounds* out_bounds
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto camera_status = validate_camera_options(camera);
+  if (camera_status != MLN_STATUS_OK) {
+    return camera_status;
+  }
+  if (out_bounds == nullptr) {
+    set_thread_error("out_bounds must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_bounds = from_native_lat_lng_bounds(
+    map->map->latLngBoundsForCameraUnwrapped(to_native_camera(*camera))
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_get_bounds(mln_map* map, mln_bound_options* out_options)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (out_options == nullptr || out_options->size < sizeof(mln_bound_options)) {
+    set_thread_error("out_options must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_options = from_native_bound_options(map->map->getBounds());
+  return MLN_STATUS_OK;
+}
+
+auto map_set_bounds(mln_map* map, const mln_bound_options* options)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto options_status = validate_bound_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  map->map->setBounds(to_native_bound_options(*options));
+  return MLN_STATUS_OK;
+}
+
+auto map_get_free_camera_options(
+  mln_map* map, mln_free_camera_options* out_options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (
+    out_options == nullptr ||
+    out_options->size < sizeof(mln_free_camera_options)
+  ) {
+    set_thread_error("out_options must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_options = from_native_free_camera(map->map->getFreeCameraOptions());
+  return MLN_STATUS_OK;
+}
+
+auto map_set_free_camera_options(
+  mln_map* map, const mln_free_camera_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto options_status = validate_free_camera_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  map->map->setFreeCameraOptions(to_native_free_camera(*options));
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2818,6 +2818,8 @@ auto map_set_bounds(mln_map* map, const mln_bound_options* options)
     return options_status;
   }
 
+  // Native setBounds only applies optionals that are set, so this preserves
+  // constraints omitted from options->fields.
   map->map->setBounds(to_native_bound_options(*options));
   return MLN_STATUS_OK;
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -473,6 +473,12 @@ auto validate_camera_options(const mln_camera_options* camera) -> mln_status {
   return MLN_STATUS_OK;
 }
 
+auto max_animation_duration_ms() -> double {
+  using DoubleMilliseconds = std::chrono::duration<double, std::milli>;
+  return std::chrono::duration_cast<DoubleMilliseconds>(mbgl::Duration::max())
+    .count();
+}
+
 auto validate_animation_options(const mln_animation_options* animation)
   -> mln_status {
   if (animation == nullptr) {
@@ -495,10 +501,11 @@ auto validate_animation_options(const mln_animation_options* animation)
   }
   if (
     (animation->fields & MLN_ANIMATION_OPTION_DURATION) != 0U &&
-    (!std::isfinite(animation->duration_ms) || animation->duration_ms < 0.0)
+    (!std::isfinite(animation->duration_ms) || animation->duration_ms < 0.0 ||
+     animation->duration_ms > max_animation_duration_ms())
   ) {
     mln::core::set_thread_error(
-      "animation duration_ms must be finite and greater than or equal to 0"
+      "animation duration_ms must fit the native duration range"
     );
     return MLN_STATUS_INVALID_ARGUMENT;
   }

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -17,6 +17,10 @@ namespace mln::core {
 
 auto map_options_default() noexcept -> mln_map_options;
 auto camera_options_default() noexcept -> mln_camera_options;
+auto animation_options_default() noexcept -> mln_animation_options;
+auto camera_fit_options_default() noexcept -> mln_camera_fit_options;
+auto bound_options_default() noexcept -> mln_bound_options;
+auto free_camera_options_default() noexcept -> mln_free_camera_options;
 auto projection_mode_default() noexcept -> mln_projection_mode;
 auto map_viewport_options_default() noexcept -> mln_map_viewport_options;
 auto map_tile_options_default() noexcept -> mln_map_tile_options;
@@ -30,6 +34,14 @@ auto map_set_style_url(mln_map* map, const char* url) -> mln_status;
 auto map_set_style_json(mln_map* map, const char* json) -> mln_status;
 auto map_get_camera(mln_map* map, mln_camera_options* out_camera) -> mln_status;
 auto map_jump_to(mln_map* map, const mln_camera_options* camera) -> mln_status;
+auto map_ease_to(
+  mln_map* map, const mln_camera_options* camera,
+  const mln_animation_options* animation
+) -> mln_status;
+auto map_fly_to(
+  mln_map* map, const mln_camera_options* camera,
+  const mln_animation_options* animation
+) -> mln_status;
 auto map_get_projection_mode(mln_map* map, mln_projection_mode* out_mode)
   -> mln_status;
 auto map_set_projection_mode(mln_map* map, const mln_projection_mode* mode)
@@ -98,13 +110,55 @@ auto lat_lng_for_projected_meters(
   mln_projected_meters meters, mln_lat_lng* out_coordinate
 ) -> mln_status;
 auto map_move_by(mln_map* map, double delta_x, double delta_y) -> mln_status;
+auto map_move_by_animated(
+  mln_map* map, double delta_x, double delta_y,
+  const mln_animation_options* animation
+) -> mln_status;
 auto map_scale_by(mln_map* map, double scale, const mln_screen_point* anchor)
   -> mln_status;
+auto map_scale_by_animated(
+  mln_map* map, double scale, const mln_screen_point* anchor,
+  const mln_animation_options* animation
+) -> mln_status;
 auto map_rotate_by(
   mln_map* map, mln_screen_point first, mln_screen_point second
 ) -> mln_status;
+auto map_rotate_by_animated(
+  mln_map* map, mln_screen_point first, mln_screen_point second,
+  const mln_animation_options* animation
+) -> mln_status;
 auto map_pitch_by(mln_map* map, double pitch) -> mln_status;
+auto map_pitch_by_animated(
+  mln_map* map, double pitch, const mln_animation_options* animation
+) -> mln_status;
 auto map_cancel_transitions(mln_map* map) -> mln_status;
+auto map_camera_for_lat_lng_bounds(
+  mln_map* map, mln_lat_lng_bounds bounds,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) -> mln_status;
+auto map_camera_for_lat_lngs(
+  mln_map* map, const mln_lat_lng* coordinates, size_t coordinate_count,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) -> mln_status;
+auto map_camera_for_geometry(
+  mln_map* map, const mln_geometry* geometry,
+  const mln_camera_fit_options* fit_options, mln_camera_options* out_camera
+) -> mln_status;
+auto map_lat_lng_bounds_for_camera(
+  mln_map* map, const mln_camera_options* camera, mln_lat_lng_bounds* out_bounds
+) -> mln_status;
+auto map_lat_lng_bounds_for_camera_unwrapped(
+  mln_map* map, const mln_camera_options* camera, mln_lat_lng_bounds* out_bounds
+) -> mln_status;
+auto map_get_bounds(mln_map* map, mln_bound_options* out_options) -> mln_status;
+auto map_set_bounds(mln_map* map, const mln_bound_options* options)
+  -> mln_status;
+auto map_get_free_camera_options(
+  mln_map* map, mln_free_camera_options* out_options
+) -> mln_status;
+auto map_set_free_camera_options(
+  mln_map* map, const mln_free_camera_options* options
+) -> mln_status;
 auto validate_map(mln_map* map) -> mln_status;
 auto map_owner_thread(const mln_map* map) -> std::thread::id;
 auto map_native(mln_map* map) -> mbgl::Map*;

--- a/tests/c/camera.zig
+++ b/tests/c/camera.zig
@@ -70,6 +70,11 @@ test "camera rejects invalid arguments" {
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_ease_to(map, &camera, &animation));
 
     animation = c.mln_animation_options_default();
+    animation.fields = c.MLN_ANIMATION_OPTION_DURATION;
+    animation.duration_ms = std.math.floatMax(f64);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_ease_to(map, &camera, &animation));
+
+    animation = c.mln_animation_options_default();
     animation.fields = c.MLN_ANIMATION_OPTION_EASING;
     animation.easing.x1 = 2;
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_fly_to(map, &camera, &animation));

--- a/tests/c/camera.zig
+++ b/tests/c/camera.zig
@@ -1,4 +1,5 @@
-const testing = @import("std").testing;
+const std = @import("std");
+const testing = std.testing;
 const support = @import("support.zig");
 const c = support.c;
 
@@ -6,6 +7,22 @@ test "camera exposes default options" {
     const camera = c.mln_camera_options_default();
     try testing.expectEqual(@as(u32, @sizeOf(c.mln_camera_options)), camera.size);
     try testing.expectEqual(@as(u32, 0), camera.fields);
+
+    const animation = c.mln_animation_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_animation_options)), animation.size);
+    try testing.expectEqual(@as(u32, 0), animation.fields);
+
+    const fit = c.mln_camera_fit_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_camera_fit_options)), fit.size);
+    try testing.expectEqual(@as(u32, 0), fit.fields);
+
+    const bounds = c.mln_bound_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_bound_options)), bounds.size);
+    try testing.expectEqual(@as(u32, 0), bounds.fields);
+
+    const free_camera = c.mln_free_camera_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_free_camera_options)), free_camera.size);
+    try testing.expectEqual(@as(u32, 0), free_camera.fields);
 }
 
 test "camera rejects invalid arguments" {
@@ -30,6 +47,37 @@ test "camera rejects invalid arguments" {
     camera = support.testCamera();
     camera.fields |= @as(u32, 1) << 31;
     try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_jump_to(map, &camera));
+
+    camera = support.testCamera();
+    camera.fields = c.MLN_CAMERA_OPTION_CENTER;
+    camera.latitude = std.math.inf(f64);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_jump_to(map, &camera));
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_ease_to(map, null, null));
+
+    camera = support.testCamera();
+    var animation = c.mln_animation_options_default();
+    animation.size = @sizeOf(c.mln_animation_options) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_ease_to(map, &camera, &animation));
+
+    animation = c.mln_animation_options_default();
+    animation.fields = @as(u32, 1) << 31;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_fly_to(map, &camera, &animation));
+
+    animation = c.mln_animation_options_default();
+    animation.fields = c.MLN_ANIMATION_OPTION_DURATION;
+    animation.duration_ms = -1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_ease_to(map, &camera, &animation));
+
+    animation = c.mln_animation_options_default();
+    animation.fields = c.MLN_ANIMATION_OPTION_EASING;
+    animation.easing.x1 = 2;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_fly_to(map, &camera, &animation));
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_move_by(map, std.math.nan(f64), 0));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_scale_by(map, 0, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_rotate_by(map, .{ .x = std.math.inf(f64), .y = 0 }, .{ .x = 0, .y = 0 }));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_pitch_by(map, std.math.nan(f64)));
 }
 
 test "camera jump updates snapshot fields" {
@@ -64,5 +112,200 @@ test "camera commands accept valid arguments" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_scale_by(map, 0.95, null));
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_rotate_by(map, rotate_start, rotate_end));
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_pitch_by(map, 3));
+
+    var animation = c.mln_animation_options_default();
+    animation.fields = c.MLN_ANIMATION_OPTION_DURATION | c.MLN_ANIMATION_OPTION_EASING;
+    animation.duration_ms = 0;
+    animation.easing = .{ .x1 = 0.0, .y1 = 0.0, .x2 = 0.25, .y2 = 1.0 };
+    var camera = support.testCamera();
+    camera.zoom = 12.0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_ease_to(map, &camera, &animation));
+    camera.zoom = 10.0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_fly_to(map, &camera, &animation));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_move_by_animated(map, 1, 2, &animation));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_scale_by_animated(map, 1.01, &anchor, &animation));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_rotate_by_animated(map, rotate_start, rotate_end, &animation));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_pitch_by_animated(map, 1, &animation));
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_cancel_transitions(map));
+}
+
+test "camera fitting computes cameras and visible bounds" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    const bounds = c.mln_lat_lng_bounds{
+        .southwest = .{ .latitude = 35.0, .longitude = -125.0 },
+        .northeast = .{ .latitude = 39.0, .longitude = -120.0 },
+    };
+    var fit = c.mln_camera_fit_options_default();
+    fit.fields = c.MLN_CAMERA_FIT_OPTION_PADDING | c.MLN_CAMERA_FIT_OPTION_BEARING | c.MLN_CAMERA_FIT_OPTION_PITCH;
+    fit.padding = .{ .top = 8, .left = 12, .bottom = 8, .right = 12 };
+    fit.bearing = 5;
+    fit.pitch = 15;
+
+    var camera = c.mln_camera_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_camera_for_lat_lng_bounds(map, bounds, &fit, &camera));
+    try testing.expect((camera.fields & c.MLN_CAMERA_OPTION_CENTER) != 0);
+    try testing.expect((camera.fields & c.MLN_CAMERA_OPTION_ZOOM) != 0);
+    try testing.expect((camera.fields & c.MLN_CAMERA_OPTION_PADDING) != 0);
+    try testing.expect((camera.fields & c.MLN_CAMERA_OPTION_BEARING) != 0);
+    try testing.expect((camera.fields & c.MLN_CAMERA_OPTION_PITCH) != 0);
+
+    const coordinates = [_]c.mln_lat_lng{ bounds.southwest, bounds.northeast };
+    camera = c.mln_camera_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_camera_for_lat_lngs(map, coordinates[0..].ptr, coordinates.len, null, &camera));
+    try testing.expect((camera.fields & c.MLN_CAMERA_OPTION_CENTER) != 0);
+
+    const line = c.mln_geometry{
+        .size = @sizeOf(c.mln_geometry),
+        .type = c.MLN_GEOMETRY_TYPE_LINE_STRING,
+        .data = .{ .line_string = .{ .coordinates = coordinates[0..].ptr, .coordinate_count = coordinates.len } },
+    };
+    camera = c.mln_camera_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_camera_for_geometry(map, &line, null, &camera));
+    try testing.expect((camera.fields & c.MLN_CAMERA_OPTION_ZOOM) != 0);
+
+    var visible_bounds: c.mln_lat_lng_bounds = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_lat_lng_bounds_for_camera(map, &camera, &visible_bounds));
+    try testing.expect(visible_bounds.southwest.latitude <= visible_bounds.northeast.latitude);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_lat_lng_bounds_for_camera_unwrapped(map, &camera, &visible_bounds));
+    try testing.expect(visible_bounds.southwest.latitude <= visible_bounds.northeast.latitude);
+}
+
+test "camera fitting rejects invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var camera = c.mln_camera_options_default();
+    const bounds = c.mln_lat_lng_bounds{
+        .southwest = .{ .latitude = 10.0, .longitude = 10.0 },
+        .northeast = .{ .latitude = -10.0, .longitude = 20.0 },
+    };
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_camera_for_lat_lng_bounds(map, bounds, null, &camera));
+
+    var fit = c.mln_camera_fit_options_default();
+    fit.size = @sizeOf(c.mln_camera_fit_options) - 1;
+    const valid_bounds = c.mln_lat_lng_bounds{
+        .southwest = .{ .latitude = -10.0, .longitude = -10.0 },
+        .northeast = .{ .latitude = 10.0, .longitude = 10.0 },
+    };
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_camera_for_lat_lng_bounds(map, valid_bounds, &fit, &camera));
+
+    const coordinate = c.mln_lat_lng{ .latitude = 0.0, .longitude = 0.0 };
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_camera_for_lat_lngs(map, null, 0, null, &camera));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_camera_for_lat_lngs(map, null, 1, null, &camera));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_camera_for_lat_lngs(map, &coordinate, 1, null, null));
+
+    var empty_geometry = c.mln_geometry{
+        .size = @sizeOf(c.mln_geometry),
+        .type = c.MLN_GEOMETRY_TYPE_EMPTY,
+        .data = .{ .point = coordinate },
+    };
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_camera_for_geometry(map, null, null, &camera));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_camera_for_geometry(map, &empty_geometry, null, &camera));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_lat_lng_bounds_for_camera(map, null, null));
+}
+
+test "camera bounds constraints round trip" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var options = c.mln_bound_options_default();
+    options.fields = c.MLN_BOUND_OPTION_BOUNDS |
+        c.MLN_BOUND_OPTION_MIN_ZOOM |
+        c.MLN_BOUND_OPTION_MAX_ZOOM |
+        c.MLN_BOUND_OPTION_MIN_PITCH |
+        c.MLN_BOUND_OPTION_MAX_PITCH;
+    options.bounds = .{
+        .southwest = .{ .latitude = -20.0, .longitude = -30.0 },
+        .northeast = .{ .latitude = 20.0, .longitude = 30.0 },
+    };
+    options.min_zoom = 1.0;
+    options.max_zoom = 8.0;
+    options.min_pitch = 0.0;
+    options.max_pitch = 45.0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_bounds(map, &options));
+
+    var snapshot = c.mln_bound_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_bounds(map, &snapshot));
+    try testing.expect((snapshot.fields & c.MLN_BOUND_OPTION_BOUNDS) != 0);
+    try testing.expect((snapshot.fields & c.MLN_BOUND_OPTION_MIN_ZOOM) != 0);
+    try testing.expect((snapshot.fields & c.MLN_BOUND_OPTION_MAX_ZOOM) != 0);
+    try testing.expectApproxEqAbs(options.bounds.southwest.latitude, snapshot.bounds.southwest.latitude, 0.000001);
+    try testing.expectApproxEqAbs(options.min_zoom, snapshot.min_zoom, 0.000001);
+    try testing.expectApproxEqAbs(options.max_zoom, snapshot.max_zoom, 0.000001);
+    try testing.expectApproxEqAbs(options.max_pitch, snapshot.max_pitch, 0.000001);
+}
+
+test "camera bounds constraints reject invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_bounds(map, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_bounds(map, null));
+
+    var options = c.mln_bound_options_default();
+    options.size = @sizeOf(c.mln_bound_options) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_bounds(map, &options));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_bounds(map, &options));
+
+    options = c.mln_bound_options_default();
+    options.fields = @as(u32, 1) << 31;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_bounds(map, &options));
+
+    options = c.mln_bound_options_default();
+    options.fields = c.MLN_BOUND_OPTION_MIN_ZOOM | c.MLN_BOUND_OPTION_MAX_ZOOM;
+    options.min_zoom = 10;
+    options.max_zoom = 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_bounds(map, &options));
+}
+
+test "free camera options round trip and reject invalid arguments" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var snapshot = c.mln_free_camera_options_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_free_camera_options(map, &snapshot));
+    try testing.expect((snapshot.fields & c.MLN_FREE_CAMERA_OPTION_POSITION) != 0);
+    try testing.expect((snapshot.fields & c.MLN_FREE_CAMERA_OPTION_ORIENTATION) != 0);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_free_camera_options(map, &snapshot));
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_free_camera_options(map, null));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_free_camera_options(map, null));
+
+    var options = c.mln_free_camera_options_default();
+    options.size = @sizeOf(c.mln_free_camera_options) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_get_free_camera_options(map, &options));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_free_camera_options(map, &options));
+
+    options = c.mln_free_camera_options_default();
+    options.fields = @as(u32, 1) << 31;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_free_camera_options(map, &options));
+
+    options = c.mln_free_camera_options_default();
+    options.fields = c.MLN_FREE_CAMERA_OPTION_POSITION;
+    options.position.x = std.math.inf(f64);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_free_camera_options(map, &options));
+
+    options = c.mln_free_camera_options_default();
+    options.fields = c.MLN_FREE_CAMERA_OPTION_ORIENTATION;
+    options.orientation = .{ .x = 0, .y = 0, .z = 0, .w = 0 };
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_free_camera_options(map, &options));
 }


### PR DESCRIPTION
## Summary
- Expand the C camera ABI with animation, fitting, bounds constraint, and free-camera option structs and functions.
- Wire MapLibre Native camera fitting, bounds, animated camera, and free camera APIs through the C boundary with validation.
- Update Zig and Swift map examples to animate discrete keyboard camera actions and normalize Swift precise scroll zoom.

## Tests
- `mise run test`
- `mise run build` in `examples/zig-map`
- `mise run build` in `examples/swift-map`
- Commit hook: dprint, zig-ast-check, clang-tidy

Closes #26.