### PR TITLE
Add feature state APIs

### DIFF
--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -77,6 +77,7 @@ typedef struct mln_map mln_map;
 typedef struct mln_map_projection mln_map_projection;
 typedef struct mln_offline_region_snapshot mln_offline_region_snapshot;
 typedef struct mln_offline_region_list mln_offline_region_list;
+typedef struct mln_json_snapshot mln_json_snapshot;
 typedef struct mln_resource_request_handle mln_resource_request_handle;
 typedef struct mln_render_session mln_render_session;
 
@@ -1200,6 +1201,28 @@ typedef struct mln_json_value {
     mln_json_object object_value;
   } data;
 } mln_json_value;
+
+/** Optional fields for mln_feature_state_selector. */
+typedef enum mln_feature_state_selector_field : uint32_t {
+  MLN_FEATURE_STATE_SELECTOR_SOURCE_LAYER_ID = 1U << 0U,
+  MLN_FEATURE_STATE_SELECTOR_FEATURE_ID = 1U << 1U,
+  MLN_FEATURE_STATE_SELECTOR_STATE_KEY = 1U << 2U,
+} mln_feature_state_selector_field;
+
+/** Feature-state source, feature, and key selector. */
+typedef struct mln_feature_state_selector {
+  uint32_t size;
+  uint32_t fields;
+  /** Source ID. Required and borrowed for the duration of the call. */
+  mln_string_view source_id;
+  /** Optional source layer ID. Required for vector-source disambiguation. */
+  mln_string_view source_layer_id;
+  /** Optional feature ID string. Required by set/get and optional for remove.
+   */
+  mln_string_view feature_id;
+  /** Optional state key. Used only by remove and requires feature_id. */
+  mln_string_view state_key;
+} mln_feature_state_selector;
 
 /** Feature identifier variant tags used by mln_feature. */
 typedef enum mln_feature_identifier_type : uint32_t {
@@ -2873,6 +2896,103 @@ mln_render_session_clear_data(mln_render_session* session) MLN_NOEXCEPT;
  */
 MLN_API mln_status
 mln_render_session_dump_debug_logs(mln_render_session* session) MLN_NOEXCEPT;
+
+/**
+ * Sets per-feature state on a render source for this render session.
+ *
+ * The session renderer must already exist; call
+ * mln_render_session_render_update() once after loading style data before using
+ * feature state. selector->source_id and selector->feature_id are borrowed for
+ * the duration of the call. state must be a JSON object descriptor and is
+ * copied before return. The accepted command requests a map repaint.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, selector is
+ *   null or invalid, selector lacks MLN_FEATURE_STATE_SELECTOR_FEATURE_ID,
+ *   state is null or not an object, state contains invalid descriptor data, or
+ *   state contains non-finite numbers.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_render_session_set_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector,
+  const mln_json_value* state
+) MLN_NOEXCEPT;
+
+/**
+ * Copies per-feature state from a render source in this render session.
+ *
+ * The session renderer must already exist. selector->source_id and
+ * selector->feature_id are borrowed for the duration of the call. On success,
+ * *out_state receives an owned snapshot handle. Use
+ * mln_json_snapshot_get() to borrow its root JSON object value, and destroy it
+ * with mln_json_snapshot_destroy(). Missing native source or feature state is
+ * reported as an empty object snapshot.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, selector is
+ *   null or invalid, selector lacks MLN_FEATURE_STATE_SELECTOR_FEATURE_ID,
+ *   out_state is null, or *out_state is not null.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_render_session_get_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector,
+  mln_json_snapshot** out_state
+) MLN_NOEXCEPT;
+
+/**
+ * Removes per-feature state from a render source in this render session.
+ *
+ * The session renderer must already exist. selector->source_id is required.
+ * selector->feature_id and selector->state_key are optional. Passing both
+ * removes one state key from one feature. Passing only feature_id removes all
+ * state for that feature. Passing neither removes all feature state for the
+ * source/source-layer. The accepted command requests a map repaint.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, selector is
+ *   null or invalid, or selector has MLN_FEATURE_STATE_SELECTOR_STATE_KEY
+ *   without MLN_FEATURE_STATE_SELECTOR_FEATURE_ID.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_render_session_remove_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector
+) MLN_NOEXCEPT;
+
+/**
+ * Borrows the root JSON value from a snapshot handle.
+ *
+ * The returned pointer and all nested pointers remain valid until the snapshot
+ * is destroyed.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when snapshot is null or not live, or out_value
+ *   is null.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_json_snapshot_get(
+  const mln_json_snapshot* snapshot, const mln_json_value** out_value
+) MLN_NOEXCEPT;
+
+/** Destroys a JSON snapshot handle. Null is accepted as a no-op. */
+MLN_API void mln_json_snapshot_destroy(
+  mln_json_snapshot* snapshot
+) MLN_NOEXCEPT;
 
 #pragma endregion
 

--- a/src/c_api/render_session.cpp
+++ b/src/c_api/render_session.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "c_api/boundary.hpp"
+#include "geojson/geojson.hpp"
 #include "maplibre_native_c.h"
 #include "render/render_session_common.hpp"
 
@@ -57,4 +58,46 @@ auto mln_render_session_dump_debug_logs(mln_render_session* session) noexcept
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::render_session_dump_debug_logs(session);
   });
