### PR TITLE
Add style registry APIs

### DIFF
--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -6,6 +6,13 @@
 #ifndef MAPLIBRE_NATIVE_C_STYLE_H
 #define MAPLIBRE_NATIVE_C_STYLE_H
 
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
 #include "base.h"
 #include "map.h"
 
@@ -14,6 +21,333 @@ extern "C" {
 #endif
 
 #pragma region Style mutation
+
+typedef struct mln_style_id_list mln_style_id_list;
+
+/** Style source type values returned by mln_map_get_style_source_type(). */
+typedef enum mln_style_source_type : uint32_t {
+  MLN_STYLE_SOURCE_TYPE_UNKNOWN = 0,
+  MLN_STYLE_SOURCE_TYPE_VECTOR = 1,
+  MLN_STYLE_SOURCE_TYPE_RASTER = 2,
+  MLN_STYLE_SOURCE_TYPE_RASTER_DEM = 3,
+  MLN_STYLE_SOURCE_TYPE_GEOJSON = 4,
+  MLN_STYLE_SOURCE_TYPE_IMAGE = 5,
+  MLN_STYLE_SOURCE_TYPE_VIDEO = 6,
+  MLN_STYLE_SOURCE_TYPE_ANNOTATIONS = 7,
+  MLN_STYLE_SOURCE_TYPE_CUSTOM_VECTOR = 8,
+} mln_style_source_type;
+
+/** Fixed source metadata returned by mln_map_get_style_source_info(). */
+typedef struct mln_style_source_info {
+  uint32_t size;
+  /** One of mln_style_source_type. */
+  uint32_t type;
+  /** Source ID byte length, excluding any null terminator. */
+  size_t id_size;
+  bool is_volatile;
+  bool has_attribution;
+  /** Attribution byte length, excluding any null terminator. */
+  size_t attribution_size;
+} mln_style_source_info;
+
+/**
+ * Gets the number of IDs in a style ID list handle.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when list is null or not live, or out_count is
+ *   null.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_style_id_list_count(
+  const mln_style_id_list* list, size_t* out_count
+) MLN_NOEXCEPT;
+
+/**
+ * Borrows one ID from a style ID list handle.
+ *
+ * On success, out_id receives a view into list-owned storage. The view remains
+ * valid until the list is destroyed.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when list is null or not live, index is out of
+ *   range, or out_id is null.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_style_id_list_get(
+  const mln_style_id_list* list, size_t index, mln_string_view* out_id
+) MLN_NOEXCEPT;
+
+/** Destroys a style ID list handle. Null is accepted as a no-op. */
+MLN_API void mln_style_id_list_destroy(mln_style_id_list* list) MLN_NOEXCEPT;
+
+/**
+ * Adds one style source from a style-spec source JSON object.
+ *
+ * source_id and source_json are borrowed for the call. source_json is the
+ * object that appears under sources[source_id] in a style document. The
+ * function parses and copies the accepted source into MapLibre Native before
+ * return.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, source_json is null or invalid, the source ID already
+ *   exists, or the source JSON cannot be converted.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_style_source_json(
+  mln_map* map, mln_string_view source_id, const mln_json_value* source_json
+) MLN_NOEXCEPT;
+
+/**
+ * Removes one style source by ID.
+ *
+ * source_id is borrowed for the call. On success, out_removed reports whether a
+ * source existed and was removed.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, or out_removed is null.
+ * - MLN_STATUS_INVALID_STATE when the source exists but a layer still uses it.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_remove_style_source(
+  mln_map* map, mln_string_view source_id, bool* out_removed
+) MLN_NOEXCEPT;
+
+/**
+ * Reports whether a style source ID exists.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, or out_exists is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_style_source_exists(
+  mln_map* map, mln_string_view source_id, bool* out_exists
+) MLN_NOEXCEPT;
+
+/**
+ * Gets one style source type.
+ *
+ * On success, out_found reports whether source_id exists. When found,
+ * out_source_type receives one of mln_style_source_type.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, out_source_type is null, or out_found is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_style_source_type(
+  mln_map* map, mln_string_view source_id, uint32_t* out_source_type,
+  bool* out_found
+) MLN_NOEXCEPT;
+
+/**
+ * Copies fixed metadata for one style source.
+ *
+ * The returned struct contains string lengths, not string contents. Use
+ * mln_map_copy_style_source_attribution() to copy attribution bytes when
+ * has_attribution is true. The source ID is the lookup key and is also
+ * available through style source ID lists.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, out_info is null, out_info->size is too small, or
+ *   out_found is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_style_source_info(
+  mln_map* map, mln_string_view source_id, mln_style_source_info* out_info,
+  bool* out_found
+) MLN_NOEXCEPT;
+
+/**
+ * Copies one style source attribution string into caller-owned memory.
+ *
+ * source_id is borrowed for the call. out_attribution may be null only when
+ * attribution_capacity is 0. On success, out_attribution_size receives the byte
+ * length of the attribution, excluding any null terminator. When out_found is
+ * false or the source has no attribution, out_attribution_size receives 0.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, out_attribution is null with non-zero capacity,
+ *   attribution_capacity is too small for a present attribution,
+ *   out_attribution_size is null, or out_found is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_copy_style_source_attribution(
+  mln_map* map, mln_string_view source_id, char* out_attribution,
+  size_t attribution_capacity, size_t* out_attribution_size, bool* out_found
+) MLN_NOEXCEPT;
+
+/**
+ * Copies style source IDs in style order.
+ *
+ * On success, *out_source_ids receives an owned list handle. Destroy it with
+ * mln_style_id_list_destroy().
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_source_ids is
+ *   null, or *out_source_ids is not null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_list_style_source_ids(
+  mln_map* map, mln_style_id_list** out_source_ids
+) MLN_NOEXCEPT;
+
+/**
+ * Adds one style layer from a full style-spec layer JSON object.
+ *
+ * layer_json and before_layer_id are borrowed for the call. layer_json must
+ * contain id and type members. Passing an empty before_layer_id appends the
+ * layer; otherwise the layer is inserted before that existing layer.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_json is
+ *   null or invalid, the layer ID already exists, before_layer_id is invalid or
+ *   does not exist, or the layer JSON cannot be converted.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_style_layer_json(
+  mln_map* map, const mln_json_value* layer_json,
+  mln_string_view before_layer_id
+) MLN_NOEXCEPT;
+
+/**
+ * Removes one style layer by ID.
+ *
+ * layer_id is borrowed for the call. On success, out_removed reports whether a
+ * layer existed and was removed.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, or out_removed is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_remove_style_layer(
+  mln_map* map, mln_string_view layer_id, bool* out_removed
+) MLN_NOEXCEPT;
+
+/**
+ * Reports whether a style layer ID exists.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, or out_exists is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_style_layer_exists(
+  mln_map* map, mln_string_view layer_id, bool* out_exists
+) MLN_NOEXCEPT;
+
+/**
+ * Borrows one style layer type string.
+ *
+ * On success, out_found reports whether layer_id exists. When found,
+ * out_layer_type receives a view of a static style-spec layer type string.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, out_layer_type is null, or out_found is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_style_layer_type(
+  mln_map* map, mln_string_view layer_id, mln_string_view* out_layer_type,
+  bool* out_found
+) MLN_NOEXCEPT;
+
+/**
+ * Copies style layer IDs in style order.
+ *
+ * On success, *out_layer_ids receives an owned list handle. Destroy it with
+ * mln_style_id_list_destroy().
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, out_layer_ids is
+ *   null, or *out_layer_ids is not null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_list_style_layer_ids(
+  mln_map* map, mln_style_id_list** out_layer_ids
+) MLN_NOEXCEPT;
+
+/**
+ * Moves one style layer before another layer or to the top.
+ *
+ * layer_id and before_layer_id are borrowed for the call. Passing an empty
+ * before_layer_id moves the layer to the top of the style order.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, before_layer_id is invalid, layer_id does not exist, or
+ *   before_layer_id is non-empty and does not exist.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_move_style_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view before_layer_id
+) MLN_NOEXCEPT;
+
+/**
+ * Copies one style layer as a full style-spec layer JSON snapshot.
+ *
+ * On success, out_found reports whether layer_id exists. When found,
+ * *out_layer receives an owned snapshot handle.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, out_layer is null, *out_layer is not null, or out_found
+ *   is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_style_layer_json(
+  mln_map* map, mln_string_view layer_id, mln_json_snapshot** out_layer,
+  bool* out_found
+) MLN_NOEXCEPT;
 
 /**
  * Sets one layer property using its MapLibre style-spec property name.

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -85,6 +85,157 @@ auto mln_map_set_style_json(mln_map* map, const char* json) noexcept
   });
 }
 
+auto mln_style_id_list_count(
+  const mln_style_id_list* list, size_t* out_count
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::style_id_list_count(list, out_count);
+  });
+}
+
+auto mln_style_id_list_get(
+  const mln_style_id_list* list, size_t index, mln_string_view* out_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::style_id_list_get(list, index, out_id);
+  });
+}
+
+auto mln_style_id_list_destroy(mln_style_id_list* list) noexcept -> void {
+  mln::core::style_id_list_destroy(list);
+}
+
+auto mln_map_add_style_source_json(
+  mln_map* map, mln_string_view source_id, const mln_json_value* source_json
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_style_source_json(map, source_id, source_json);
+  });
+}
+
+auto mln_map_remove_style_source(
+  mln_map* map, mln_string_view source_id, bool* out_removed
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_remove_style_source(map, source_id, out_removed);
+  });
+}
+
+auto mln_map_style_source_exists(
+  mln_map* map, mln_string_view source_id, bool* out_exists
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_style_source_exists(map, source_id, out_exists);
+  });
+}
+
+auto mln_map_get_style_source_type(
+  mln_map* map, mln_string_view source_id, uint32_t* out_source_type,
+  bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_style_source_type(
+      map, source_id, out_source_type, out_found
+    );
+  });
+}
+
+auto mln_map_get_style_source_info(
+  mln_map* map, mln_string_view source_id, mln_style_source_info* out_info,
+  bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_style_source_info(
+      map, source_id, out_info, out_found
+    );
+  });
+}
+
+auto mln_map_copy_style_source_attribution(
+  mln_map* map, mln_string_view source_id, char* out_attribution,
+  size_t attribution_capacity, size_t* out_attribution_size, bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_copy_style_source_attribution(
+      map, source_id, out_attribution, attribution_capacity,
+      out_attribution_size, out_found
+    );
+  });
+}
+
+auto mln_map_list_style_source_ids(
+  mln_map* map, mln_style_id_list** out_source_ids
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_list_style_source_ids(map, out_source_ids);
+  });
+}
+
+auto mln_map_add_style_layer_json(
+  mln_map* map, const mln_json_value* layer_json,
+  mln_string_view before_layer_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_style_layer_json(
+      map, layer_json, before_layer_id
+    );
+  });
+}
+
+auto mln_map_remove_style_layer(
+  mln_map* map, mln_string_view layer_id, bool* out_removed
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_remove_style_layer(map, layer_id, out_removed);
+  });
+}
+
+auto mln_map_style_layer_exists(
+  mln_map* map, mln_string_view layer_id, bool* out_exists
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_style_layer_exists(map, layer_id, out_exists);
+  });
+}
+
+auto mln_map_get_style_layer_type(
+  mln_map* map, mln_string_view layer_id, mln_string_view* out_layer_type,
+  bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_style_layer_type(
+      map, layer_id, out_layer_type, out_found
+    );
+  });
+}
+
+auto mln_map_list_style_layer_ids(
+  mln_map* map, mln_style_id_list** out_layer_ids
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_list_style_layer_ids(map, out_layer_ids);
+  });
+}
+
+auto mln_map_move_style_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view before_layer_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_move_style_layer(map, layer_id, before_layer_id);
+  });
+}
+
+auto mln_map_get_style_layer_json(
+  mln_map* map, mln_string_view layer_id, mln_json_snapshot** out_layer,
+  bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_style_layer_json(
+      map, layer_id, out_layer, out_found
+    );
+  });
+}
+
 auto mln_map_set_layer_property(
   mln_map* map, mln_string_view layer_id, mln_string_view property_name,
   const mln_json_value* value

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -29,9 +30,15 @@
 #include <mbgl/renderer/renderer_frontend.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/layer.hpp>   // IWYU pragma: keep
+#include <mbgl/style/conversion/source.hpp>  // IWYU pragma: keep
+#include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/style/layer.hpp>
+#include <mbgl/style/source.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_property.hpp>
+#include <mbgl/style/types.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/tile/tile_operation.hpp>
 #include <mbgl/util/chrono.hpp>
@@ -49,10 +56,16 @@
 #include "runtime/runtime.hpp"
 #include "style/style_value.hpp"
 
+struct mln_style_id_list {
+  std::vector<std::string> ids;
+};
+
 namespace {
 using MapRegistry = std::unordered_map<mln_map*, std::unique_ptr<mln_map>>;
 using ProjectionRegistry =
   std::unordered_map<mln_map_projection*, std::unique_ptr<mln_map_projection>>;
+using StyleIdListRegistry = std::unordered_map<
+  const mln_style_id_list*, std::unique_ptr<mln_style_id_list>>;
 
 constexpr auto default_map_width = uint32_t{256};
 constexpr auto default_map_height = uint32_t{256};
@@ -78,6 +91,16 @@ auto map_projection_registry() -> ProjectionRegistry& {
   return value;
 }
 
+auto style_id_list_registry_mutex() -> std::mutex& {
+  static std::mutex value;
+  return value;
+}
+
+auto style_id_list_registry() -> StyleIdListRegistry& {
+  static StyleIdListRegistry value;
+  return value;
+}
+
 auto validate_string_view(mln_string_view string, const char* name) -> bool {
   if (string.size > 0 && string.data == nullptr) {
     auto message = std::string{name} + " data must not be null";
@@ -92,6 +115,64 @@ auto string_from_view(mln_string_view string) -> std::string {
     return {};
   }
   return std::string{string.data, string.size};
+}
+
+auto string_view_from_string(const std::string& string) -> mln_string_view {
+  return mln_string_view{.data = string.data(), .size = string.size()};
+}
+
+auto string_view_from_literal(const char* string) -> mln_string_view {
+  return mln_string_view{.data = string, .size = std::strlen(string)};
+}
+
+auto to_c_source_type(mbgl::style::SourceType type) -> uint32_t {
+  switch (type) {
+    case mbgl::style::SourceType::Vector:
+      return MLN_STYLE_SOURCE_TYPE_VECTOR;
+    case mbgl::style::SourceType::Raster:
+      return MLN_STYLE_SOURCE_TYPE_RASTER;
+    case mbgl::style::SourceType::RasterDEM:
+      return MLN_STYLE_SOURCE_TYPE_RASTER_DEM;
+    case mbgl::style::SourceType::GeoJSON:
+      return MLN_STYLE_SOURCE_TYPE_GEOJSON;
+    case mbgl::style::SourceType::Video:
+      return MLN_STYLE_SOURCE_TYPE_VIDEO;
+    case mbgl::style::SourceType::Annotations:
+      return MLN_STYLE_SOURCE_TYPE_ANNOTATIONS;
+    case mbgl::style::SourceType::Image:
+      return MLN_STYLE_SOURCE_TYPE_IMAGE;
+    case mbgl::style::SourceType::CustomVector:
+      return MLN_STYLE_SOURCE_TYPE_CUSTOM_VECTOR;
+  }
+  return MLN_STYLE_SOURCE_TYPE_UNKNOWN;
+}
+
+auto create_style_id_list(
+  std::vector<std::string> ids, mln_style_id_list** out_list
+) -> mln_status {
+  if (out_list == nullptr || *out_list != nullptr) {
+    mln::core::set_thread_error(
+      "out_list must not be null and *out_list must be null"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto list = std::make_unique<mln_style_id_list>();
+  list->ids = std::move(ids);
+  auto* handle = list.get();
+  const auto lock = std::scoped_lock{style_id_list_registry_mutex()};
+  style_id_list_registry().emplace(handle, std::move(list));
+  *out_list = handle;
+  return MLN_STATUS_OK;
+}
+
+auto find_style_id_list_locked(const mln_style_id_list* list)
+  -> const mln_style_id_list* {
+  const auto found = style_id_list_registry().find(list);
+  if (found == style_id_list_registry().end()) {
+    return nullptr;
+  }
+  return found->second.get();
 }
 
 template <typename Payload>
@@ -1915,6 +1996,524 @@ auto map_set_style_json(mln_map* map, const char* json) -> mln_status {
     return MLN_STATUS_NATIVE_ERROR;
   }
   return MLN_STATUS_OK;
+}
+
+auto style_id_list_count(const mln_style_id_list* list, size_t* out_count)
+  -> mln_status {
+  if (list == nullptr) {
+    set_thread_error("style ID list must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_count == nullptr) {
+    set_thread_error("out_count must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto lock = std::scoped_lock{style_id_list_registry_mutex()};
+  const auto* live_list = find_style_id_list_locked(list);
+  if (live_list == nullptr) {
+    set_thread_error("style ID list is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_count = live_list->ids.size();
+  return MLN_STATUS_OK;
+}
+
+auto style_id_list_get(
+  const mln_style_id_list* list, size_t index, mln_string_view* out_id
+) -> mln_status {
+  if (list == nullptr) {
+    set_thread_error("style ID list must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_id == nullptr) {
+    set_thread_error("out_id must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto lock = std::scoped_lock{style_id_list_registry_mutex()};
+  const auto* live_list = find_style_id_list_locked(list);
+  if (live_list == nullptr) {
+    set_thread_error("style ID list is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (index >= live_list->ids.size()) {
+    set_thread_error("index is out of range");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_id = string_view_from_string(live_list->ids.at(index));
+  return MLN_STATUS_OK;
+}
+
+auto style_id_list_destroy(mln_style_id_list* list) -> void {
+  if (list == nullptr) {
+    return;
+  }
+  const auto lock = std::scoped_lock{style_id_list_registry_mutex()};
+  style_id_list_registry().erase(list);
+}
+
+auto map_add_style_source_json(
+  mln_map* map, mln_string_view source_id, const mln_json_value* source_json
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(source_id, "source_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (source_id.size == 0) {
+    set_thread_error("source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!validate_style_json_value(source_json)) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  if (style.getSource(id) != nullptr) {
+    set_thread_error("source already exists");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto error = mbgl::style::conversion::Error{};
+  auto source =
+    mbgl::style::conversion::convert<std::unique_ptr<mbgl::style::Source>>(
+      mbgl::style::conversion::Convertible{source_json}, error, id
+    );
+  if (!source) {
+    set_style_conversion_error("style source", error);
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  style.addSource(std::move(*source));
+  return MLN_STATUS_OK;
+}
+
+auto map_remove_style_source(
+  mln_map* map, mln_string_view source_id, bool* out_removed
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(source_id, "source_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (source_id.size == 0) {
+    set_thread_error("source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_removed == nullptr) {
+    set_thread_error("out_removed must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  if (style.getSource(id) == nullptr) {
+    *out_removed = false;
+    return MLN_STATUS_OK;
+  }
+
+  auto removed = style.removeSource(id);
+  if (!removed) {
+    set_thread_error("source is used by a layer");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  *out_removed = true;
+  return MLN_STATUS_OK;
+}
+
+auto map_style_source_exists(
+  mln_map* map, mln_string_view source_id, bool* out_exists
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(source_id, "source_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (source_id.size == 0) {
+    set_thread_error("source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_exists == nullptr) {
+    set_thread_error("out_exists must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_exists =
+    map->map->getStyle().getSource(string_from_view(source_id)) != nullptr;
+  return MLN_STATUS_OK;
+}
+
+auto map_get_style_source_type(
+  mln_map* map, mln_string_view source_id, uint32_t* out_source_type,
+  bool* out_found
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(source_id, "source_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (source_id.size == 0) {
+    set_thread_error("source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_source_type == nullptr || out_found == nullptr) {
+    set_thread_error("out_source_type and out_found must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto* source =
+    map->map->getStyle().getSource(string_from_view(source_id));
+  *out_found = source != nullptr;
+  *out_source_type = MLN_STYLE_SOURCE_TYPE_UNKNOWN;
+  if (source != nullptr) {
+    *out_source_type = to_c_source_type(source->getType());
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_get_style_source_info(
+  mln_map* map, mln_string_view source_id, mln_style_source_info* out_info,
+  bool* out_found
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(source_id, "source_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (source_id.size == 0) {
+    set_thread_error("source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_info == nullptr || out_info->size < sizeof(mln_style_source_info)) {
+    set_thread_error("out_info must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_found == nullptr) {
+    set_thread_error("out_found must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto* source =
+    map->map->getStyle().getSource(string_from_view(source_id));
+  *out_found = source != nullptr;
+  *out_info = mln_style_source_info{
+    .size = sizeof(mln_style_source_info),
+    .type = MLN_STYLE_SOURCE_TYPE_UNKNOWN,
+    .id_size = 0,
+    .is_volatile = false,
+    .has_attribution = false,
+    .attribution_size = 0
+  };
+  if (source == nullptr) {
+    return MLN_STATUS_OK;
+  }
+
+  const auto attribution = source->getAttribution();
+  *out_info = mln_style_source_info{
+    .size = sizeof(mln_style_source_info),
+    .type = to_c_source_type(source->getType()),
+    .id_size = source->getID().size(),
+    .is_volatile = source->isVolatile(),
+    .has_attribution = attribution.has_value(),
+    .attribution_size = attribution ? attribution->size() : 0
+  };
+  return MLN_STATUS_OK;
+}
+
+auto map_copy_style_source_attribution(
+  mln_map* map, mln_string_view source_id, char* out_attribution,
+  size_t attribution_capacity, size_t* out_attribution_size, bool* out_found
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(source_id, "source_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (source_id.size == 0) {
+    set_thread_error("source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_attribution == nullptr && attribution_capacity > 0) {
+    set_thread_error(
+      "out_attribution must not be null when capacity is non-zero"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_attribution_size == nullptr || out_found == nullptr) {
+    set_thread_error("out_attribution_size and out_found must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto* source =
+    map->map->getStyle().getSource(string_from_view(source_id));
+  *out_found = source != nullptr;
+  *out_attribution_size = 0;
+  if (source == nullptr) {
+    return MLN_STATUS_OK;
+  }
+
+  const auto attribution = source->getAttribution();
+  if (!attribution) {
+    return MLN_STATUS_OK;
+  }
+  *out_attribution_size = attribution->size();
+  if (attribution_capacity < attribution->size()) {
+    set_thread_error("attribution_capacity is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!attribution->empty()) {
+    std::copy(attribution->begin(), attribution->end(), out_attribution);
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_list_style_source_ids(mln_map* map, mln_style_id_list** out_source_ids)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  auto ids = std::vector<std::string>{};
+  for (const auto* source : map->map->getStyle().getSources()) {
+    ids.push_back(source->getID());
+  }
+  return create_style_id_list(std::move(ids), out_source_ids);
+}
+
+auto map_add_style_layer_json(
+  mln_map* map, const mln_json_value* layer_json,
+  mln_string_view before_layer_id
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(before_layer_id, "before_layer_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!validate_style_json_value(layer_json)) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  auto before = std::optional<std::string>{};
+  if (before_layer_id.size > 0) {
+    before = string_from_view(before_layer_id);
+    if (style.getLayer(*before) == nullptr) {
+      set_thread_error("before_layer_id does not exist");
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+
+  auto error = mbgl::style::conversion::Error{};
+  auto layer =
+    mbgl::style::conversion::convert<std::unique_ptr<mbgl::style::Layer>>(
+      mbgl::style::conversion::Convertible{layer_json}, error
+    );
+  if (!layer) {
+    set_style_conversion_error("style layer", error);
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto id = (*layer)->getID();
+  if (style.getLayer(id) != nullptr) {
+    set_thread_error("layer already exists");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    (*layer)->getTypeInfo()->source ==
+      mbgl::style::LayerTypeInfo::Source::Required &&
+    style.getSource((*layer)->getSourceID()) == nullptr
+  ) {
+    set_thread_error("layer source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  style.addLayer(std::move(*layer), before);
+  return MLN_STATUS_OK;
+}
+
+auto map_remove_style_layer(
+  mln_map* map, mln_string_view layer_id, bool* out_removed
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(layer_id, "layer_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0) {
+    set_thread_error("layer_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_removed == nullptr) {
+    set_thread_error("out_removed must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto removed = map->map->getStyle().removeLayer(string_from_view(layer_id));
+  *out_removed = removed != nullptr;
+  return MLN_STATUS_OK;
+}
+
+auto map_style_layer_exists(
+  mln_map* map, mln_string_view layer_id, bool* out_exists
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(layer_id, "layer_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0) {
+    set_thread_error("layer_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_exists == nullptr) {
+    set_thread_error("out_exists must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_exists =
+    map->map->getStyle().getLayer(string_from_view(layer_id)) != nullptr;
+  return MLN_STATUS_OK;
+}
+
+auto map_get_style_layer_type(
+  mln_map* map, mln_string_view layer_id, mln_string_view* out_layer_type,
+  bool* out_found
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(layer_id, "layer_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0) {
+    set_thread_error("layer_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_layer_type == nullptr || out_found == nullptr) {
+    set_thread_error("out_layer_type and out_found must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto* layer = map->map->getStyle().getLayer(string_from_view(layer_id));
+  *out_found = layer != nullptr;
+  *out_layer_type = {};
+  if (layer != nullptr) {
+    *out_layer_type = string_view_from_literal(layer->getTypeInfo()->type);
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_list_style_layer_ids(mln_map* map, mln_style_id_list** out_layer_ids)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  auto ids = std::vector<std::string>{};
+  for (const auto* layer : map->map->getStyle().getLayers()) {
+    ids.push_back(layer->getID());
+  }
+  return create_style_id_list(std::move(ids), out_layer_ids);
+}
+
+auto map_move_style_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view before_layer_id
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (
+    !validate_string_view(layer_id, "layer_id") ||
+    !validate_string_view(before_layer_id, "before_layer_id")
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0) {
+    set_thread_error("layer_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(layer_id);
+  if (style.getLayer(id) == nullptr) {
+    set_thread_error("layer does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto before = std::optional<std::string>{};
+  if (before_layer_id.size > 0) {
+    before = string_from_view(before_layer_id);
+    if (*before == id) {
+      return MLN_STATUS_OK;
+    }
+    if (style.getLayer(*before) == nullptr) {
+      set_thread_error("before_layer_id does not exist");
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+
+  auto layer = style.removeLayer(id);
+  if (!layer) {
+    set_thread_error("layer does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  style.addLayer(std::move(layer), before);
+  return MLN_STATUS_OK;
+}
+
+auto map_get_style_layer_json(
+  mln_map* map, mln_string_view layer_id, mln_json_snapshot** out_layer,
+  bool* out_found
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(layer_id, "layer_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0) {
+    set_thread_error("layer_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_layer == nullptr || *out_layer != nullptr || out_found == nullptr) {
+    set_thread_error(
+      "out_layer must not be null, *out_layer must be null, and out_found must "
+      "not be null"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto* layer = map->map->getStyle().getLayer(string_from_view(layer_id));
+  *out_found = layer != nullptr;
+  if (layer == nullptr) {
+    return MLN_STATUS_OK;
+  }
+  return json_snapshot_create(layer->serialize(), out_layer);
 }
 
 auto map_set_layer_property(

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -32,6 +32,58 @@ auto map_request_repaint(mln_map* map) -> mln_status;
 auto map_request_still_image(mln_map* map) -> mln_status;
 auto map_set_style_url(mln_map* map, const char* url) -> mln_status;
 auto map_set_style_json(mln_map* map, const char* json) -> mln_status;
+auto style_id_list_count(const mln_style_id_list* list, size_t* out_count)
+  -> mln_status;
+auto style_id_list_get(
+  const mln_style_id_list* list, size_t index, mln_string_view* out_id
+) -> mln_status;
+auto style_id_list_destroy(mln_style_id_list* list) -> void;
+auto map_add_style_source_json(
+  mln_map* map, mln_string_view source_id, const mln_json_value* source_json
+) -> mln_status;
+auto map_remove_style_source(
+  mln_map* map, mln_string_view source_id, bool* out_removed
+) -> mln_status;
+auto map_style_source_exists(
+  mln_map* map, mln_string_view source_id, bool* out_exists
+) -> mln_status;
+auto map_get_style_source_type(
+  mln_map* map, mln_string_view source_id, uint32_t* out_source_type,
+  bool* out_found
+) -> mln_status;
+auto map_get_style_source_info(
+  mln_map* map, mln_string_view source_id, mln_style_source_info* out_info,
+  bool* out_found
+) -> mln_status;
+auto map_copy_style_source_attribution(
+  mln_map* map, mln_string_view source_id, char* out_attribution,
+  size_t attribution_capacity, size_t* out_attribution_size, bool* out_found
+) -> mln_status;
+auto map_list_style_source_ids(mln_map* map, mln_style_id_list** out_source_ids)
+  -> mln_status;
+auto map_add_style_layer_json(
+  mln_map* map, const mln_json_value* layer_json,
+  mln_string_view before_layer_id
+) -> mln_status;
+auto map_remove_style_layer(
+  mln_map* map, mln_string_view layer_id, bool* out_removed
+) -> mln_status;
+auto map_style_layer_exists(
+  mln_map* map, mln_string_view layer_id, bool* out_exists
+) -> mln_status;
+auto map_get_style_layer_type(
+  mln_map* map, mln_string_view layer_id, mln_string_view* out_layer_type,
+  bool* out_found
+) -> mln_status;
+auto map_list_style_layer_ids(mln_map* map, mln_style_id_list** out_layer_ids)
+  -> mln_status;
+auto map_move_style_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view before_layer_id
+) -> mln_status;
+auto map_get_style_layer_json(
+  mln_map* map, mln_string_view layer_id, mln_json_snapshot** out_layer,
+  bool* out_found
+) -> mln_status;
 auto map_set_layer_property(
   mln_map* map, mln_string_view layer_id, mln_string_view property_name,
   const mln_json_value* value

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -39,6 +39,59 @@ fn jsonArray(values: []const c.mln_json_value) c.mln_json_value {
     };
 }
 
+fn jsonObject(members: []const c.mln_json_member) c.mln_json_value {
+    return .{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_OBJECT,
+        .data = .{ .object_value = .{ .members = members.ptr, .member_count = members.len } },
+    };
+}
+
+fn jsonMember(key: []const u8, value: *const c.mln_json_value) c.mln_json_member {
+    return .{ .key = stringView(key), .value = value };
+}
+
+fn viewBytes(view: c.mln_string_view) []const u8 {
+    return view.data[0..view.size];
+}
+
+fn listId(list: *c.mln_style_id_list, index: usize) ![]const u8 {
+    var id: c.mln_string_view = .{ .data = null, .size = 0 };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_style_id_list_get(list, index, &id));
+    return viewBytes(id);
+}
+
+fn expectListContains(list: *c.mln_style_id_list, expected: []const u8) !void {
+    var count: usize = 0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_style_id_list_count(list, &count));
+    for (0..count) |index| {
+        if (std.mem.eql(u8, try listId(list, index), expected)) return;
+    }
+    return error.MissingListEntry;
+}
+
+fn listIndexOf(list: *c.mln_style_id_list, expected: []const u8) !usize {
+    var count: usize = 0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_style_id_list_count(list, &count));
+    for (0..count) |index| {
+        if (std.mem.eql(u8, try listId(list, index), expected)) return index;
+    }
+    return error.MissingListEntry;
+}
+
+fn expectObjectString(root: *const c.mln_json_value, key: []const u8, expected: []const u8) !void {
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_OBJECT, root.type);
+    const members = root.data.object_value.members[0..root.data.object_value.member_count];
+    for (members) |member| {
+        if (std.mem.eql(u8, viewBytes(member.key), key)) {
+            try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_STRING, member.value.*.type);
+            try testing.expect(std.mem.eql(u8, viewBytes(member.value.*.data.string_value), expected));
+            return;
+        }
+    }
+    return error.MissingObjectMember;
+}
+
 fn snapshotRoot(snapshot: *c.mln_json_snapshot) !*const c.mln_json_value {
     var root: ?*const c.mln_json_value = null;
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_json_snapshot_get(snapshot, &root));
@@ -133,4 +186,168 @@ test "style value conversion reports invalid descriptors and conversion errors" 
         c.mln_map_set_layer_property(map, stringView("point-circle"), stringView("circle-radius"), &invalid_property_value),
     );
     try testing.expect(std.mem.len(c.mln_thread_last_error_message()) > 0);
+}
+
+test "style registry exposes primary source and layer ID APIs" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
+
+    var source_ids: ?*c.mln_style_id_list = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_list_style_source_ids(map, &source_ids));
+    defer c.mln_style_id_list_destroy(source_ids.?);
+    var source_count: usize = 0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_style_id_list_count(source_ids.?, &source_count));
+    try testing.expect(source_count >= 1);
+    try expectListContains(source_ids.?, "point");
+
+    const feature_collection_type = jsonString("FeatureCollection");
+    const empty_features = [_]c.mln_json_value{};
+    const features = jsonArray(&empty_features);
+    const data_members = [_]c.mln_json_member{
+        jsonMember("type", &feature_collection_type),
+        jsonMember("features", &features),
+    };
+    const data = jsonObject(&data_members);
+    const source_type = jsonString("geojson");
+    const source_members = [_]c.mln_json_member{
+        jsonMember("type", &source_type),
+        jsonMember("data", &data),
+    };
+    const source = jsonObject(&source_members);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_add_style_source_json(map, stringView("empty"), &source));
+
+    var exists = false;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_style_source_exists(map, stringView("empty"), &exists));
+    try testing.expect(exists);
+
+    var found = false;
+    var source_type_value: u32 = c.MLN_STYLE_SOURCE_TYPE_UNKNOWN;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_source_type(map, stringView("empty"), &source_type_value, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_GEOJSON, source_type_value);
+
+    var info: c.mln_style_source_info = .{
+        .size = @sizeOf(c.mln_style_source_info),
+        .type = c.MLN_STYLE_SOURCE_TYPE_UNKNOWN,
+        .id_size = 0,
+        .is_volatile = false,
+        .has_attribution = false,
+        .attribution_size = 0,
+    };
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_source_info(map, stringView("empty"), &info, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_GEOJSON, info.type);
+    try testing.expectEqual(@as(usize, "empty".len), info.id_size);
+    try testing.expect(!info.has_attribution);
+
+    const vector_type = jsonString("vector");
+    const tile_url = jsonString("https://example.com/{z}/{x}/{y}.pbf");
+    const tile_values = [_]c.mln_json_value{tile_url};
+    const tiles = jsonArray(&tile_values);
+    const attribution = jsonString("Example attribution");
+    const vector_members = [_]c.mln_json_member{
+        jsonMember("type", &vector_type),
+        jsonMember("tiles", &tiles),
+        jsonMember("attribution", &attribution),
+    };
+    const vector_source = jsonObject(&vector_members);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_add_style_source_json(map, stringView("vector-meta"), &vector_source));
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_source_info(map, stringView("vector-meta"), &info, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_VECTOR, info.type);
+    try testing.expect(info.has_attribution);
+    try testing.expectEqual(@as(usize, "Example attribution".len), info.attribution_size);
+
+    var attribution_buffer: [64]u8 = undefined;
+    var attribution_size: usize = 0;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_copy_style_source_attribution(
+            map,
+            stringView("vector-meta"),
+            &attribution_buffer,
+            attribution_buffer.len,
+            &attribution_size,
+            &found,
+        ),
+    );
+    try testing.expect(found);
+    try testing.expect(std.mem.eql(u8, attribution_buffer[0..attribution_size], "Example attribution"));
+
+    const layer_id = jsonString("empty-circle");
+    const layer_type = jsonString("circle");
+    const layer_source = jsonString("empty");
+    const layer_members = [_]c.mln_json_member{
+        jsonMember("id", &layer_id),
+        jsonMember("type", &layer_type),
+        jsonMember("source", &layer_source),
+    };
+    const layer = jsonObject(&layer_members);
+
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_style_layer_json(map, &layer, stringView("point-circle")),
+    );
+
+    var layer_ids: ?*c.mln_style_id_list = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_list_style_layer_ids(map, &layer_ids));
+    defer c.mln_style_id_list_destroy(layer_ids.?);
+    var layer_count: usize = 0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_style_id_list_count(layer_ids.?, &layer_count));
+    try testing.expect(layer_count >= 3);
+    try testing.expect((try listIndexOf(layer_ids.?, "empty-circle")) < (try listIndexOf(layer_ids.?, "point-circle")));
+
+    var layer_type_view: c.mln_string_view = .{ .data = null, .size = 0 };
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_layer_type(map, stringView("empty-circle"), &layer_type_view, &found),
+    );
+    try testing.expect(found);
+    try testing.expect(std.mem.eql(u8, viewBytes(layer_type_view), "circle"));
+
+    var layer_snapshot: ?*c.mln_json_snapshot = null;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_layer_json(map, stringView("empty-circle"), &layer_snapshot, &found),
+    );
+    defer c.mln_json_snapshot_destroy(layer_snapshot.?);
+    try testing.expect(found);
+    try expectObjectString(try snapshotRoot(layer_snapshot.?), "id", "empty-circle");
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_move_style_layer(map, stringView("empty-circle"), stringView("")));
+
+    var used_source_removed = false;
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_STATE,
+        c.mln_map_remove_style_source(map, stringView("empty"), &used_source_removed),
+    );
+
+    var layer_removed = false;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_remove_style_layer(map, stringView("empty-circle"), &layer_removed));
+    try testing.expect(layer_removed);
+    var source_removed = false;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_remove_style_source(map, stringView("empty"), &source_removed));
+    try testing.expect(source_removed);
+    var vector_source_removed = false;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_remove_style_source(map, stringView("vector-meta"), &vector_source_removed));
+    try testing.expect(vector_source_removed);
 }


### PR DESCRIPTION
## Summary
- Add ID-first source and layer registry APIs for style mutation.
- Keep JSON entry points explicit for source/layer creation and layer serialization.
- Add source metadata and attribution readback using fixed fields plus caller-provided buffers.

## Testing
- mise run test

partial #15
resolves #30