### PR TITLE
Add image source APIs

### DIFF
--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -572,6 +572,142 @@ MLN_API mln_status mln_map_copy_style_image_premultiplied_rgba8(
 ) MLN_NOEXCEPT;
 
 /**
+ * Adds an image source that loads its image from a URL.
+ *
+ * source_id, coordinates, and url are borrowed for the call. coordinates must
+ * contain exactly four coordinates in top-left, top-right, bottom-right,
+ * bottom-left order. The function copies accepted strings and coordinates into
+ * the current style before return. Later URL load or decode failures are
+ * reported through runtime events.
+ *
+ * Image sources belong to the current style. Loading another style URL or JSON
+ * document drops sources that were added to the previous style.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id or url
+ *   is invalid or empty, coordinates is null or invalid, coordinate_count is
+ * not 4, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_image_source_url(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, mln_string_view url
+) MLN_NOEXCEPT;
+
+/**
+ * Adds an image source with inline image pixels.
+ *
+ * source_id, coordinates, image, and image pixels are borrowed for the call.
+ * coordinates must contain exactly four coordinates in top-left, top-right,
+ * bottom-right, bottom-left order. The function copies accepted coordinates and
+ * pixels into the current style before return.
+ *
+ * Image sources belong to the current style. Loading another style URL or JSON
+ * document drops sources that were added to the previous style.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, coordinates is null or invalid, coordinate_count is not
+ * 4, image is invalid, image pixels are null, image dimensions or stride are
+ *   invalid, image byte_length is too small, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_image_source_image(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, const mln_premultiplied_rgba8_image* image
+) MLN_NOEXCEPT;
+
+/**
+ * Updates an image source to load its image from a URL.
+ *
+ * source_id and url are borrowed for the call. Later URL load or decode
+ * failures are reported through runtime events.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id or url
+ *   is invalid or empty, the source does not exist, or the source is not an
+ *   image source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_image_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) MLN_NOEXCEPT;
+
+/**
+ * Updates an image source with inline image pixels.
+ *
+ * source_id, image, and image pixels are borrowed for the call. The function
+ * copies accepted pixels into MapLibre Native before return.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, image is invalid, image pixels are null, image dimensions
+ *   or stride are invalid, image byte_length is too small, the source does not
+ *   exist, or the source is not an image source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_image_source_image(
+  mln_map* map, mln_string_view source_id,
+  const mln_premultiplied_rgba8_image* image
+) MLN_NOEXCEPT;
+
+/**
+ * Updates image source coordinates.
+ *
+ * coordinates is borrowed for the call and must contain exactly four
+ * coordinates in top-left, top-right, bottom-right, bottom-left order. The
+ * function copies accepted coordinates into MapLibre Native before return.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, coordinates is null or invalid, coordinate_count is not
+ * 4, the source does not exist, or the source is not an image source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_image_source_coordinates(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count
+) MLN_NOEXCEPT;
+
+/**
+ * Copies image source coordinates.
+ *
+ * On success, out_found reports whether source_id exists. When found,
+ * out_coordinate_count receives 4. If coordinate_capacity is less than 4,
+ * out_coordinate_count still receives 4 and the function returns
+ * MLN_STATUS_INVALID_ARGUMENT.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, out_coordinates is null with non-zero capacity,
+ *   coordinate_capacity is too small for a found source, out_coordinate_count
+ * is null, out_found is null, or the source exists and is not an image source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_get_image_source_coordinates(
+  mln_map* map, mln_string_view source_id, mln_lat_lng* out_coordinates,
+  size_t coordinate_capacity, size_t* out_coordinate_count, bool* out_found
+) MLN_NOEXCEPT;
+
+/**
  * Adds one style layer from a full style-spec layer JSON object.
  *
  * layer_json and before_layer_id are borrowed for the call. layer_json must

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -309,6 +309,68 @@ auto mln_map_copy_style_image_premultiplied_rgba8(
   });
 }
 
+auto mln_map_add_image_source_url(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, mln_string_view url
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_image_source_url(
+      map, source_id, coordinates, coordinate_count, url
+    );
+  });
+}
+
+auto mln_map_add_image_source_image(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, const mln_premultiplied_rgba8_image* image
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_image_source_image(
+      map, source_id, coordinates, coordinate_count, image
+    );
+  });
+}
+
+auto mln_map_set_image_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_image_source_url(map, source_id, url);
+  });
+}
+
+auto mln_map_set_image_source_image(
+  mln_map* map, mln_string_view source_id,
+  const mln_premultiplied_rgba8_image* image
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_image_source_image(map, source_id, image);
+  });
+}
+
+auto mln_map_set_image_source_coordinates(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_image_source_coordinates(
+      map, source_id, coordinates, coordinate_count
+    );
+  });
+}
+
+auto mln_map_get_image_source_coordinates(
+  mln_map* map, mln_string_view source_id, mln_lat_lng* out_coordinates,
+  size_t coordinate_capacity, size_t* out_coordinate_count, bool* out_found
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_get_image_source_coordinates(
+      map, source_id, out_coordinates, coordinate_capacity,
+      out_coordinate_count, out_found
+    );
+  });
+}
+
 auto mln_map_add_style_layer_json(
   mln_map* map, const mln_json_value* layer_json,
   mln_string_view before_layer_id

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -40,6 +41,7 @@
 #include <mbgl/style/light.hpp>
 #include <mbgl/style/source.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/style/sources/image_source.hpp>
 #include <mbgl/style/sources/raster_source.hpp>
 #include <mbgl/style/sources/vector_source.hpp>
 #include <mbgl/style/style.hpp>
@@ -136,6 +138,11 @@ auto string_view_from_literal(const char* string) -> mln_string_view {
 }
 
 auto validate_lat_lng_bounds(mln_lat_lng_bounds bounds) -> mln_status;
+auto validate_lat_lng_array(
+  const mln_lat_lng* coordinates, size_t coordinate_count, bool allow_empty
+) -> mln_status;
+auto to_native_lat_lng(mln_lat_lng coordinate) -> mbgl::LatLng;
+auto from_native_lat_lng(const mbgl::LatLng& coordinate) -> mln_lat_lng;
 auto to_native_lat_lng_bounds(mln_lat_lng_bounds bounds) -> mbgl::LatLngBounds;
 
 auto to_c_source_type(mbgl::style::SourceType type) -> uint32_t {
@@ -614,6 +621,55 @@ auto style_image_info_from_native(const mbgl::style::Image& image)
     .pixel_ratio = image.getPixelRatio(),
     .sdf = image.isSdf()
   };
+}
+
+auto validate_image_source_coordinates(
+  const mln_lat_lng* coordinates, size_t coordinate_count
+) -> mln_status {
+  if (coordinate_count != 4) {
+    mln::core::set_thread_error("image source coordinate_count must be 4");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto status =
+    validate_lat_lng_array(coordinates, coordinate_count, false);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  const auto coordinate_span = std::span<const mln_lat_lng>{coordinates, 4};
+  const auto first = coordinate_span.front();
+  const auto all_same =
+    std::ranges::all_of(coordinate_span, [first](mln_lat_lng value) -> bool {
+      return value.latitude == first.latitude &&
+             value.longitude == first.longitude;
+    });
+  if (all_same) {
+    mln::core::set_thread_error("image source coordinates must not all match");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto to_native_image_source_coordinates(const mln_lat_lng* coordinates)
+  -> std::array<mbgl::LatLng, 4> {
+  auto result = std::array<mbgl::LatLng, 4>{};
+  const auto coordinate_span = std::span<const mln_lat_lng>{coordinates, 4};
+  auto index = size_t{0};
+  for (const auto coordinate : coordinate_span) {
+    result.at(index) = to_native_lat_lng(coordinate);
+    ++index;
+  }
+  return result;
+}
+
+auto from_native_image_source_coordinates(
+  const std::array<mbgl::LatLng, 4>& coordinates
+) -> std::array<mln_lat_lng, 4> {
+  auto result = std::array<mln_lat_lng, 4>{};
+  for (auto index = size_t{0}; index < result.size(); ++index) {
+    result.at(index) = from_native_lat_lng(coordinates.at(index));
+  }
+  return result;
 }
 
 auto create_style_id_list(
@@ -3272,6 +3328,236 @@ auto map_copy_style_image_premultiplied_rgba8(
   if (pixels.bytes() > 0) {
     std::copy_n(pixels.data.get(), pixels.bytes(), out_pixels);
   }
+  return MLN_STATUS_OK;
+}
+
+auto map_add_image_source_url(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, mln_string_view url
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto coordinate_status =
+    validate_image_source_coordinates(coordinates, coordinate_count);
+  if (coordinate_status != MLN_STATUS_OK) {
+    return coordinate_status;
+  }
+  if (!validate_string_view(url, "url")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (url.size == 0) {
+    set_thread_error("url must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  auto source = std::make_unique<mbgl::style::ImageSource>(
+    id, to_native_image_source_coordinates(coordinates)
+  );
+  source->setURL(string_from_view(url));
+  style.addSource(std::move(source));
+  return MLN_STATUS_OK;
+}
+
+auto map_add_image_source_image(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, const mln_premultiplied_rgba8_image* image
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto coordinate_status =
+    validate_image_source_coordinates(coordinates, coordinate_count);
+  if (coordinate_status != MLN_STATUS_OK) {
+    return coordinate_status;
+  }
+  const auto image_status = validate_premultiplied_rgba8_image(image);
+  if (image_status != MLN_STATUS_OK) {
+    return image_status;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  style.addSource(
+    std::make_unique<mbgl::style::ImageSource>(
+      id, to_native_image_source_coordinates(coordinates)
+    )
+  );
+  auto* added_source = style.getSource(id);
+  auto* image_source = added_source == nullptr
+                         ? nullptr
+                         : added_source->as<mbgl::style::ImageSource>();
+  if (image_source == nullptr) {
+    set_thread_error("added source is not an image source");
+    return MLN_STATUS_NATIVE_ERROR;
+  }
+  image_source->setImage(to_native_premultiplied_rgba8_image(*image));
+  return MLN_STATUS_OK;
+}
+
+auto map_set_image_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  if (!validate_string_view(url, "url")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (url.size == 0) {
+    set_thread_error("url must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  if (source == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* image_source = source->as<mbgl::style::ImageSource>();
+  if (image_source == nullptr) {
+    set_thread_error("source is not an image source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  image_source->setURL(string_from_view(url));
+  return MLN_STATUS_OK;
+}
+
+auto map_set_image_source_image(
+  mln_map* map, mln_string_view source_id,
+  const mln_premultiplied_rgba8_image* image
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto image_status = validate_premultiplied_rgba8_image(image);
+  if (image_status != MLN_STATUS_OK) {
+    return image_status;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  if (source == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* image_source = source->as<mbgl::style::ImageSource>();
+  if (image_source == nullptr) {
+    set_thread_error("source is not an image source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  image_source->setImage(to_native_premultiplied_rgba8_image(*image));
+  return MLN_STATUS_OK;
+}
+
+auto map_set_image_source_coordinates(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto coordinate_status =
+    validate_image_source_coordinates(coordinates, coordinate_count);
+  if (coordinate_status != MLN_STATUS_OK) {
+    return coordinate_status;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  if (source == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* image_source = source->as<mbgl::style::ImageSource>();
+  if (image_source == nullptr) {
+    set_thread_error("source is not an image source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  image_source->setCoordinates(to_native_image_source_coordinates(coordinates));
+  return MLN_STATUS_OK;
+}
+
+auto map_get_image_source_coordinates(
+  mln_map* map, mln_string_view source_id, mln_lat_lng* out_coordinates,
+  size_t coordinate_capacity, size_t* out_coordinate_count, bool* out_found
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  if (out_coordinates == nullptr && coordinate_capacity > 0) {
+    set_thread_error(
+      "out_coordinates must not be null when capacity is non-zero"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_coordinate_count == nullptr || out_found == nullptr) {
+    set_thread_error("out_coordinate_count and out_found must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  *out_found = source != nullptr;
+  *out_coordinate_count = 0;
+  if (source == nullptr) {
+    return MLN_STATUS_OK;
+  }
+  auto* image_source = source->as<mbgl::style::ImageSource>();
+  if (image_source == nullptr) {
+    set_thread_error("source is not an image source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  constexpr auto image_source_coordinate_count = size_t{4};
+  *out_coordinate_count = image_source_coordinate_count;
+  if (coordinate_capacity < image_source_coordinate_count) {
+    set_thread_error("coordinate_capacity is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto coordinates =
+    from_native_image_source_coordinates(image_source->getCoordinates());
+  auto output = std::span<mln_lat_lng>{out_coordinates, coordinate_capacity};
+  std::ranges::copy(coordinates, output.begin());
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -3400,6 +3400,7 @@ auto map_add_image_source_image(
     return add_status;
   }
 
+  auto native_image = to_native_premultiplied_rgba8_image(*image);
   style.addSource(
     std::make_unique<mbgl::style::ImageSource>(
       id, to_native_image_source_coordinates(coordinates)
@@ -3413,7 +3414,7 @@ auto map_add_image_source_image(
     set_thread_error("added source is not an image source");
     return MLN_STATUS_NATIVE_ERROR;
   }
-  image_source->setImage(to_native_premultiplied_rgba8_image(*image));
+  image_source->setImage(std::move(native_image));
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -114,6 +114,29 @@ auto map_copy_style_image_premultiplied_rgba8(
   mln_map* map, mln_string_view image_id, uint8_t* out_pixels,
   size_t pixel_capacity, size_t* out_byte_length, bool* out_found
 ) -> mln_status;
+auto map_add_image_source_url(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, mln_string_view url
+) -> mln_status;
+auto map_add_image_source_image(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count, const mln_premultiplied_rgba8_image* image
+) -> mln_status;
+auto map_set_image_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url
+) -> mln_status;
+auto map_set_image_source_image(
+  mln_map* map, mln_string_view source_id,
+  const mln_premultiplied_rgba8_image* image
+) -> mln_status;
+auto map_set_image_source_coordinates(
+  mln_map* map, mln_string_view source_id, const mln_lat_lng* coordinates,
+  size_t coordinate_count
+) -> mln_status;
+auto map_get_image_source_coordinates(
+  mln_map* map, mln_string_view source_id, mln_lat_lng* out_coordinates,
+  size_t coordinate_capacity, size_t* out_coordinate_count, bool* out_found
+) -> mln_status;
 auto map_add_style_layer_json(
   mln_map* map, const mln_json_value* layer_json,
   mln_string_view before_layer_id

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -615,3 +615,111 @@ test "runtime style images copy premultiplied RGBA8 pixels" {
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_remove_style_image(map, stringView("runtime-icon"), &removed));
     try testing.expect(!removed);
 }
+
+test "image source helpers add and update URL and inline images" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
+
+    var coordinates = [_]c.mln_lat_lng{
+        .{ .latitude = 38.0, .longitude = -123.0 },
+        .{ .latitude = 38.0, .longitude = -122.0 },
+        .{ .latitude = 37.0, .longitude = -122.0 },
+        .{ .latitude = 37.0, .longitude = -123.0 },
+    };
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_image_source_url(map, stringView("image-url-source"), &coordinates, coordinates.len, stringView("https://example.com/image.png")),
+    );
+
+    var found = false;
+    var source_type: u32 = c.MLN_STYLE_SOURCE_TYPE_UNKNOWN;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_style_source_type(map, stringView("image-url-source"), &source_type, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_IMAGE, source_type);
+
+    var required_coordinates: usize = 0;
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_get_image_source_coordinates(map, stringView("image-url-source"), null, 0, &required_coordinates, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(@as(usize, 4), required_coordinates);
+
+    var copied_coordinates: [4]c.mln_lat_lng = undefined;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_image_source_coordinates(map, stringView("image-url-source"), &copied_coordinates, copied_coordinates.len, &required_coordinates, &found),
+    );
+    try testing.expect(found);
+    try testing.expectEqual(@as(usize, 4), required_coordinates);
+    try testing.expectApproxEqAbs(coordinates[0].latitude, copied_coordinates[0].latitude, 0.000001);
+    try testing.expectApproxEqAbs(coordinates[0].longitude, copied_coordinates[0].longitude, 0.000001);
+
+    var image_pixels = [_]u8{ 1, 2, 3, 4 };
+    var image = c.mln_premultiplied_rgba8_image_default();
+    image.width = 1;
+    image.height = 1;
+    image.stride = 4;
+    image.pixels = &image_pixels;
+    image.byte_length = image_pixels.len;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_image_source_image(map, stringView("image-inline-source"), &coordinates, coordinates.len, &image),
+    );
+    image_pixels[0] = 9;
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_set_image_source_url(map, stringView("image-inline-source"), stringView("https://example.com/replacement.png")),
+    );
+    image_pixels[0] = 5;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_image_source_image(map, stringView("image-inline-source"), &image));
+
+    const updated_coordinates = [_]c.mln_lat_lng{
+        .{ .latitude = 39.0, .longitude = -124.0 },
+        .{ .latitude = 39.0, .longitude = -121.0 },
+        .{ .latitude = 36.0, .longitude = -121.0 },
+        .{ .latitude = 36.0, .longitude = -124.0 },
+    };
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_set_image_source_coordinates(map, stringView("image-inline-source"), &updated_coordinates, updated_coordinates.len),
+    );
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_image_source_coordinates(map, stringView("image-inline-source"), &copied_coordinates, copied_coordinates.len, &required_coordinates, &found),
+    );
+    try testing.expect(found);
+    try testing.expectApproxEqAbs(updated_coordinates[0].latitude, copied_coordinates[0].latitude, 0.000001);
+    try testing.expectApproxEqAbs(updated_coordinates[0].longitude, copied_coordinates[0].longitude, 0.000001);
+
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_get_image_source_coordinates(map, stringView("missing-image-source"), &copied_coordinates, copied_coordinates.len, &required_coordinates, &found),
+    );
+    try testing.expect(!found);
+    try testing.expectEqual(@as(usize, 0), required_coordinates);
+
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_add_image_source_url(map, stringView("image-url-source"), &coordinates, coordinates.len, stringView("https://example.com/duplicate.png")),
+    );
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_set_image_source_url(map, stringView("point"), stringView("https://example.com/not-image.png")),
+    );
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_set_image_source_coordinates(map, stringView("image-url-source"), &coordinates, 3),
+    );
+}


### PR DESCRIPTION
## Summary
- Add image source creation from URL or premultiplied RGBA8 pixels.
- Add image source URL, image, and coordinate mutation plus coordinate readback.
- Cover source type, coordinate probing, replacement, missing source, duplicate source, and non-image errors through C API tests.

## Issue
resolves #36

## Testing
- mise run test