+}
+
+auto mln_render_session_set_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector,
+  const mln_json_value* state
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_set_feature_state(
+      session, selector, state
+    );
+  });
+}
+
+auto mln_render_session_get_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector,
+  mln_json_snapshot** out_state
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_get_feature_state(
+      session, selector, out_state
+    );
+  });
+}
+
+auto mln_render_session_remove_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_remove_feature_state(session, selector);
+  });
+}
+
+auto mln_json_snapshot_get(
+  const mln_json_snapshot* snapshot, const mln_json_value** out_value
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::json_snapshot_get(snapshot, out_value);
+  });
+}
+
+auto mln_json_snapshot_destroy(mln_json_snapshot* snapshot) noexcept -> void {
+  mln::core::json_snapshot_destroy(snapshot);
 }

--- a/src/geojson/geojson.cpp
+++ b/src/geojson/geojson.cpp
@@ -2,10 +2,12 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -21,6 +23,10 @@
 #include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
 
+struct mln_json_snapshot {
+  std::unique_ptr<mln::core::OwnedJsonDescriptor> value;
+};
+
 namespace {
 
 constexpr std::size_t max_recursive_depth = 64;
@@ -32,6 +38,19 @@ struct Overloaded : Ts... {
 
 using GeometryDescriptorPtr =
   std::unique_ptr<mln::core::OwnedGeometryDescriptor>;
+using JsonDescriptorPtr = std::unique_ptr<mln::core::OwnedJsonDescriptor>;
+
+auto json_snapshot_mutex() -> std::mutex& {
+  static auto value = std::mutex{};
+  return value;
+}
+
+auto json_snapshots() -> std::unordered_map<
+  const mln_json_snapshot*, std::unique_ptr<mln_json_snapshot>>& {
+  static auto value = std::unordered_map<
+    const mln_json_snapshot*, std::unique_ptr<mln_json_snapshot>>{};
+  return value;
+}
 
 auto validate_depth(std::size_t depth) -> bool {
   if (depth > max_recursive_depth) {
@@ -626,6 +645,142 @@ auto make_geometry_descriptor(
   );
 }
 
+auto string_view(const std::string& string) -> mln_string_view {
+  return mln_string_view{
+    .data = string.empty() ? nullptr : string.data(), .size = string.size()
+  };
+}
+
+auto make_json_descriptor(const mbgl::Value& value, std::size_t depth)
+  -> JsonDescriptorPtr;
+
+auto make_array_json_descriptor(
+  const mbgl::Value::array_type& array, std::size_t depth
+) -> JsonDescriptorPtr {
+  auto result = std::make_unique<mln::core::OwnedJsonDescriptor>();
+  result->children.reserve(array.size());
+  result->child_values.reserve(array.size());
+  for (const auto& child : array) {
+    result->children.emplace_back(make_json_descriptor(child, depth + 1));
+  }
+  for (const auto& child : result->children) {
+    result->child_values.emplace_back(child->root);
+  }
+
+  result->root = mln_json_value{
+    .size = sizeof(mln_json_value),
+    .type = MLN_JSON_VALUE_TYPE_ARRAY,
+    .data = {
+      .array_value = {
+        .values =
+          result->child_values.empty() ? nullptr : result->child_values.data(),
+        .value_count = result->child_values.size()
+      }
+    }
+  };
+  return result;
+}
+
+auto make_object_json_descriptor(
+  const mbgl::Value::object_type& object, std::size_t depth
+) -> JsonDescriptorPtr {
+  auto result = std::make_unique<mln::core::OwnedJsonDescriptor>();
+  result->strings.reserve(object.size());
+  result->children.reserve(object.size());
+  result->child_values.reserve(object.size());
+  result->members.reserve(object.size());
+
+  for (const auto& [key, child] : object) {
+    result->strings.emplace_back(key);
+    result->children.emplace_back(make_json_descriptor(child, depth + 1));
+  }
+  for (std::size_t index = 0; index < result->children.size(); ++index) {
+    result->child_values.emplace_back(result->children.at(index)->root);
+    result->members.emplace_back(
+      mln_json_member{
+        .key = string_view(result->strings.at(index)),
+        .value = &result->child_values.back()
+      }
+    );
+  }
+
+  result->root = mln_json_value{
+    .size = sizeof(mln_json_value),
+    .type = MLN_JSON_VALUE_TYPE_OBJECT,
+    .data = {
+      .object_value = {
+        .members = result->members.empty() ? nullptr : result->members.data(),
+        .member_count = result->members.size()
+      }
+    }
+  };
+  return result;
+}
+
+auto make_json_descriptor(const mbgl::Value& value, std::size_t depth)
+  -> JsonDescriptorPtr {
+  validate_export_depth(depth);
+
+  auto result = std::make_unique<mln::core::OwnedJsonDescriptor>();
+  if (value.is<mbgl::NullValue>()) {
+    result->root = mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_NULL,
+      .data = {.bool_value = false}
+    };
+    return result;
+  }
+  if (const auto* bool_value = value.getBool(); bool_value != nullptr) {
+    result->root = mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_BOOL,
+      .data = {.bool_value = *bool_value}
+    };
+    return result;
+  }
+  if (const auto* uint_value = value.getUint(); uint_value != nullptr) {
+    result->root = mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_UINT,
+      .data = {.uint_value = *uint_value}
+    };
+    return result;
+  }
+  if (const auto* int_value = value.getInt(); int_value != nullptr) {
+    result->root = mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_INT,
+      .data = {.int_value = *int_value}
+    };
+    return result;
+  }
+  if (const auto* double_value = value.getDouble(); double_value != nullptr) {
+    result->root = mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_DOUBLE,
+      .data = {.double_value = *double_value}
+    };
+    return result;
+  }
+  if (const auto* string_value = value.getString(); string_value != nullptr) {
+    result->strings.emplace_back(*string_value);
+    result->root = mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_STRING,
+      .data = {.string_value = string_view(result->strings.front())}
+    };
+    return result;
+  }
+  if (const auto* array_value = value.getArray(); array_value != nullptr) {
+    return make_array_json_descriptor(*array_value, depth);
+  }
+  if (const auto* object_value = value.getObject(); object_value != nullptr) {
+    return make_object_json_descriptor(*object_value, depth);
+  }
+
+  throw std::runtime_error("unsupported JSON value type");
+}
+
 }  // namespace
 
 namespace mln::core {
@@ -643,6 +798,62 @@ auto to_c_geometry(const mbgl::Geometry<double>& geometry)
 auto to_native_json_value(const mln_json_value* value)
   -> std::optional<mbgl::Value> {
   return convert_value(value, 0);
+}
+
+auto to_c_json_value(const mbgl::Value& value)
+  -> std::unique_ptr<OwnedJsonDescriptor> {
+  return make_json_descriptor(value, 0);
+}
+
+auto json_snapshot_create(mbgl::Value value, mln_json_snapshot** out_snapshot)
+  -> mln_status {
+  if (out_snapshot == nullptr) {
+    set_thread_error("out_state must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (*out_snapshot != nullptr) {
+    set_thread_error("*out_state must be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto snapshot = std::make_unique<mln_json_snapshot>();
+  snapshot->value = to_c_json_value(value);
+  auto* handle = snapshot.get();
+  const auto lock = std::scoped_lock{json_snapshot_mutex()};
+  json_snapshots().emplace(handle, std::move(snapshot));
+  *out_snapshot = handle;
+  return MLN_STATUS_OK;
+}
+
+auto json_snapshot_get(
+  const mln_json_snapshot* snapshot, const mln_json_value** out_value
+) -> mln_status {
+  if (snapshot == nullptr) {
+    set_thread_error("JSON snapshot must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_value == nullptr) {
+    set_thread_error("out_value must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto lock = std::scoped_lock{json_snapshot_mutex()};
+  const auto found = json_snapshots().find(snapshot);
+  if (found == json_snapshots().end()) {
+    set_thread_error("JSON snapshot is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_value = &found->second->value->root;
+  return MLN_STATUS_OK;
+}
+
+auto json_snapshot_destroy(mln_json_snapshot* snapshot) -> void {
+  if (snapshot == nullptr) {
+    return;
+  }
+
+  const auto lock = std::scoped_lock{json_snapshot_mutex()};
+  json_snapshots().erase(snapshot);
 }
 
 auto to_native_feature(const mln_feature* feature)

--- a/src/geojson/geojson.hpp
+++ b/src/geojson/geojson.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <mbgl/util/feature.hpp>
@@ -22,12 +23,28 @@ struct OwnedGeometryDescriptor {
   std::vector<mln_geometry> child_geometries;
 };
 
+struct OwnedJsonDescriptor {
+  mln_json_value root{};
+  std::vector<std::string> strings;
+  std::vector<std::unique_ptr<OwnedJsonDescriptor>> children;
+  std::vector<mln_json_value> child_values;
+  std::vector<mln_json_member> members;
+};
+
 auto to_native_geometry(const mln_geometry* geometry)
   -> std::optional<mbgl::Geometry<double>>;
 auto to_c_geometry(const mbgl::Geometry<double>& geometry)
   -> std::unique_ptr<OwnedGeometryDescriptor>;
 auto to_native_json_value(const mln_json_value* value)
   -> std::optional<mbgl::Value>;
+auto to_c_json_value(const mbgl::Value& value)
+  -> std::unique_ptr<OwnedJsonDescriptor>;
+auto json_snapshot_create(mbgl::Value value, mln_json_snapshot** out_snapshot)
+  -> mln_status;
+auto json_snapshot_get(
+  const mln_json_snapshot* snapshot, const mln_json_value** out_value
+) -> mln_status;
+auto json_snapshot_destroy(mln_json_snapshot* snapshot) -> void;
 auto to_native_feature(const mln_feature* feature)
   -> std::optional<mbgl::GeoJSONFeature>;
 auto to_native_geojson(const mln_geojson* geojson)

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -2,6 +2,8 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -15,6 +17,7 @@
 #include "render/render_session_common.hpp"
 
 #include "diagnostics/diagnostics.hpp"
+#include "geojson/geojson.hpp"
 #include "map/map.hpp"
 #include "maplibre_native_c.h"
 
@@ -74,6 +77,108 @@ auto validate_renderer_backend(mln_render_session* session)
     return nullptr;
   }
   return backend;
+}
+
+constexpr uint32_t feature_state_selector_known_fields =
+  MLN_FEATURE_STATE_SELECTOR_SOURCE_LAYER_ID |
+  MLN_FEATURE_STATE_SELECTOR_FEATURE_ID | MLN_FEATURE_STATE_SELECTOR_STATE_KEY;
+
+auto validate_string_view(mln_string_view string) -> bool {
+  if (string.size > 0 && string.data == nullptr) {
+    mln::core::set_thread_error("string data must not be null");
+    return false;
+  }
+  return true;
+}
+
+auto string_from_view(mln_string_view string) -> std::string {
+  if (string.size == 0) {
+    return {};
+  }
+  return std::string{string.data, string.size};
+}
+
+auto selector_has_field(
+  const mln_feature_state_selector& selector, uint32_t field
+) -> bool {
+  return (selector.fields & field) != 0;
+}
+
+auto validate_feature_state_selector(
+  const mln_feature_state_selector* selector, bool require_feature_id
+) -> mln_status {
+  if (selector == nullptr) {
+    mln::core::set_thread_error("feature state selector must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (selector->size < sizeof(mln_feature_state_selector)) {
+    mln::core::set_thread_error("mln_feature_state_selector.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if ((selector->fields & ~feature_state_selector_known_fields) != 0) {
+    mln::core::set_thread_error("feature state selector has unknown fields");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!validate_string_view(selector->source_id)) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (selector->source_id.size == 0) {
+    mln::core::set_thread_error("feature state source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    selector_has_field(*selector, MLN_FEATURE_STATE_SELECTOR_SOURCE_LAYER_ID) &&
+    !validate_string_view(selector->source_layer_id)
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    selector_has_field(*selector, MLN_FEATURE_STATE_SELECTOR_FEATURE_ID) &&
+    !validate_string_view(selector->feature_id)
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    selector_has_field(*selector, MLN_FEATURE_STATE_SELECTOR_STATE_KEY) &&
+    !validate_string_view(selector->state_key)
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto has_feature_id =
+    selector_has_field(*selector, MLN_FEATURE_STATE_SELECTOR_FEATURE_ID);
+  if (require_feature_id && !has_feature_id) {
+    mln::core::set_thread_error("feature state selector requires feature_id");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    selector_has_field(*selector, MLN_FEATURE_STATE_SELECTOR_STATE_KEY) &&
+    !has_feature_id
+  ) {
+    mln::core::set_thread_error(
+      "feature state selector state_key requires feature_id"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto optional_selector_string(
+  const mln_feature_state_selector& selector, uint32_t field,
+  mln_string_view value
+) -> std::optional<std::string> {
+  if (!selector_has_field(selector, field)) {
+    return std::nullopt;
+  }
+  return string_from_view(value);
+}
+
+auto feature_state_source_layer(const mln_feature_state_selector& selector)
+  -> std::optional<std::string> {
+  return optional_selector_string(
+    selector, MLN_FEATURE_STATE_SELECTOR_SOURCE_LAYER_ID,
+    selector.source_layer_id
+  );
 }
 
 }  // namespace
@@ -386,6 +491,111 @@ auto render_session_dump_debug_logs(mln_render_session* session) -> mln_status {
     *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
   };
   session->renderer->dumpDebugLogs();
+  return MLN_STATUS_OK;
+}
+
+auto render_session_set_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector,
+  const mln_json_value* state
+) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto selector_status = validate_feature_state_selector(selector, true);
+  if (selector_status != MLN_STATUS_OK) {
+    return selector_status;
+  }
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto native_state = to_native_json_value(state);
+  if (!native_state) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto* state_object = native_state->getObject();
+  if (state_object == nullptr) {
+    set_thread_error("feature state value must be a JSON object");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
+  session->renderer->setFeatureState(
+    string_from_view(selector->source_id),
+    feature_state_source_layer(*selector),
+    string_from_view(selector->feature_id), *state_object
+  );
+  if (auto* native_map = map_native(session->map); native_map != nullptr) {
+    native_map->triggerRepaint();
+  }
+  return MLN_STATUS_OK;
+}
+
+auto render_session_get_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector,
+  mln_json_snapshot** out_state
+) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto selector_status = validate_feature_state_selector(selector, true);
+  if (selector_status != MLN_STATUS_OK) {
+    return selector_status;
+  }
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto state = mbgl::FeatureState{};
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
+  session->renderer->getFeatureState(
+    state, string_from_view(selector->source_id),
+    feature_state_source_layer(*selector),
+    string_from_view(selector->feature_id)
+  );
+  return json_snapshot_create(mbgl::Value{std::move(state)}, out_state);
+}
+
+auto render_session_remove_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector
+) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto selector_status = validate_feature_state_selector(selector, false);
+  if (selector_status != MLN_STATUS_OK) {
+    return selector_status;
+  }
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
+  session->renderer->removeFeatureState(
+    string_from_view(selector->source_id),
+    feature_state_source_layer(*selector),
+    optional_selector_string(
+      *selector, MLN_FEATURE_STATE_SELECTOR_FEATURE_ID, selector->feature_id
+    ),
+    optional_selector_string(
+      *selector, MLN_FEATURE_STATE_SELECTOR_STATE_KEY, selector->state_key
+    )
+  );
+  if (auto* native_map = map_native(session->map); native_map != nullptr) {
+    native_map->triggerRepaint();
+  }
   return MLN_STATUS_OK;
 }
 

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -133,5 +133,16 @@ auto render_session_reduce_memory_use(mln_render_session* session)
   -> mln_status;
 auto render_session_clear_data(mln_render_session* session) -> mln_status;
 auto render_session_dump_debug_logs(mln_render_session* session) -> mln_status;
+auto render_session_set_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector,
+  const mln_json_value* state
+) -> mln_status;
+auto render_session_get_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector,
+  mln_json_snapshot** out_state
+) -> mln_status;
+auto render_session_remove_feature_state(
+  mln_render_session* session, const mln_feature_state_selector* selector
+) -> mln_status;
 
 }  // namespace mln::core

--- a/tests/c/feature_state.zig
+++ b/tests/c/feature_state.zig
@@ -1,0 +1,149 @@
+const std = @import("std");
+const testing = std.testing;
+const support = @import("support.zig");
+const c = support.c;
+
+fn stringView(value: []const u8) c.mln_string_view {
+    return .{ .data = value.ptr, .size = value.len };
+}
+
+fn featureStateSelector(source_id: []const u8, feature_id: []const u8) c.mln_feature_state_selector {
+    return .{
+        .size = @sizeOf(c.mln_feature_state_selector),
+        .fields = c.MLN_FEATURE_STATE_SELECTOR_FEATURE_ID,
+        .source_id = stringView(source_id),
+        .source_layer_id = .{ .data = null, .size = 0 },
+        .feature_id = stringView(feature_id),
+        .state_key = .{ .data = null, .size = 0 },
+    };
+}
+
+fn expectObjectMemberBool(root: *const c.mln_json_value, key: []const u8, expected: bool) !void {
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_OBJECT, root.type);
+    const object = root.data.object_value;
+    for (object.members[0..object.member_count]) |member| {
+        if (std.mem.eql(u8, member.key.data[0..member.key.size], key)) {
+            const value = member.value.?;
+            try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_BOOL, value.*.type);
+            try testing.expectEqual(expected, value.*.data.bool_value);
+            return;
+        }
+    }
+    return error.MissingJsonMember;
+}
+
+fn expectObjectMemberUint(root: *const c.mln_json_value, key: []const u8, expected: u64) !void {
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_OBJECT, root.type);
+    const object = root.data.object_value;
+    for (object.members[0..object.member_count]) |member| {
+        if (std.mem.eql(u8, member.key.data[0..member.key.size], key)) {
+            const value = member.value.?;
+            try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_UINT, value.*.type);
+            try testing.expectEqual(expected, value.*.data.uint_value);
+            return;
+        }
+    }
+    return error.MissingJsonMember;
+}
+
+test "feature state ABI structs import" {
+    const selector = featureStateSelector("point", "feature-1");
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_feature_state_selector)), selector.size);
+    try testing.expectEqual(@as(u32, c.MLN_FEATURE_STATE_SELECTOR_FEATURE_ID), selector.fields);
+}
+
+test "render session feature state set get and remove" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var descriptor = c.mln_owned_texture_descriptor_default();
+    descriptor.width = 64;
+    descriptor.height = 64;
+
+    var session: ?*c.mln_render_session = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_owned_texture_attach(map, &descriptor, &session));
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(session.?)) catch @panic("session destroy failed");
+
+    var selector = featureStateSelector("point", "feature-1");
+
+    const hover_key = "hover";
+    const radius_key = "radius";
+    const hover = c.mln_json_value{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_BOOL,
+        .data = .{ .bool_value = true },
+    };
+    const radius = c.mln_json_value{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_UINT,
+        .data = .{ .uint_value = 20 },
+    };
+    const members = [_]c.mln_json_member{
+        .{ .key = stringView(hover_key), .value = &hover },
+        .{ .key = stringView(radius_key), .value = &radius },
+    };
+    const state = c.mln_json_value{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_OBJECT,
+        .data = .{ .object_value = .{ .members = &members, .member_count = members.len } },
+    };
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_set_feature_state(session.?, &selector, &state));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(session.?));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_set_feature_state(session.?, &selector, &state));
+
+    var snapshot: ?*c.mln_json_snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_get_feature_state(session.?, &selector, &snapshot));
+    defer c.mln_json_snapshot_destroy(snapshot.?);
+
+    var root: ?*const c.mln_json_value = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_json_snapshot_get(snapshot.?, &root));
+    try testing.expectEqual(@as(usize, 2), root.?.*.data.object_value.member_count);
+    try expectObjectMemberBool(root.?, hover_key, true);
+    try expectObjectMemberUint(root.?, radius_key, 20);
+
+    selector.fields |= c.MLN_FEATURE_STATE_SELECTOR_STATE_KEY;
+    selector.state_key = stringView(hover_key);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_remove_feature_state(session.?, &selector));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(session.?));
+
+    var after_remove: ?*c.mln_json_snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_get_feature_state(session.?, &selector, &after_remove));
+    defer c.mln_json_snapshot_destroy(after_remove.?);
+
+    root = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_json_snapshot_get(after_remove.?, &root));
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_OBJECT, root.?.*.type);
+    try testing.expectEqual(@as(usize, 1), root.?.*.data.object_value.member_count);
+    try expectObjectMemberUint(root.?, radius_key, 20);
+}
+
+test "feature state selector validation" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    var descriptor = c.mln_owned_texture_descriptor_default();
+    descriptor.width = 64;
+    descriptor.height = 64;
+
+    var session: ?*c.mln_render_session = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_owned_texture_attach(map, &descriptor, &session));
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(session.?)) catch @panic("session destroy failed");
+
+    var selector = featureStateSelector("point", "feature-1");
+    selector.fields = c.MLN_FEATURE_STATE_SELECTOR_STATE_KEY;
+    selector.state_key = stringView("hover");
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_remove_feature_state(session.?, &selector));
+}

--- a/tests/c/main.zig
+++ b/tests/c/main.zig
@@ -4,6 +4,7 @@ comptime {
     _ = @import("style.zig");
     _ = @import("resources.zig");
     _ = @import("geojson.zig");
+    _ = @import("feature_state.zig");
     _ = @import("camera.zig");
     _ = @import("projection.zig");
     _ = @import("map_tuning.zig");


### PR DESCRIPTION
## Summary
- Add render-session feature state set/get/remove APIs over the existing JSON value ABI.
- Add owned JSON snapshot handles for returned feature-state objects.
- Cover the new C ABI through Zig tests, including set/get/remove behavior and selector validation.

## Testing
- `mise run test`

Closes #27