### PR TITLE
Add core source helper APIs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks:
   - bugprone-*
   - cert-*
   - cppcoreguidelines-*
+  - -bugprone-easily-swappable-parameters
   - -cppcoreguidelines-avoid-magic-numbers
   - -cppcoreguidelines-pro-type-union-access
   - -readability-magic-numbers

--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -37,6 +37,29 @@ typedef enum mln_style_source_type : uint32_t {
   MLN_STYLE_SOURCE_TYPE_CUSTOM_VECTOR = 8,
 } mln_style_source_type;
 
+/** Field mask values for mln_style_tile_source_options. */
+typedef enum mln_style_tile_source_option_field : uint32_t {
+  MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM = 1U << 0U,
+  MLN_STYLE_TILE_SOURCE_OPTION_MAX_ZOOM = 1U << 1U,
+  MLN_STYLE_TILE_SOURCE_OPTION_ATTRIBUTION = 1U << 2U,
+  MLN_STYLE_TILE_SOURCE_OPTION_SCHEME = 1U << 3U,
+  MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS = 1U << 4U,
+  MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE = 1U << 5U,
+  MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING = 1U << 6U,
+} mln_style_tile_source_option_field;
+
+/** Tile URL coordinate scheme values used by mln_style_tile_source_options. */
+typedef enum mln_style_tile_scheme : uint32_t {
+  MLN_STYLE_TILE_SCHEME_XYZ = 0,
+  MLN_STYLE_TILE_SCHEME_TMS = 1,
+} mln_style_tile_scheme;
+
+/** Vector tile encoding values used by mln_style_tile_source_options. */
+typedef enum mln_style_vector_tile_encoding : uint32_t {
+  MLN_STYLE_VECTOR_TILE_ENCODING_MVT = 0,
+  MLN_STYLE_VECTOR_TILE_ENCODING_MLT = 1,
+} mln_style_vector_tile_encoding;
+
 /** Fixed source metadata returned by mln_map_get_style_source_info(). */
 typedef struct mln_style_source_info {
   uint32_t size;
@@ -49,6 +72,26 @@ typedef struct mln_style_source_info {
   /** Attribution byte length, excluding any null terminator. */
   size_t attribution_size;
 } mln_style_source_info;
+
+/** Options for vector and raster tile sources. */
+typedef struct mln_style_tile_source_options {
+  uint32_t size;
+  uint32_t fields;
+  double min_zoom;
+  double max_zoom;
+  mln_string_view attribution;
+  /** One of mln_style_tile_scheme. Defaults to MLN_STYLE_TILE_SCHEME_XYZ. */
+  uint32_t scheme;
+  mln_lat_lng_bounds bounds;
+  /** Raster tile size in pixels. Defaults to 512. */
+  uint32_t tile_size;
+  /** One of mln_style_vector_tile_encoding. Defaults to MVT. */
+  uint32_t vector_encoding;
+} mln_style_tile_source_options;
+
+/** Returns default tile source options. */
+MLN_API mln_style_tile_source_options
+mln_style_tile_source_options_default(void) MLN_NOEXCEPT;
 
 /**
  * Gets the number of IDs in a style ID list handle.
@@ -217,6 +260,160 @@ MLN_API mln_status mln_map_copy_style_source_attribution(
  */
 MLN_API mln_status mln_map_list_style_source_ids(
   mln_map* map, mln_style_id_list** out_source_ids
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a GeoJSON source with URL data.
+ *
+ * source_id and url are borrowed for the call. The source loads GeoJSON from
+ * url through MapLibre Native's resource system.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id or url
+ *   is invalid or empty, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_geojson_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a GeoJSON source with inline data.
+ *
+ * source_id and data are borrowed for the call. The accepted GeoJSON descriptor
+ * is copied into MapLibre Native before return.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, data is null or invalid, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_geojson_source_data(
+  mln_map* map, mln_string_view source_id, const mln_geojson* data
+) MLN_NOEXCEPT;
+
+/**
+ * Updates one GeoJSON source to load data from a URL.
+ *
+ * source_id and url are borrowed for the call.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id or url
+ *   is invalid or empty, the source does not exist, or the source is not a
+ *   GeoJSON source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_geojson_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) MLN_NOEXCEPT;
+
+/**
+ * Updates one GeoJSON source with inline data.
+ *
+ * source_id and data are borrowed for the call. The accepted GeoJSON descriptor
+ * is copied into MapLibre Native before return.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, data is null or invalid, the source does not exist, or
+ *   the source is not a GeoJSON source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_geojson_source_data(
+  mln_map* map, mln_string_view source_id, const mln_geojson* data
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a vector source with a TileJSON URL.
+ *
+ * source_id and url are borrowed for the call. options may be null for
+ * defaults. For URL sources, min_zoom, max_zoom, and vector_encoding override
+ * values from the loaded TileJSON when their field bits are set.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id or url
+ *   is invalid or empty, options is invalid, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_vector_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a vector source with inline tile URLs.
+ *
+ * source_id and tile URL views are borrowed for the call. The function copies
+ * accepted strings into MapLibre Native before return. options may be null for
+ * defaults.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, tile URLs are null, empty, or invalid, options is
+ *   invalid, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_vector_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a raster source with a TileJSON URL.
+ *
+ * source_id and url are borrowed for the call. options may be null for
+ * defaults. For URL sources, only tile_size is used when its field bit is set.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id or url
+ *   is invalid or empty, options is invalid, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_raster_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a raster source with inline tile URLs.
+ *
+ * source_id and tile URL views are borrowed for the call. The function copies
+ * accepted strings into MapLibre Native before return. options may be null for
+ * defaults.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, tile URLs are null, empty, or invalid, options is
+ *   invalid, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_raster_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
 ) MLN_NOEXCEPT;
 
 /**

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -45,6 +45,11 @@ auto mln_map_tile_options_default(void) noexcept -> mln_map_tile_options {
   return mln::core::map_tile_options_default();
 }
 
+auto mln_style_tile_source_options_default(void) noexcept
+  -> mln_style_tile_source_options {
+  return mln::core::style_tile_source_options_default();
+}
+
 auto mln_map_create(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) noexcept -> mln_status {
@@ -168,6 +173,78 @@ auto mln_map_list_style_source_ids(
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_list_style_source_ids(map, out_source_ids);
+  });
+}
+
+auto mln_map_add_geojson_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_geojson_source_url(map, source_id, url);
+  });
+}
+
+auto mln_map_add_geojson_source_data(
+  mln_map* map, mln_string_view source_id, const mln_geojson* data
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_geojson_source_data(map, source_id, data);
+  });
+}
+
+auto mln_map_set_geojson_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_geojson_source_url(map, source_id, url);
+  });
+}
+
+auto mln_map_set_geojson_source_data(
+  mln_map* map, mln_string_view source_id, const mln_geojson* data
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_geojson_source_data(map, source_id, data);
+  });
+}
+
+auto mln_map_add_vector_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_vector_source_url(map, source_id, url, options);
+  });
+}
+
+auto mln_map_add_vector_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_vector_source_tiles(
+      map, source_id, tiles, tile_count, options
+    );
+  });
+}
+
+auto mln_map_add_raster_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_raster_source_url(map, source_id, url, options);
+  });
+}
+
+auto mln_map_add_raster_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_raster_source_tiles(
+      map, source_id, tiles, tile_count, options
+    );
   });
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2621,7 +2621,6 @@ auto map_list_style_source_ids(mln_map* map, mln_style_id_list** out_source_ids)
   return create_style_id_list(std::move(ids), out_source_ids);
 }
 
-// NOLINTBEGIN(bugprone-easily-swappable-parameters)
 auto map_add_geojson_source_url(
   mln_map* map, mln_string_view source_id, mln_string_view url
 ) -> mln_status {
@@ -2885,7 +2884,6 @@ auto map_add_raster_source_url(
   );
   return MLN_STATUS_OK;
 }
-// NOLINTEND(bugprone-easily-swappable-parameters)
 
 auto map_add_raster_source_tiles(
   mln_map* map, mln_string_view source_id, const mln_string_view* tiles,

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -38,16 +38,22 @@
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/light.hpp>
 #include <mbgl/style/source.hpp>
+#include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/style/sources/raster_source.hpp>
+#include <mbgl/style/sources/vector_source.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_property.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/tile/tile_operation.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/constants.hpp>
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/projection.hpp>
+#include <mbgl/util/range.hpp>
 #include <mbgl/util/size.hpp>
+#include <mbgl/util/tileset.hpp>
 #include <mbgl/util/vectors.hpp>
 
 #include "map/map.hpp"
@@ -127,6 +133,9 @@ auto string_view_from_literal(const char* string) -> mln_string_view {
   return mln_string_view{.data = string, .size = std::strlen(string)};
 }
 
+auto validate_lat_lng_bounds(mln_lat_lng_bounds bounds) -> mln_status;
+auto to_native_lat_lng_bounds(mln_lat_lng_bounds bounds) -> mbgl::LatLngBounds;
+
 auto to_c_source_type(mbgl::style::SourceType type) -> uint32_t {
   switch (type) {
     case mbgl::style::SourceType::Vector:
@@ -147,6 +156,305 @@ auto to_c_source_type(mbgl::style::SourceType type) -> uint32_t {
       return MLN_STYLE_SOURCE_TYPE_CUSTOM_VECTOR;
   }
   return MLN_STYLE_SOURCE_TYPE_UNKNOWN;
+}
+
+auto has_tile_source_option(
+  const mln_style_tile_source_options& options, uint32_t field
+) -> bool {
+  return (options.fields & field) != 0U;
+}
+
+auto validate_zoom_option(double zoom, const char* name) -> mln_status {
+  if (!std::isfinite(zoom) || zoom < 0.0 || zoom > 255.0) {
+    auto message = std::string{name} + " must be finite and within [0, 255]";
+    mln::core::set_thread_error(message.c_str());
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_tile_source_option_header(
+  const mln_style_tile_source_options& options
+) -> mln_status {
+  if (options.size < sizeof(mln_style_tile_source_options)) {
+    mln::core::set_thread_error(
+      "mln_style_tile_source_options.size is too small"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM) |
+    MLN_STYLE_TILE_SOURCE_OPTION_MAX_ZOOM |
+    MLN_STYLE_TILE_SOURCE_OPTION_ATTRIBUTION |
+    MLN_STYLE_TILE_SOURCE_OPTION_SCHEME | MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS |
+    MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE |
+    MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING;
+  if ((options.fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_style_tile_source_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_tile_source_zoom_options(
+  const mln_style_tile_source_options& options
+) -> mln_status {
+  if (has_tile_source_option(options, MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM)) {
+    const auto status = validate_zoom_option(options.min_zoom, "min_zoom");
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  if (has_tile_source_option(options, MLN_STYLE_TILE_SOURCE_OPTION_MAX_ZOOM)) {
+    const auto status = validate_zoom_option(options.max_zoom, "max_zoom");
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  if (
+    has_tile_source_option(options, MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM) &&
+    has_tile_source_option(options, MLN_STYLE_TILE_SOURCE_OPTION_MAX_ZOOM) &&
+    options.min_zoom > options.max_zoom
+  ) {
+    mln::core::set_thread_error(
+      "min_zoom must be less than or equal to max_zoom"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_tile_source_attribution_option(
+  const mln_style_tile_source_options& options
+) -> mln_status {
+  if (!has_tile_source_option(
+        options, MLN_STYLE_TILE_SOURCE_OPTION_ATTRIBUTION
+      )) {
+    return MLN_STATUS_OK;
+  }
+  return validate_string_view(options.attribution, "attribution")
+           ? MLN_STATUS_OK
+           : MLN_STATUS_INVALID_ARGUMENT;
+}
+
+auto validate_tile_source_scheme_option(
+  const mln_style_tile_source_options& options
+) -> mln_status {
+  if (!has_tile_source_option(options, MLN_STYLE_TILE_SOURCE_OPTION_SCHEME)) {
+    return MLN_STATUS_OK;
+  }
+  switch (options.scheme) {
+    case MLN_STYLE_TILE_SCHEME_XYZ:
+    case MLN_STYLE_TILE_SCHEME_TMS:
+      return MLN_STATUS_OK;
+    default:
+      mln::core::set_thread_error("scheme is invalid");
+      return MLN_STATUS_INVALID_ARGUMENT;
+  }
+}
+
+auto validate_tile_source_bounds_option(
+  const mln_style_tile_source_options& options
+) -> mln_status {
+  if (!has_tile_source_option(options, MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS)) {
+    return MLN_STATUS_OK;
+  }
+  return validate_lat_lng_bounds(options.bounds);
+}
+
+auto validate_tile_source_tile_size_option(
+  const mln_style_tile_source_options& options
+) -> mln_status {
+  if (!has_tile_source_option(
+        options, MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE
+      )) {
+    return MLN_STATUS_OK;
+  }
+  if (options.tile_size == 0 || options.tile_size > 65535U) {
+    mln::core::set_thread_error("tile_size must be within [1, 65535]");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_tile_source_vector_encoding_option(
+  const mln_style_tile_source_options& options
+) -> mln_status {
+  if (!has_tile_source_option(
+        options, MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING
+      )) {
+    return MLN_STATUS_OK;
+  }
+  switch (options.vector_encoding) {
+    case MLN_STYLE_VECTOR_TILE_ENCODING_MVT:
+    case MLN_STYLE_VECTOR_TILE_ENCODING_MLT:
+      return MLN_STATUS_OK;
+    default:
+      mln::core::set_thread_error("vector_encoding is invalid");
+      return MLN_STATUS_INVALID_ARGUMENT;
+  }
+}
+
+auto validate_tile_source_options(const mln_style_tile_source_options* options)
+  -> mln_status {
+  if (options == nullptr) {
+    return MLN_STATUS_OK;
+  }
+  for (const auto validator : {
+         validate_tile_source_option_header,
+         validate_tile_source_zoom_options,
+         validate_tile_source_attribution_option,
+         validate_tile_source_scheme_option,
+         validate_tile_source_bounds_option,
+         validate_tile_source_tile_size_option,
+         validate_tile_source_vector_encoding_option,
+       }) {
+    const auto status = validator(*options);
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  return MLN_STATUS_OK;
+}
+
+auto effective_tile_source_options(const mln_style_tile_source_options* options)
+  -> mln_style_tile_source_options {
+  auto result = mln::core::style_tile_source_options_default();
+  if (options == nullptr) {
+    return result;
+  }
+
+  result.fields = options->fields;
+  if (has_tile_source_option(*options, MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM)) {
+    result.min_zoom = options->min_zoom;
+  }
+  if (has_tile_source_option(*options, MLN_STYLE_TILE_SOURCE_OPTION_MAX_ZOOM)) {
+    result.max_zoom = options->max_zoom;
+  }
+  if (
+    has_tile_source_option(*options, MLN_STYLE_TILE_SOURCE_OPTION_ATTRIBUTION)
+  ) {
+    result.attribution = options->attribution;
+  }
+  if (has_tile_source_option(*options, MLN_STYLE_TILE_SOURCE_OPTION_SCHEME)) {
+    result.scheme = options->scheme;
+  }
+  if (has_tile_source_option(*options, MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS)) {
+    result.bounds = options->bounds;
+  }
+  if (
+    has_tile_source_option(*options, MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE)
+  ) {
+    result.tile_size = options->tile_size;
+  }
+  if (
+    has_tile_source_option(
+      *options, MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING
+    )
+  ) {
+    result.vector_encoding = options->vector_encoding;
+  }
+  return result;
+}
+
+auto to_native_tile_scheme(uint32_t scheme) -> mbgl::Tileset::Scheme {
+  return scheme == MLN_STYLE_TILE_SCHEME_TMS ? mbgl::Tileset::Scheme::TMS
+                                             : mbgl::Tileset::Scheme::XYZ;
+}
+
+auto to_native_vector_encoding(uint32_t encoding)
+  -> mbgl::Tileset::VectorEncoding {
+  return encoding == MLN_STYLE_VECTOR_TILE_ENCODING_MLT
+           ? mbgl::Tileset::VectorEncoding::MLT
+           : mbgl::Tileset::VectorEncoding::Mapbox;
+}
+
+auto validate_tile_urls(const mln_string_view* tiles, size_t tile_count)
+  -> mln_status {
+  if (tile_count == 0) {
+    mln::core::set_thread_error("tile_count must be greater than 0");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (tiles == nullptr) {
+    mln::core::set_thread_error("tiles must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  for (const auto tile : std::span<const mln_string_view>{tiles, tile_count}) {
+    if (!validate_string_view(tile, "tile URL")) {
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+    if (tile.size == 0) {
+      mln::core::set_thread_error("tile URLs must not be empty");
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  return MLN_STATUS_OK;
+}
+
+auto to_native_tile_urls(const mln_string_view* tiles, size_t tile_count)
+  -> std::vector<std::string> {
+  auto result = std::vector<std::string>{};
+  result.reserve(tile_count);
+  for (const auto tile : std::span<const mln_string_view>{tiles, tile_count}) {
+    result.push_back(string_from_view(tile));
+  }
+  return result;
+}
+
+auto to_native_tileset(
+  const mln_string_view* tiles, size_t tile_count,
+  const mln_style_tile_source_options& options, bool vector_source
+) -> std::optional<mbgl::Tileset> {
+  if (options.min_zoom > options.max_zoom) {
+    mln::core::set_thread_error(
+      "effective min_zoom must be less than or equal to max_zoom"
+    );
+    return std::nullopt;
+  }
+
+  auto tileset = mbgl::Tileset{
+    to_native_tile_urls(tiles, tile_count),
+    mbgl::Range<uint8_t>{
+      static_cast<uint8_t>(options.min_zoom),
+      static_cast<uint8_t>(options.max_zoom)
+    },
+    string_from_view(options.attribution),
+    to_native_tile_scheme(options.scheme),
+    std::nullopt,
+    vector_source
+      ? std::optional<mbgl::Tileset::VectorEncoding>{to_native_vector_encoding(
+          options.vector_encoding
+        )}
+      : std::nullopt
+  };
+  if (has_tile_source_option(options, MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS)) {
+    tileset.bounds = to_native_lat_lng_bounds(options.bounds);
+  }
+  return tileset;
+}
+
+auto validate_source_id(mln_string_view source_id) -> mln_status {
+  if (!validate_string_view(source_id, "source_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (source_id.size == 0) {
+    mln::core::set_thread_error("source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_source_can_be_added(
+  mbgl::style::Style& style, const std::string& source_id
+) -> mln_status {
+  if (style.getSource(source_id) != nullptr) {
+    mln::core::set_thread_error("source already exists");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
 }
 
 auto create_style_id_list(
@@ -508,7 +816,6 @@ auto exception_message(std::exception_ptr error) -> std::string {
 }
 
 auto validate_lat_lng(mln_lat_lng coordinate) -> mln_status;
-auto validate_lat_lng_bounds(mln_lat_lng_bounds bounds) -> mln_status;
 auto validate_edge_insets(mln_edge_insets padding) -> mln_status;
 auto validate_screen_point(mln_screen_point point) -> mln_status;
 
@@ -1723,6 +2030,23 @@ auto map_tile_options_default() noexcept -> mln_map_tile_options {
   };
 }
 
+auto style_tile_source_options_default() noexcept
+  -> mln_style_tile_source_options {
+  return mln_style_tile_source_options{
+    .size = sizeof(mln_style_tile_source_options),
+    .fields = 0,
+    .min_zoom = 0,
+    .max_zoom = mbgl::util::DEFAULT_MAX_ZOOM,
+    .attribution = {.data = nullptr, .size = 0},
+    .scheme = MLN_STYLE_TILE_SCHEME_XYZ,
+    .bounds =
+      {.southwest = {.latitude = 0, .longitude = 0},
+       .northeast = {.latitude = 0, .longitude = 0}},
+    .tile_size = mbgl::util::tileSize_I,
+    .vector_encoding = MLN_STYLE_VECTOR_TILE_ENCODING_MVT
+  };
+}
+
 auto validate_map(mln_map* map) -> mln_status {
   if (map == nullptr) {
     set_thread_error("map must not be null");
@@ -2295,6 +2619,313 @@ auto map_list_style_source_ids(mln_map* map, mln_style_id_list** out_source_ids)
     ids.push_back(source->getID());
   }
   return create_style_id_list(std::move(ids), out_source_ids);
+}
+
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+auto map_add_geojson_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  if (!validate_string_view(url, "url")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (url.size == 0) {
+    set_thread_error("url must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  auto source = std::make_unique<mbgl::style::GeoJSONSource>(id);
+  source->setURL(string_from_view(url));
+  style.addSource(std::move(source));
+  return MLN_STATUS_OK;
+}
+
+auto map_add_geojson_source_data(
+  mln_map* map, mln_string_view source_id, const mln_geojson* data
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+
+  auto geojson = to_native_geojson(data);
+  if (!geojson) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  auto source = std::make_unique<mbgl::style::GeoJSONSource>(id);
+  source->setGeoJSON(*geojson);
+  style.addSource(std::move(source));
+  return MLN_STATUS_OK;
+}
+
+auto map_set_geojson_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  if (!validate_string_view(url, "url")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (url.size == 0) {
+    set_thread_error("url must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  if (source == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* geojson_source = source->as<mbgl::style::GeoJSONSource>();
+  if (geojson_source == nullptr) {
+    set_thread_error("source is not a GeoJSON source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  geojson_source->setURL(string_from_view(url));
+  return MLN_STATUS_OK;
+}
+
+auto map_set_geojson_source_data(
+  mln_map* map, mln_string_view source_id, const mln_geojson* data
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+
+  auto geojson = to_native_geojson(data);
+  if (!geojson) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  if (source == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* geojson_source = source->as<mbgl::style::GeoJSONSource>();
+  if (geojson_source == nullptr) {
+    set_thread_error("source is not a GeoJSON source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  geojson_source->setGeoJSON(*geojson);
+  return MLN_STATUS_OK;
+}
+
+auto map_add_vector_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  if (!validate_string_view(url, "url")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (url.size == 0) {
+    set_thread_error("url must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto options_status = validate_tile_source_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  const auto effective = effective_tile_source_options(options);
+  auto min_zoom = std::optional<float>{};
+  if (
+    has_tile_source_option(effective, MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM)
+  ) {
+    min_zoom = static_cast<float>(effective.min_zoom);
+  }
+  auto max_zoom = std::optional<float>{};
+  if (
+    has_tile_source_option(effective, MLN_STYLE_TILE_SOURCE_OPTION_MAX_ZOOM)
+  ) {
+    max_zoom = static_cast<float>(effective.max_zoom);
+  }
+
+  style.addSource(
+    std::make_unique<mbgl::style::VectorSource>(
+      id, string_from_view(url), max_zoom, min_zoom,
+      to_native_vector_encoding(effective.vector_encoding)
+    )
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_add_vector_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto tiles_status = validate_tile_urls(tiles, tile_count);
+  if (tiles_status != MLN_STATUS_OK) {
+    return tiles_status;
+  }
+  const auto options_status = validate_tile_source_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  const auto effective = effective_tile_source_options(options);
+  auto tileset = to_native_tileset(tiles, tile_count, effective, true);
+  if (!tileset) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  style.addSource(
+    std::make_unique<mbgl::style::VectorSource>(
+      id, *tileset, std::nullopt, std::nullopt,
+      to_native_vector_encoding(effective.vector_encoding)
+    )
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_add_raster_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  if (!validate_string_view(url, "url")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (url.size == 0) {
+    set_thread_error("url must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto options_status = validate_tile_source_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  const auto effective = effective_tile_source_options(options);
+  style.addSource(
+    std::make_unique<mbgl::style::RasterSource>(
+      id, string_from_view(url), static_cast<uint16_t>(effective.tile_size)
+    )
+  );
+  return MLN_STATUS_OK;
+}
+// NOLINTEND(bugprone-easily-swappable-parameters)
+
+auto map_add_raster_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto tiles_status = validate_tile_urls(tiles, tile_count);
+  if (tiles_status != MLN_STATUS_OK) {
+    return tiles_status;
+  }
+  const auto options_status = validate_tile_source_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  const auto effective = effective_tile_source_options(options);
+  auto tileset = to_native_tileset(tiles, tile_count, effective, false);
+  if (!tileset) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  style.addSource(
+    std::make_unique<mbgl::style::RasterSource>(
+      id, *tileset, static_cast<uint16_t>(effective.tile_size)
+    )
+  );
+  return MLN_STATUS_OK;
 }
 
 auto map_add_style_layer_json(

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2794,12 +2794,24 @@ auto map_add_vector_source_url(
     max_zoom = static_cast<float>(effective.max_zoom);
   }
 
-  style.addSource(
-    std::make_unique<mbgl::style::VectorSource>(
-      id, string_from_view(url), max_zoom, min_zoom,
-      to_native_vector_encoding(effective.vector_encoding)
+  if (
+    has_tile_source_option(
+      effective, MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING
     )
-  );
+  ) {
+    style.addSource(
+      std::make_unique<mbgl::style::VectorSource>(
+        id, string_from_view(url), max_zoom, min_zoom,
+        to_native_vector_encoding(effective.vector_encoding)
+      )
+    );
+  } else {
+    style.addSource(
+      std::make_unique<mbgl::style::VectorSource>(
+        id, string_from_view(url), max_zoom, min_zoom
+      )
+    );
+  }
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -24,6 +24,8 @@ auto free_camera_options_default() noexcept -> mln_free_camera_options;
 auto projection_mode_default() noexcept -> mln_projection_mode;
 auto map_viewport_options_default() noexcept -> mln_map_viewport_options;
 auto map_tile_options_default() noexcept -> mln_map_tile_options;
+auto style_tile_source_options_default() noexcept
+  -> mln_style_tile_source_options;
 auto create_map(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) -> mln_status;
@@ -61,6 +63,34 @@ auto map_copy_style_source_attribution(
 ) -> mln_status;
 auto map_list_style_source_ids(mln_map* map, mln_style_id_list** out_source_ids)
   -> mln_status;
+auto map_add_geojson_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) -> mln_status;
+auto map_add_geojson_source_data(
+  mln_map* map, mln_string_view source_id, const mln_geojson* data
+) -> mln_status;
+auto map_set_geojson_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) -> mln_status;
+auto map_set_geojson_source_data(
+  mln_map* map, mln_string_view source_id, const mln_geojson* data
+) -> mln_status;
+auto map_add_vector_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) -> mln_status;
+auto map_add_vector_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) -> mln_status;
+auto map_add_raster_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) -> mln_status;
+auto map_add_raster_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) -> mln_status;
 auto map_add_style_layer_json(
   mln_map* map, const mln_json_value* layer_json,
   mln_string_view before_layer_id

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -405,3 +405,121 @@ test "style light accepts full JSON and property updates" {
     );
     try testing.expect(std.mem.len(c.mln_thread_last_error_message()) > 0);
 }
+
+test "core source helpers add and update ordinary sources" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
+
+    const point = c.mln_geometry{
+        .size = @sizeOf(c.mln_geometry),
+        .type = c.MLN_GEOMETRY_TYPE_POINT,
+        .data = .{ .point = .{ .latitude = 37.7749, .longitude = -122.4194 } },
+    };
+    const geojson = c.mln_geojson{
+        .size = @sizeOf(c.mln_geojson),
+        .type = c.MLN_GEOJSON_TYPE_GEOMETRY,
+        .data = .{ .geometry = &point },
+    };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_add_geojson_source_data(map, stringView("geo-helper"), &geojson));
+
+    var found = false;
+    var source_type: u32 = c.MLN_STYLE_SOURCE_TYPE_UNKNOWN;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_source_type(map, stringView("geo-helper"), &source_type, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_GEOJSON, source_type);
+
+    const empty_collection = c.mln_geojson{
+        .size = @sizeOf(c.mln_geojson),
+        .type = c.MLN_GEOJSON_TYPE_FEATURE_COLLECTION,
+        .data = .{ .feature_collection = .{ .features = null, .feature_count = 0 } },
+    };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_geojson_source_data(map, stringView("geo-helper"), &empty_collection));
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_set_geojson_source_url(map, stringView("geo-helper"), stringView("https://example.com/data.geojson")),
+    );
+
+    var tile_options = c.mln_style_tile_source_options_default();
+    try testing.expectEqual(@as(u32, 512), tile_options.tile_size);
+    tile_options.fields = c.MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM |
+        c.MLN_STYLE_TILE_SOURCE_OPTION_MAX_ZOOM |
+        c.MLN_STYLE_TILE_SOURCE_OPTION_ATTRIBUTION |
+        c.MLN_STYLE_TILE_SOURCE_OPTION_SCHEME |
+        c.MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS |
+        c.MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING;
+    tile_options.min_zoom = 1.0;
+    tile_options.max_zoom = 14.0;
+    tile_options.attribution = stringView("Helper attribution");
+    tile_options.scheme = c.MLN_STYLE_TILE_SCHEME_TMS;
+    tile_options.bounds = .{
+        .southwest = .{ .latitude = -45.0, .longitude = -120.0 },
+        .northeast = .{ .latitude = 45.0, .longitude = 120.0 },
+    };
+    tile_options.vector_encoding = c.MLN_STYLE_VECTOR_TILE_ENCODING_MLT;
+    const vector_tiles = [_]c.mln_string_view{stringView("https://example.com/vector/{z}/{x}/{y}.mvt")};
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_vector_source_tiles(map, stringView("vector-helper"), &vector_tiles, vector_tiles.len, &tile_options),
+    );
+
+    var info: c.mln_style_source_info = .{
+        .size = @sizeOf(c.mln_style_source_info),
+        .type = c.MLN_STYLE_SOURCE_TYPE_UNKNOWN,
+        .id_size = 0,
+        .is_volatile = false,
+        .has_attribution = false,
+        .attribution_size = 0,
+    };
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_source_info(map, stringView("vector-helper"), &info, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_VECTOR, info.type);
+    try testing.expect(info.has_attribution);
+    try testing.expectEqual(@as(usize, "Helper attribution".len), info.attribution_size);
+
+    var raster_options = c.mln_style_tile_source_options_default();
+    raster_options.fields = c.MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE;
+    raster_options.tile_size = 256;
+    const raster_tiles = [_]c.mln_string_view{stringView("https://example.com/raster/{z}/{x}/{y}.png")};
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_raster_source_tiles(map, stringView("raster-helper"), &raster_tiles, raster_tiles.len, &raster_options),
+    );
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_source_type(map, stringView("raster-helper"), &source_type, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_RASTER, source_type);
+
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_vector_source_url(map, stringView("vector-url-helper"), stringView("https://example.com/vector.json"), null),
+    );
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_raster_source_url(map, stringView("raster-url-helper"), stringView("https://example.com/raster.json"), &raster_options),
+    );
+
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_add_geojson_source_url(map, stringView("geo-helper"), stringView("https://example.com/again.geojson")),
+    );
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_set_geojson_source_url(map, stringView("vector-helper"), stringView("https://example.com/not-geojson")),
+    );
+}


### PR DESCRIPTION
## Summary
- Add focused C helpers for GeoJSON, vector, and raster sources on top of the style registry APIs.
- Add tile source option defaults and validation for zoom, attribution, scheme, bounds, tile size, and vector encoding.
- Disable clang-tidy's easily-swappable-parameters check because it is noisy for C ABI shape.

## Issue
partial #15

## Testing
- mise run test