### PR TITLE
Add style light APIs

### DIFF
--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -350,6 +350,64 @@ MLN_API mln_status mln_map_get_style_layer_json(
 ) MLN_NOEXCEPT;
 
 /**
+ * Sets the style light from a style-spec light JSON object.
+ *
+ * light_json is borrowed for the call. The function parses and copies the
+ * accepted light into MapLibre Native before return.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, light_json is
+ *   null or invalid, or the light JSON cannot be converted.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_style_light_json(
+  mln_map* map, const mln_json_value* light_json
+) MLN_NOEXCEPT;
+
+/**
+ * Sets one style light property using its MapLibre style-spec property name.
+ *
+ * property_name and value are borrowed for the call. value is a style-spec JSON
+ * value descriptor. The function parses and copies the accepted value into
+ * MapLibre Native's typed light property storage before return.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, property_name is
+ *   invalid or empty, value is null or invalid, the property name is unknown,
+ *   or the property value cannot be converted for that property.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_style_light_property(
+  mln_map* map, mln_string_view property_name, const mln_json_value* value
+) MLN_NOEXCEPT;
+
+/**
+ * Copies one style light property as a style-spec JSON value snapshot.
+ *
+ * On success, *out_value receives an owned snapshot handle. Use
+ * mln_json_snapshot_get() to borrow its root JSON value. Destroy the snapshot
+ * with mln_json_snapshot_destroy(). Undefined native style light properties
+ * return null snapshots.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, property_name is
+ *   invalid or empty, out_value is null, or *out_value is not null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_style_light_property(
+  mln_map* map, mln_string_view property_name, mln_json_snapshot** out_value
+) MLN_NOEXCEPT;
+
+/**
  * Sets one layer property using its MapLibre style-spec property name.
  *
  * layer_id, property_name, and value are borrowed for the call. value is a

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -236,6 +236,32 @@ auto mln_map_get_style_layer_json(
   });
 }
 
+auto mln_map_set_style_light_json(
+  mln_map* map, const mln_json_value* light_json
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_style_light_json(map, light_json);
+  });
+}
+
+auto mln_map_set_style_light_property(
+  mln_map* map, mln_string_view property_name, const mln_json_value* value
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_style_light_property(map, property_name, value);
+  });
+}
+
+auto mln_map_get_style_light_property(
+  mln_map* map, mln_string_view property_name, mln_json_snapshot** out_value
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_style_light_property(
+      map, property_name, out_value
+    );
+  });
+}
+
 auto mln_map_set_layer_property(
   mln_map* map, mln_string_view layer_id, mln_string_view property_name,
   const mln_json_value* value

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -32,9 +32,11 @@
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/style/conversion.hpp>
 #include <mbgl/style/conversion/layer.hpp>   // IWYU pragma: keep
+#include <mbgl/style/conversion/light.hpp>   // IWYU pragma: keep
 #include <mbgl/style/conversion/source.hpp>  // IWYU pragma: keep
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/style/layer.hpp>
+#include <mbgl/style/light.hpp>
 #include <mbgl/style/source.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_property.hpp>
@@ -2514,6 +2516,96 @@ auto map_get_style_layer_json(
     return MLN_STATUS_OK;
   }
   return json_snapshot_create(layer->serialize(), out_layer);
+}
+
+auto map_set_style_light_json(mln_map* map, const mln_json_value* light_json)
+  -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_style_json_value(light_json)) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto error = mbgl::style::conversion::Error{};
+  auto light = mbgl::style::conversion::convert<mbgl::style::Light>(
+    mbgl::style::conversion::Convertible{light_json}, error
+  );
+  if (!light) {
+    set_style_conversion_error("style light", error);
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  map->map->getStyle().setLight(std::make_unique<mbgl::style::Light>(*light));
+  return MLN_STATUS_OK;
+}
+
+auto map_set_style_light_property(
+  mln_map* map, mln_string_view property_name, const mln_json_value* value
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(property_name, "property_name")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (property_name.size == 0) {
+    set_thread_error("property_name must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!validate_style_json_value(value)) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto* light = map->map->getStyle().getLight();
+  if (light == nullptr) {
+    set_thread_error("style light does not exist");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto error = light->setProperty(
+    string_from_view(property_name), mbgl::style::conversion::Convertible{value}
+  );
+  if (error) {
+    set_style_conversion_error("style light property", *error);
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_get_style_light_property(
+  mln_map* map, mln_string_view property_name, mln_json_snapshot** out_value
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!validate_string_view(property_name, "property_name")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (property_name.size == 0) {
+    set_thread_error("property_name must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_value == nullptr || *out_value != nullptr) {
+    set_thread_error("out_value must not be null and *out_value must be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto* light = map->map->getStyle().getLight();
+  if (light == nullptr) {
+    set_thread_error("style light does not exist");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  const auto property = light->getProperty(string_from_view(property_name));
+  const auto value =
+    property.getKind() == mbgl::style::StyleProperty::Kind::Undefined
+      ? mbgl::Value{mbgl::NullValue{}}
+      : property.getValue();
+  return json_snapshot_create(value, out_value);
 }
 
 auto map_set_layer_property(

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2601,11 +2601,10 @@ auto map_get_style_light_property(
   }
 
   const auto property = light->getProperty(string_from_view(property_name));
-  const auto value =
-    property.getKind() == mbgl::style::StyleProperty::Kind::Undefined
-      ? mbgl::Value{mbgl::NullValue{}}
-      : property.getValue();
-  return json_snapshot_create(value, out_value);
+  if (property.getKind() == mbgl::style::StyleProperty::Kind::Undefined) {
+    return MLN_STATUS_OK;
+  }
+  return json_snapshot_create(property.getValue(), out_value);
 }
 
 auto map_set_layer_property(

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -84,6 +84,14 @@ auto map_get_style_layer_json(
   mln_map* map, mln_string_view layer_id, mln_json_snapshot** out_layer,
   bool* out_found
 ) -> mln_status;
+auto map_set_style_light_json(mln_map* map, const mln_json_value* light_json)
+  -> mln_status;
+auto map_set_style_light_property(
+  mln_map* map, mln_string_view property_name, const mln_json_value* value
+) -> mln_status;
+auto map_get_style_light_property(
+  mln_map* map, mln_string_view property_name, mln_json_snapshot** out_value
+) -> mln_status;
 auto map_set_layer_property(
   mln_map* map, mln_string_view layer_id, mln_string_view property_name,
   const mln_json_value* value

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -394,6 +394,10 @@ test "style light accepts full JSON and property updates" {
     try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_DOUBLE, root.type);
     try testing.expectApproxEqAbs(@as(f64, 0.75), root.data.double_value, 0.000001);
 
+    var missing_snapshot: ?*c.mln_json_snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_light_property(map, stringView("unknown-light-property"), &missing_snapshot));
+    try testing.expectEqual(@as(?*c.mln_json_snapshot, null), missing_snapshot);
+
     const invalid_intensity = jsonBool(false);
     try testing.expectEqual(
         c.MLN_STATUS_INVALID_ARGUMENT,

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -351,3 +351,53 @@ test "style registry exposes primary source and layer ID APIs" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_remove_style_source(map, stringView("vector-meta"), &vector_source_removed));
     try testing.expect(vector_source_removed);
 }
+
+test "style light accepts full JSON and property updates" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
+
+    const light_color = jsonString("blue");
+    const light_intensity = jsonDouble(0.3);
+    const position_values = [_]c.mln_json_value{ jsonDouble(1.0), jsonDouble(2.0), jsonDouble(3.0) };
+    const light_position = jsonArray(&position_values);
+    const light_members = [_]c.mln_json_member{
+        jsonMember("color", &light_color),
+        jsonMember("intensity", &light_intensity),
+        jsonMember("position", &light_position),
+    };
+    const light = jsonObject(&light_members);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_light_json(map, &light));
+
+    var snapshot: ?*c.mln_json_snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_light_property(map, stringView("intensity"), &snapshot));
+    defer c.mln_json_snapshot_destroy(snapshot.?);
+    var root = try snapshotRoot(snapshot.?);
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_DOUBLE, root.type);
+    try testing.expectApproxEqAbs(@as(f64, 0.3), root.data.double_value, 0.000001);
+
+    const updated_intensity = jsonDouble(0.75);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_light_property(map, stringView("intensity"), &updated_intensity));
+
+    var updated_snapshot: ?*c.mln_json_snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_light_property(map, stringView("intensity"), &updated_snapshot));
+    defer c.mln_json_snapshot_destroy(updated_snapshot.?);
+    root = try snapshotRoot(updated_snapshot.?);
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_DOUBLE, root.type);
+    try testing.expectApproxEqAbs(@as(f64, 0.75), root.data.double_value, 0.000001);
+
+    const invalid_intensity = jsonBool(false);
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_set_style_light_property(map, stringView("intensity"), &invalid_intensity),
+    );
+    try testing.expect(std.mem.len(c.mln_thread_last_error_message()) > 0);
+}


### PR DESCRIPTION
## Summary
- Add style-level light JSON set support using native light conversion.
- Add generic light property get/set APIs through native light property conversion.
- Cover light JSON and property mutation through Zig C API tests.

## Testing
- mise run test

resolves #34