### PR TITLE
Add runtime style image APIs

### DIFF
--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -60,6 +60,12 @@ typedef enum mln_style_vector_tile_encoding : uint32_t {
   MLN_STYLE_VECTOR_TILE_ENCODING_MLT = 1,
 } mln_style_vector_tile_encoding;
 
+/** Field mask values for mln_style_image_options. */
+typedef enum mln_style_image_option_field : uint32_t {
+  MLN_STYLE_IMAGE_OPTION_PIXEL_RATIO = 1U << 0U,
+  MLN_STYLE_IMAGE_OPTION_SDF = 1U << 1U,
+} mln_style_image_option_field;
+
 /** Fixed source metadata returned by mln_map_get_style_source_info(). */
 typedef struct mln_style_source_info {
   uint32_t size;
@@ -89,9 +95,55 @@ typedef struct mln_style_tile_source_options {
   uint32_t vector_encoding;
 } mln_style_tile_source_options;
 
+/** Caller-owned premultiplied RGBA8 image pixels. */
+typedef struct mln_premultiplied_rgba8_image {
+  uint32_t size;
+  uint32_t width;
+  uint32_t height;
+  /** Bytes per image row. Must be at least width * 4. */
+  uint32_t stride;
+  /** Premultiplied RGBA8 pixels. Must not be null for a non-empty image. */
+  const uint8_t* pixels;
+  /** Available bytes at pixels. */
+  size_t byte_length;
+} mln_premultiplied_rgba8_image;
+
+/** Options for runtime style images. */
+typedef struct mln_style_image_options {
+  uint32_t size;
+  uint32_t fields;
+  /** Sprite pixel ratio. Defaults to 1. */
+  float pixel_ratio;
+  /** Whether the image is a signed distance field icon. Defaults to false. */
+  bool sdf;
+} mln_style_image_options;
+
+/** Fixed metadata for one runtime style image. */
+typedef struct mln_style_image_info {
+  uint32_t size;
+  uint32_t width;
+  uint32_t height;
+  /** Native copied images are exposed as tightly packed premultiplied RGBA8. */
+  uint32_t stride;
+  size_t byte_length;
+  float pixel_ratio;
+  bool sdf;
+} mln_style_image_info;
+
 /** Returns default tile source options. */
 MLN_API mln_style_tile_source_options
 mln_style_tile_source_options_default(void) MLN_NOEXCEPT;
+
+/** Returns a default premultiplied RGBA8 image descriptor. */
+MLN_API mln_premultiplied_rgba8_image
+mln_premultiplied_rgba8_image_default(void) MLN_NOEXCEPT;
+
+/** Returns default runtime style image options. */
+MLN_API mln_style_image_options
+mln_style_image_options_default(void) MLN_NOEXCEPT;
+
+/** Returns default runtime style image metadata. */
+MLN_API mln_style_image_info mln_style_image_info_default(void) MLN_NOEXCEPT;
 
 /**
  * Gets the number of IDs in a style ID list handle.
@@ -414,6 +466,109 @@ MLN_API mln_status mln_map_add_raster_source_url(
 MLN_API mln_status mln_map_add_raster_source_tiles(
   mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
   size_t tile_count, const mln_style_tile_source_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Sets one runtime style image.
+ *
+ * image_id, image, and image pixels are borrowed for the call. The function
+ * copies accepted pixel bytes into the current style before return. If image_id
+ * already exists, the native image is replaced.
+ *
+ * Runtime style images belong to the current style. Loading another style URL
+ * or JSON document drops images that were added to the previous style.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, image_id is
+ *   invalid or empty, image or options is invalid, image pixels are null, image
+ *   dimensions or stride are invalid, or image byte_length is too small.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_style_image(
+  mln_map* map, mln_string_view image_id,
+  const mln_premultiplied_rgba8_image* image,
+  const mln_style_image_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Removes one runtime style image by ID.
+ *
+ * image_id is borrowed for the call. On success, out_removed reports whether an
+ * image existed and was removed.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, image_id is
+ *   invalid or empty, or out_removed is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_remove_style_image(
+  mln_map* map, mln_string_view image_id, bool* out_removed
+) MLN_NOEXCEPT;
+
+/**
+ * Reports whether a runtime style image ID exists.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, image_id is
+ *   invalid or empty, or out_exists is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_style_image_exists(
+  mln_map* map, mln_string_view image_id, bool* out_exists
+) MLN_NOEXCEPT;
+
+/**
+ * Copies fixed metadata for one runtime style image.
+ *
+ * On success, out_found reports whether image_id exists. When not found,
+ * out_info receives default image metadata.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, image_id is
+ *   invalid or empty, out_info is null, out_info->size is too small, or
+ *   out_found is null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_style_image_info(
+  mln_map* map, mln_string_view image_id, mln_style_image_info* out_info,
+  bool* out_found
+) MLN_NOEXCEPT;
+
+/**
+ * Copies one runtime style image as tightly packed premultiplied RGBA8 pixels.
+ *
+ * image_id is borrowed for the call. out_pixels may be null only when
+ * pixel_capacity is 0. On success, out_byte_length receives the required byte
+ * length. When out_found is false, out_byte_length receives 0. If
+ * pixel_capacity is too small for a present image, out_byte_length still
+ * receives the required byte length and the function returns
+ * MLN_STATUS_INVALID_ARGUMENT.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, image_id is
+ *   invalid or empty, out_pixels is null with non-zero capacity, pixel_capacity
+ *   is too small for a present image, out_byte_length is null, or out_found is
+ *   null.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_copy_style_image_premultiplied_rgba8(
+  mln_map* map, mln_string_view image_id, uint8_t* out_pixels,
+  size_t pixel_capacity, size_t* out_byte_length, bool* out_found
 ) MLN_NOEXCEPT;
 
 /**

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -50,6 +50,19 @@ auto mln_style_tile_source_options_default(void) noexcept
   return mln::core::style_tile_source_options_default();
 }
 
+auto mln_premultiplied_rgba8_image_default(void) noexcept
+  -> mln_premultiplied_rgba8_image {
+  return mln::core::premultiplied_rgba8_image_default();
+}
+
+auto mln_style_image_options_default(void) noexcept -> mln_style_image_options {
+  return mln::core::style_image_options_default();
+}
+
+auto mln_style_image_info_default(void) noexcept -> mln_style_image_info {
+  return mln::core::style_image_info_default();
+}
+
 auto mln_map_create(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) noexcept -> mln_status {
@@ -244,6 +257,54 @@ auto mln_map_add_raster_source_tiles(
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_add_raster_source_tiles(
       map, source_id, tiles, tile_count, options
+    );
+  });
+}
+
+auto mln_map_set_style_image(
+  mln_map* map, mln_string_view image_id,
+  const mln_premultiplied_rgba8_image* image,
+  const mln_style_image_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_style_image(map, image_id, image, options);
+  });
+}
+
+auto mln_map_remove_style_image(
+  mln_map* map, mln_string_view image_id, bool* out_removed
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_remove_style_image(map, image_id, out_removed);
+  });
+}
+
+auto mln_map_style_image_exists(
+  mln_map* map, mln_string_view image_id, bool* out_exists
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_style_image_exists(map, image_id, out_exists);
+  });
+}
+
+auto mln_map_get_style_image_info(
+  mln_map* map, mln_string_view image_id, mln_style_image_info* out_info,
+  bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_style_image_info(
+      map, image_id, out_info, out_found
+    );
+  });
+}
+
+auto mln_map_copy_style_image_premultiplied_rgba8(
+  mln_map* map, mln_string_view image_id, uint8_t* out_pixels,
+  size_t pixel_capacity, size_t* out_byte_length, bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_copy_style_image_premultiplied_rgba8(
+      map, image_id, out_pixels, pixel_capacity, out_byte_length, out_found
     );
   });
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -35,6 +35,7 @@
 #include <mbgl/style/conversion/light.hpp>   // IWYU pragma: keep
 #include <mbgl/style/conversion/source.hpp>  // IWYU pragma: keep
 #include <mbgl/style/conversion_impl.hpp>
+#include <mbgl/style/image.hpp>
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/light.hpp>
 #include <mbgl/style/source.hpp>
@@ -50,6 +51,7 @@
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/image.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/range.hpp>
 #include <mbgl/util/size.hpp>
@@ -455,6 +457,163 @@ auto validate_source_can_be_added(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
   return MLN_STATUS_OK;
+}
+
+auto has_style_image_option(
+  const mln_style_image_options& options, uint32_t field
+) -> bool {
+  return (options.fields & field) != 0U;
+}
+
+auto validate_style_image_options(const mln_style_image_options* options)
+  -> mln_status {
+  if (options == nullptr) {
+    return MLN_STATUS_OK;
+  }
+  if (options->size < sizeof(mln_style_image_options)) {
+    mln::core::set_thread_error("mln_style_image_options.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_STYLE_IMAGE_OPTION_PIXEL_RATIO) |
+    MLN_STYLE_IMAGE_OPTION_SDF;
+  if ((options->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_style_image_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    has_style_image_option(*options, MLN_STYLE_IMAGE_OPTION_PIXEL_RATIO) &&
+    (!std::isfinite(options->pixel_ratio) || options->pixel_ratio <= 0.0F)
+  ) {
+    mln::core::set_thread_error("pixel_ratio must be finite and positive");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto effective_style_image_options(const mln_style_image_options* options)
+  -> mln_style_image_options {
+  auto result = mln::core::style_image_options_default();
+  if (options == nullptr) {
+    return result;
+  }
+  result.fields = options->fields;
+  if (has_style_image_option(*options, MLN_STYLE_IMAGE_OPTION_PIXEL_RATIO)) {
+    result.pixel_ratio = options->pixel_ratio;
+  }
+  if (has_style_image_option(*options, MLN_STYLE_IMAGE_OPTION_SDF)) {
+    result.sdf = options->sdf;
+  }
+  return result;
+}
+
+auto required_premultiplied_rgba8_bytes(
+  uint32_t width, uint32_t height, uint32_t stride
+) -> std::optional<size_t> {
+  constexpr auto channels = size_t{4};
+  const auto row_bytes = static_cast<size_t>(width) * channels;
+  if (height == 0) {
+    return std::nullopt;
+  }
+  if (height == 1) {
+    return row_bytes;
+  }
+  const auto trailing_rows = static_cast<size_t>(height - 1U);
+  const auto row_stride = static_cast<size_t>(stride);
+  if (
+    trailing_rows >
+    (std::numeric_limits<size_t>::max() - row_bytes) / row_stride
+  ) {
+    return std::nullopt;
+  }
+  return (trailing_rows * row_stride) + row_bytes;
+}
+
+auto validate_premultiplied_rgba8_image(
+  const mln_premultiplied_rgba8_image* image
+) -> mln_status {
+  if (image == nullptr) {
+    mln::core::set_thread_error("image must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (image->size < sizeof(mln_premultiplied_rgba8_image)) {
+    mln::core::set_thread_error(
+      "mln_premultiplied_rgba8_image.size is too small"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (image->width == 0 || image->height == 0) {
+    mln::core::set_thread_error("image dimensions must be positive");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  constexpr auto channels = uint32_t{4};
+  if (image->width > std::numeric_limits<uint32_t>::max() / channels) {
+    mln::core::set_thread_error("image row byte length overflows");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto row_bytes = image->width * channels;
+  if (image->stride < row_bytes) {
+    mln::core::set_thread_error("image stride must be at least width * 4");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (image->pixels == nullptr) {
+    mln::core::set_thread_error("image pixels must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto required = required_premultiplied_rgba8_bytes(
+    image->width, image->height, image->stride
+  );
+  if (!required || image->byte_length < *required) {
+    mln::core::set_thread_error("image byte_length is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto to_native_premultiplied_rgba8_image(
+  const mln_premultiplied_rgba8_image& image
+) -> mbgl::PremultipliedImage {
+  auto result = mbgl::PremultipliedImage{mbgl::Size{image.width, image.height}};
+  const auto output_stride = result.stride();
+  const auto row_bytes = static_cast<size_t>(image.width) * 4U;
+  const auto input = std::span<const uint8_t>{image.pixels, image.byte_length};
+  const auto output = std::span<uint8_t>{result.data.get(), result.bytes()};
+  for (auto row = uint32_t{0}; row < image.height; ++row) {
+    const auto input_offset = static_cast<size_t>(row) * image.stride;
+    const auto output_offset = static_cast<size_t>(row) * output_stride;
+    std::copy_n(
+      input.subspan(input_offset, row_bytes).begin(), row_bytes,
+      output.subspan(output_offset, row_bytes).begin()
+    );
+  }
+  return result;
+}
+
+auto validate_image_id(mln_string_view image_id) -> mln_status {
+  if (!validate_string_view(image_id, "image_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (image_id.size == 0) {
+    mln::core::set_thread_error("image_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto style_image_info_from_native(const mbgl::style::Image& image)
+  -> mln_style_image_info {
+  const auto& pixels = image.getImage();
+  return mln_style_image_info{
+    .size = sizeof(mln_style_image_info),
+    .width = pixels.size.width,
+    .height = pixels.size.height,
+    .stride = static_cast<uint32_t>(pixels.stride()),
+    .byte_length = pixels.bytes(),
+    .pixel_ratio = image.getPixelRatio(),
+    .sdf = image.isSdf()
+  };
 }
 
 auto create_style_id_list(
@@ -2047,6 +2206,39 @@ auto style_tile_source_options_default() noexcept
   };
 }
 
+auto premultiplied_rgba8_image_default() noexcept
+  -> mln_premultiplied_rgba8_image {
+  return mln_premultiplied_rgba8_image{
+    .size = sizeof(mln_premultiplied_rgba8_image),
+    .width = 0,
+    .height = 0,
+    .stride = 0,
+    .pixels = nullptr,
+    .byte_length = 0
+  };
+}
+
+auto style_image_options_default() noexcept -> mln_style_image_options {
+  return mln_style_image_options{
+    .size = sizeof(mln_style_image_options),
+    .fields = 0,
+    .pixel_ratio = 1.0F,
+    .sdf = false
+  };
+}
+
+auto style_image_info_default() noexcept -> mln_style_image_info {
+  return mln_style_image_info{
+    .size = sizeof(mln_style_image_info),
+    .width = 0,
+    .height = 0,
+    .stride = 0,
+    .byte_length = 0,
+    .pixel_ratio = 1.0F,
+    .sdf = false
+  };
+}
+
 auto validate_map(mln_map* map) -> mln_status {
   if (map == nullptr) {
     set_thread_error("map must not be null");
@@ -2935,6 +3127,151 @@ auto map_add_raster_source_tiles(
       id, *tileset, static_cast<uint16_t>(effective.tile_size)
     )
   );
+  return MLN_STATUS_OK;
+}
+
+auto map_set_style_image(
+  mln_map* map, mln_string_view image_id,
+  const mln_premultiplied_rgba8_image* image,
+  const mln_style_image_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto image_id_status = validate_image_id(image_id);
+  if (image_id_status != MLN_STATUS_OK) {
+    return image_id_status;
+  }
+  const auto image_status = validate_premultiplied_rgba8_image(image);
+  if (image_status != MLN_STATUS_OK) {
+    return image_status;
+  }
+  const auto options_status = validate_style_image_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  const auto effective = effective_style_image_options(options);
+  auto style_image = std::make_unique<mbgl::style::Image>(
+    string_from_view(image_id), to_native_premultiplied_rgba8_image(*image),
+    effective.pixel_ratio, effective.sdf
+  );
+  map->map->getStyle().addImage(std::move(style_image));
+  return MLN_STATUS_OK;
+}
+
+auto map_remove_style_image(
+  mln_map* map, mln_string_view image_id, bool* out_removed
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto image_id_status = validate_image_id(image_id);
+  if (image_id_status != MLN_STATUS_OK) {
+    return image_id_status;
+  }
+  if (out_removed == nullptr) {
+    set_thread_error("out_removed must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(image_id);
+  *out_removed = style.getImage(id).has_value();
+  if (*out_removed) {
+    style.removeImage(id);
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_style_image_exists(
+  mln_map* map, mln_string_view image_id, bool* out_exists
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto image_id_status = validate_image_id(image_id);
+  if (image_id_status != MLN_STATUS_OK) {
+    return image_id_status;
+  }
+  if (out_exists == nullptr) {
+    set_thread_error("out_exists must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  *out_exists =
+    map->map->getStyle().getImage(string_from_view(image_id)).has_value();
+  return MLN_STATUS_OK;
+}
+
+auto map_get_style_image_info(
+  mln_map* map, mln_string_view image_id, mln_style_image_info* out_info,
+  bool* out_found
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto image_id_status = validate_image_id(image_id);
+  if (image_id_status != MLN_STATUS_OK) {
+    return image_id_status;
+  }
+  if (out_info == nullptr || out_info->size < sizeof(mln_style_image_info)) {
+    set_thread_error("out_info must not be null and must have a valid size");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_found == nullptr) {
+    set_thread_error("out_found must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto image = map->map->getStyle().getImage(string_from_view(image_id));
+  *out_found = image.has_value();
+  *out_info =
+    image ? style_image_info_from_native(*image) : style_image_info_default();
+  return MLN_STATUS_OK;
+}
+
+auto map_copy_style_image_premultiplied_rgba8(
+  mln_map* map, mln_string_view image_id, uint8_t* out_pixels,
+  size_t pixel_capacity, size_t* out_byte_length, bool* out_found
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto image_id_status = validate_image_id(image_id);
+  if (image_id_status != MLN_STATUS_OK) {
+    return image_id_status;
+  }
+  if (out_pixels == nullptr && pixel_capacity > 0) {
+    set_thread_error("out_pixels must not be null when capacity is non-zero");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_byte_length == nullptr || out_found == nullptr) {
+    set_thread_error("out_byte_length and out_found must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto image = map->map->getStyle().getImage(string_from_view(image_id));
+  *out_found = image.has_value();
+  *out_byte_length = 0;
+  if (!image) {
+    return MLN_STATUS_OK;
+  }
+
+  const auto& pixels = image->getImage();
+  *out_byte_length = pixels.bytes();
+  if (pixel_capacity < pixels.bytes()) {
+    set_thread_error("pixel_capacity is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (pixels.bytes() > 0) {
+    std::copy_n(pixels.data.get(), pixels.bytes(), out_pixels);
+  }
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -26,6 +26,10 @@ auto map_viewport_options_default() noexcept -> mln_map_viewport_options;
 auto map_tile_options_default() noexcept -> mln_map_tile_options;
 auto style_tile_source_options_default() noexcept
   -> mln_style_tile_source_options;
+auto premultiplied_rgba8_image_default() noexcept
+  -> mln_premultiplied_rgba8_image;
+auto style_image_options_default() noexcept -> mln_style_image_options;
+auto style_image_info_default() noexcept -> mln_style_image_info;
 auto create_map(
   mln_runtime* runtime, const mln_map_options* options, mln_map** out_map
 ) -> mln_status;
@@ -90,6 +94,25 @@ auto map_add_raster_source_url(
 auto map_add_raster_source_tiles(
   mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
   size_t tile_count, const mln_style_tile_source_options* options
+) -> mln_status;
+auto map_set_style_image(
+  mln_map* map, mln_string_view image_id,
+  const mln_premultiplied_rgba8_image* image,
+  const mln_style_image_options* options
+) -> mln_status;
+auto map_remove_style_image(
+  mln_map* map, mln_string_view image_id, bool* out_removed
+) -> mln_status;
+auto map_style_image_exists(
+  mln_map* map, mln_string_view image_id, bool* out_exists
+) -> mln_status;
+auto map_get_style_image_info(
+  mln_map* map, mln_string_view image_id, mln_style_image_info* out_info,
+  bool* out_found
+) -> mln_status;
+auto map_copy_style_image_premultiplied_rgba8(
+  mln_map* map, mln_string_view image_id, uint8_t* out_pixels,
+  size_t pixel_capacity, size_t* out_byte_length, bool* out_found
 ) -> mln_status;
 auto map_add_style_layer_json(
   mln_map* map, const mln_json_value* layer_json,

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -523,3 +523,95 @@ test "core source helpers add and update ordinary sources" {
         c.mln_map_set_geojson_source_url(map, stringView("vector-helper"), stringView("https://example.com/not-geojson")),
     );
 }
+
+test "runtime style images copy premultiplied RGBA8 pixels" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
+
+    var pixels = [_]u8{
+        10,  20,  30,  255, 40, 50, 60, 255,
+        0,   0,   0,   0,   70, 80, 90, 255,
+        100, 110, 120, 255, 0,  0,  0,  0,
+    };
+    var image = c.mln_premultiplied_rgba8_image_default();
+    try testing.expectEqual(@as(u32, 0), image.width);
+    image.width = 2;
+    image.height = 2;
+    image.stride = 12;
+    image.pixels = &pixels;
+    image.byte_length = pixels.len;
+
+    var options = c.mln_style_image_options_default();
+    options.fields = c.MLN_STYLE_IMAGE_OPTION_PIXEL_RATIO | c.MLN_STYLE_IMAGE_OPTION_SDF;
+    options.pixel_ratio = 2.0;
+    options.sdf = true;
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_image(map, stringView("runtime-icon"), &image, &options));
+    pixels[0] = 200;
+
+    var exists = false;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_style_image_exists(map, stringView("runtime-icon"), &exists));
+    try testing.expect(exists);
+
+    var found = false;
+    var info = c.mln_style_image_info_default();
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_image_info(map, stringView("runtime-icon"), &info, &found));
+    try testing.expect(found);
+    try testing.expectEqual(@as(u32, 2), info.width);
+    try testing.expectEqual(@as(u32, 2), info.height);
+    try testing.expectEqual(@as(u32, 8), info.stride);
+    try testing.expectEqual(@as(usize, 16), info.byte_length);
+    try testing.expectApproxEqAbs(@as(f32, 2.0), info.pixel_ratio, 0.000001);
+    try testing.expect(info.sdf);
+
+    var required: usize = 0;
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_copy_style_image_premultiplied_rgba8(map, stringView("runtime-icon"), null, 0, &required, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(@as(usize, 16), required);
+
+    var copied: [16]u8 = undefined;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_copy_style_image_premultiplied_rgba8(map, stringView("runtime-icon"), &copied, copied.len, &required, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(@as(usize, 16), required);
+    try testing.expect(std.mem.eql(u8, copied[0..], &[_]u8{
+        10, 20, 30, 255, 40,  50,  60,  255,
+        70, 80, 90, 255, 100, 110, 120, 255,
+    }));
+
+    var replacement_pixels = [_]u8{ 1, 2, 3, 4 };
+    image.width = 1;
+    image.height = 1;
+    image.stride = 4;
+    image.pixels = &replacement_pixels;
+    image.byte_length = replacement_pixels.len;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_image(map, stringView("runtime-icon"), &image, null));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_image_info(map, stringView("runtime-icon"), &info, &found));
+    try testing.expect(found);
+    try testing.expectEqual(@as(u32, 1), info.width);
+    try testing.expectEqual(@as(u32, 1), info.height);
+    try testing.expectEqual(@as(u32, 4), info.stride);
+    try testing.expectApproxEqAbs(@as(f32, 1.0), info.pixel_ratio, 0.000001);
+    try testing.expect(!info.sdf);
+
+    var removed = false;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_remove_style_image(map, stringView("runtime-icon"), &removed));
+    try testing.expect(removed);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_style_image_exists(map, stringView("runtime-icon"), &exists));
+    try testing.expect(!exists);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_remove_style_image(map, stringView("runtime-icon"), &removed));
+    try testing.expect(!removed);
+}


### PR DESCRIPTION
## Summary
- Add shared premultiplied RGBA8 image descriptors for style/image workflows.
- Add runtime style image set/remove/exists/info/copy APIs with strict ownership and validation rules.
- Cover non-tight input stride, native readback, replacement, and removal through C API tests.

## Issue
resolves #15
partial #36
partial #33

## Testing
- mise run test