### PR TITLE
Add raster DEM and relief APIs

### DIFF
--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -46,6 +46,7 @@ typedef enum mln_style_tile_source_option_field : uint32_t {
   MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS = 1U << 4U,
   MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE = 1U << 5U,
   MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING = 1U << 6U,
+  MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING = 1U << 7U,
 } mln_style_tile_source_option_field;
 
 /** Tile URL coordinate scheme values used by mln_style_tile_source_options. */
@@ -59,6 +60,12 @@ typedef enum mln_style_vector_tile_encoding : uint32_t {
   MLN_STYLE_VECTOR_TILE_ENCODING_MVT = 0,
   MLN_STYLE_VECTOR_TILE_ENCODING_MLT = 1,
 } mln_style_vector_tile_encoding;
+
+/** DEM raster encoding values used by mln_style_tile_source_options. */
+typedef enum mln_style_raster_dem_encoding : uint32_t {
+  MLN_STYLE_RASTER_DEM_ENCODING_MAPBOX = 0,
+  MLN_STYLE_RASTER_DEM_ENCODING_TERRARIUM = 1,
+} mln_style_raster_dem_encoding;
 
 /** Field mask values for mln_style_image_options. */
 typedef enum mln_style_image_option_field : uint32_t {
@@ -93,6 +100,8 @@ typedef struct mln_style_tile_source_options {
   uint32_t tile_size;
   /** One of mln_style_vector_tile_encoding. Defaults to MVT. */
   uint32_t vector_encoding;
+  /** One of mln_style_raster_dem_encoding. Defaults to Mapbox. */
+  uint32_t raster_encoding;
 } mln_style_tile_source_options;
 
 /** Caller-owned premultiplied RGBA8 image pixels. */
@@ -469,6 +478,47 @@ MLN_API mln_status mln_map_add_raster_source_tiles(
 ) MLN_NOEXCEPT;
 
 /**
+ * Adds a raster DEM source with a TileJSON URL.
+ *
+ * source_id and url are borrowed for the call. options may be null for
+ * defaults. For URL sources, tile_size and raster_encoding are used when their
+ * field bits are set.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id or url
+ *   is invalid or empty, options is invalid, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_raster_dem_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a raster DEM source with inline tile URLs.
+ *
+ * source_id and tile URL views are borrowed for the call. The function copies
+ * accepted strings into MapLibre Native before return. options may be null for
+ * defaults.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, tile URLs are null, empty, or invalid, options is
+ * invalid, or the source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_raster_dem_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) MLN_NOEXCEPT;
+
+/**
  * Sets one runtime style image.
  *
  * image_id, image, and image pixels are borrowed for the call. The function
@@ -705,6 +755,51 @@ MLN_API mln_status mln_map_set_image_source_coordinates(
 MLN_API mln_status mln_map_get_image_source_coordinates(
   mln_map* map, mln_string_view source_id, mln_lat_lng* out_coordinates,
   size_t coordinate_capacity, size_t* out_coordinate_count, bool* out_found
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a hillshade layer for a raster DEM source.
+ *
+ * layer_id, source_id, and before_layer_id are borrowed for the call. Passing
+ * an empty before_layer_id appends the layer; otherwise the layer is inserted
+ * before that existing layer.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id or
+ *   source_id is invalid or empty, before_layer_id is invalid or does not
+ * exist, layer_id already exists, source_id does not exist, or source_id is not
+ * a raster DEM source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_hillshade_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view source_id,
+  mln_string_view before_layer_id
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a color-relief layer for a raster DEM source.
+ *
+ * layer_id, source_id, and before_layer_id are borrowed for the call. Passing
+ * an empty before_layer_id appends the layer; otherwise the layer is inserted
+ * before that existing layer. Use mln_map_set_layer_property() with
+ * color-relief-color to set the color ramp expression.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id or
+ *   source_id is invalid or empty, before_layer_id is invalid or does not
+ * exist, layer_id already exists, source_id does not exist, or source_id is not
+ * a raster DEM source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_color_relief_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view source_id,
+  mln_string_view before_layer_id
 ) MLN_NOEXCEPT;
 
 /**

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -261,6 +261,28 @@ auto mln_map_add_raster_source_tiles(
   });
 }
 
+auto mln_map_add_raster_dem_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_raster_dem_source_url(
+      map, source_id, url, options
+    );
+  });
+}
+
+auto mln_map_add_raster_dem_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_raster_dem_source_tiles(
+      map, source_id, tiles, tile_count, options
+    );
+  });
+}
+
 auto mln_map_set_style_image(
   mln_map* map, mln_string_view image_id,
   const mln_premultiplied_rgba8_image* image,
@@ -367,6 +389,28 @@ auto mln_map_get_image_source_coordinates(
     return mln::core::map_get_image_source_coordinates(
       map, source_id, out_coordinates, coordinate_capacity,
       out_coordinate_count, out_found
+    );
+  });
+}
+
+auto mln_map_add_hillshade_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view source_id,
+  mln_string_view before_layer_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_hillshade_layer(
+      map, layer_id, source_id, before_layer_id
+    );
+  });
+}
+
+auto mln_map_add_color_relief_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view source_id,
+  mln_string_view before_layer_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_color_relief_layer(
+      map, layer_id, source_id, before_layer_id
     );
   });
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -38,10 +38,13 @@
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/style/image.hpp>
 #include <mbgl/style/layer.hpp>
+#include <mbgl/style/layers/color_relief_layer.hpp>
+#include <mbgl/style/layers/hillshade_layer.hpp>
 #include <mbgl/style/light.hpp>
 #include <mbgl/style/source.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/style/sources/image_source.hpp>
+#include <mbgl/style/sources/raster_dem_source.hpp>
 #include <mbgl/style/sources/raster_source.hpp>
 #include <mbgl/style/sources/vector_source.hpp>
 #include <mbgl/style/style.hpp>
@@ -78,6 +81,8 @@ using ProjectionRegistry =
   std::unordered_map<mln_map_projection*, std::unique_ptr<mln_map_projection>>;
 using StyleIdListRegistry = std::unordered_map<
   const mln_style_id_list*, std::unique_ptr<mln_style_id_list>>;
+
+enum class TileSourceOptionKind : uint8_t { Vector, Raster, RasterDEM };
 
 constexpr auto default_map_width = uint32_t{256};
 constexpr auto default_map_height = uint32_t{256};
@@ -198,7 +203,8 @@ auto validate_tile_source_option_header(
     MLN_STYLE_TILE_SOURCE_OPTION_ATTRIBUTION |
     MLN_STYLE_TILE_SOURCE_OPTION_SCHEME | MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS |
     MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE |
-    MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING;
+    MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING |
+    MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING;
   if ((options.fields & ~known_fields) != 0U) {
     mln::core::set_thread_error(
       "mln_style_tile_source_options.fields contains unknown bits"
@@ -307,8 +313,55 @@ auto validate_tile_source_vector_encoding_option(
   }
 }
 
-auto validate_tile_source_options(const mln_style_tile_source_options* options)
-  -> mln_status {
+auto validate_tile_source_raster_encoding_option(
+  const mln_style_tile_source_options& options
+) -> mln_status {
+  if (!has_tile_source_option(
+        options, MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING
+      )) {
+    return MLN_STATUS_OK;
+  }
+  switch (options.raster_encoding) {
+    case MLN_STYLE_RASTER_DEM_ENCODING_MAPBOX:
+    case MLN_STYLE_RASTER_DEM_ENCODING_TERRARIUM:
+      return MLN_STATUS_OK;
+    default:
+      mln::core::set_thread_error("raster_encoding is invalid");
+      return MLN_STATUS_INVALID_ARGUMENT;
+  }
+}
+
+auto validate_tile_source_option_kind(
+  const mln_style_tile_source_options& options, TileSourceOptionKind kind
+) -> mln_status {
+  if (
+    kind != TileSourceOptionKind::Vector &&
+    has_tile_source_option(
+      options, MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING
+    )
+  ) {
+    mln::core::set_thread_error(
+      "vector_encoding is only valid for vector sources"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    kind != TileSourceOptionKind::RasterDEM &&
+    has_tile_source_option(
+      options, MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING
+    )
+  ) {
+    mln::core::set_thread_error(
+      "raster_encoding is only valid for raster DEM sources"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_tile_source_options(
+  const mln_style_tile_source_options* options, TileSourceOptionKind kind
+) -> mln_status {
   if (options == nullptr) {
     return MLN_STATUS_OK;
   }
@@ -320,13 +373,14 @@ auto validate_tile_source_options(const mln_style_tile_source_options* options)
          validate_tile_source_bounds_option,
          validate_tile_source_tile_size_option,
          validate_tile_source_vector_encoding_option,
+         validate_tile_source_raster_encoding_option,
        }) {
     const auto status = validator(*options);
     if (status != MLN_STATUS_OK) {
       return status;
     }
   }
-  return MLN_STATUS_OK;
+  return validate_tile_source_option_kind(*options, kind);
 }
 
 auto effective_tile_source_options(const mln_style_tile_source_options* options)
@@ -366,6 +420,13 @@ auto effective_tile_source_options(const mln_style_tile_source_options* options)
   ) {
     result.vector_encoding = options->vector_encoding;
   }
+  if (
+    has_tile_source_option(
+      *options, MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING
+    )
+  ) {
+    result.raster_encoding = options->raster_encoding;
+  }
   return result;
 }
 
@@ -379,6 +440,13 @@ auto to_native_vector_encoding(uint32_t encoding)
   return encoding == MLN_STYLE_VECTOR_TILE_ENCODING_MLT
            ? mbgl::Tileset::VectorEncoding::MLT
            : mbgl::Tileset::VectorEncoding::Mapbox;
+}
+
+auto to_native_raster_encoding(uint32_t encoding)
+  -> mbgl::Tileset::RasterEncoding {
+  return encoding == MLN_STYLE_RASTER_DEM_ENCODING_TERRARIUM
+           ? mbgl::Tileset::RasterEncoding::Terrarium
+           : mbgl::Tileset::RasterEncoding::Mapbox;
 }
 
 auto validate_tile_urls(const mln_string_view* tiles, size_t tile_count)
@@ -2258,7 +2326,8 @@ auto style_tile_source_options_default() noexcept
       {.southwest = {.latitude = 0, .longitude = 0},
        .northeast = {.latitude = 0, .longitude = 0}},
     .tile_size = mbgl::util::tileSize_I,
-    .vector_encoding = MLN_STYLE_VECTOR_TILE_ENCODING_MVT
+    .vector_encoding = MLN_STYLE_VECTOR_TILE_ENCODING_MVT,
+    .raster_encoding = MLN_STYLE_RASTER_DEM_ENCODING_MAPBOX
   };
 }
 
@@ -3016,7 +3085,8 @@ auto map_add_vector_source_url(
     set_thread_error("url must not be empty");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  const auto options_status = validate_tile_source_options(options);
+  const auto options_status =
+    validate_tile_source_options(options, TileSourceOptionKind::Vector);
   if (options_status != MLN_STATUS_OK) {
     return options_status;
   }
@@ -3079,7 +3149,8 @@ auto map_add_vector_source_tiles(
   if (tiles_status != MLN_STATUS_OK) {
     return tiles_status;
   }
-  const auto options_status = validate_tile_source_options(options);
+  const auto options_status =
+    validate_tile_source_options(options, TileSourceOptionKind::Vector);
   if (options_status != MLN_STATUS_OK) {
     return options_status;
   }
@@ -3124,7 +3195,8 @@ auto map_add_raster_source_url(
     set_thread_error("url must not be empty");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  const auto options_status = validate_tile_source_options(options);
+  const auto options_status =
+    validate_tile_source_options(options, TileSourceOptionKind::Raster);
   if (options_status != MLN_STATUS_OK) {
     return options_status;
   }
@@ -3161,7 +3233,8 @@ auto map_add_raster_source_tiles(
   if (tiles_status != MLN_STATUS_OK) {
     return tiles_status;
   }
-  const auto options_status = validate_tile_source_options(options);
+  const auto options_status =
+    validate_tile_source_options(options, TileSourceOptionKind::Raster);
   if (options_status != MLN_STATUS_OK) {
     return options_status;
   }
@@ -3180,6 +3253,108 @@ auto map_add_raster_source_tiles(
   }
   style.addSource(
     std::make_unique<mbgl::style::RasterSource>(
+      id, *tileset, static_cast<uint16_t>(effective.tile_size)
+    )
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_add_raster_dem_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  if (!validate_string_view(url, "url")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (url.size == 0) {
+    set_thread_error("url must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto options_status =
+    validate_tile_source_options(options, TileSourceOptionKind::RasterDEM);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  const auto effective = effective_tile_source_options(options);
+  auto source_options = std::optional<mbgl::style::SourceOptions>{};
+  if (
+    has_tile_source_option(
+      effective, MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING
+    )
+  ) {
+    source_options = mbgl::style::SourceOptions{
+      .rasterEncoding = to_native_raster_encoding(effective.raster_encoding)
+    };
+  }
+  style.addSource(
+    std::make_unique<mbgl::style::RasterDEMSource>(
+      id, string_from_view(url), static_cast<uint16_t>(effective.tile_size),
+      source_options
+    )
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_add_raster_dem_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto tiles_status = validate_tile_urls(tiles, tile_count);
+  if (tiles_status != MLN_STATUS_OK) {
+    return tiles_status;
+  }
+  const auto options_status =
+    validate_tile_source_options(options, TileSourceOptionKind::RasterDEM);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  const auto effective = effective_tile_source_options(options);
+  auto tileset = to_native_tileset(tiles, tile_count, effective, false);
+  if (!tileset) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    has_tile_source_option(
+      effective, MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING
+    )
+  ) {
+    tileset->rasterEncoding =
+      to_native_raster_encoding(effective.raster_encoding);
+  }
+  style.addSource(
+    std::make_unique<mbgl::style::RasterDEMSource>(
       id, *tileset, static_cast<uint16_t>(effective.tile_size)
     )
   );
@@ -3559,6 +3734,108 @@ auto map_get_image_source_coordinates(
     from_native_image_source_coordinates(image_source->getCoordinates());
   auto output = std::span<mln_lat_lng>{out_coordinates, coordinate_capacity};
   std::ranges::copy(coordinates, output.begin());
+  return MLN_STATUS_OK;
+}
+
+auto map_add_hillshade_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view source_id,
+  mln_string_view before_layer_id
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (
+    !validate_string_view(layer_id, "layer_id") ||
+    !validate_string_view(source_id, "source_id") ||
+    !validate_string_view(before_layer_id, "before_layer_id")
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0 || source_id.size == 0) {
+    set_thread_error("layer_id and source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto layer = string_from_view(layer_id);
+  const auto source = string_from_view(source_id);
+  if (style.getLayer(layer) != nullptr) {
+    set_thread_error("layer already exists");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* source_ptr = style.getSource(source);
+  if (source_ptr == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!source_ptr->is<mbgl::style::RasterDEMSource>()) {
+    set_thread_error("source is not a raster DEM source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto before = std::optional<std::string>{};
+  if (before_layer_id.size > 0) {
+    before = string_from_view(before_layer_id);
+    if (style.getLayer(*before) == nullptr) {
+      set_thread_error("before_layer_id does not exist");
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  style.addLayer(
+    std::make_unique<mbgl::style::HillshadeLayer>(layer, source), before
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_add_color_relief_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view source_id,
+  mln_string_view before_layer_id
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (
+    !validate_string_view(layer_id, "layer_id") ||
+    !validate_string_view(source_id, "source_id") ||
+    !validate_string_view(before_layer_id, "before_layer_id")
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0 || source_id.size == 0) {
+    set_thread_error("layer_id and source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto layer = string_from_view(layer_id);
+  const auto source = string_from_view(source_id);
+  if (style.getLayer(layer) != nullptr) {
+    set_thread_error("layer already exists");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* source_ptr = style.getSource(source);
+  if (source_ptr == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!source_ptr->is<mbgl::style::RasterDEMSource>()) {
+    set_thread_error("source is not a raster DEM source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto before = std::optional<std::string>{};
+  if (before_layer_id.size > 0) {
+    before = string_from_view(before_layer_id);
+    if (style.getLayer(*before) == nullptr) {
+      set_thread_error("before_layer_id does not exist");
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  style.addLayer(
+    std::make_unique<mbgl::style::ColorReliefLayer>(layer, source), before
+  );
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -95,6 +95,14 @@ auto map_add_raster_source_tiles(
   mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
   size_t tile_count, const mln_style_tile_source_options* options
 ) -> mln_status;
+auto map_add_raster_dem_source_url(
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_style_tile_source_options* options
+) -> mln_status;
+auto map_add_raster_dem_source_tiles(
+  mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
+  size_t tile_count, const mln_style_tile_source_options* options
+) -> mln_status;
 auto map_set_style_image(
   mln_map* map, mln_string_view image_id,
   const mln_premultiplied_rgba8_image* image,
@@ -136,6 +144,14 @@ auto map_set_image_source_coordinates(
 auto map_get_image_source_coordinates(
   mln_map* map, mln_string_view source_id, mln_lat_lng* out_coordinates,
   size_t coordinate_capacity, size_t* out_coordinate_count, bool* out_found
+) -> mln_status;
+auto map_add_hillshade_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view source_id,
+  mln_string_view before_layer_id
+) -> mln_status;
+auto map_add_color_relief_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view source_id,
+  mln_string_view before_layer_id
 ) -> mln_status;
 auto map_add_style_layer_json(
   mln_map* map, const mln_json_value* layer_json,

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -723,3 +723,87 @@ test "image source helpers add and update URL and inline images" {
         c.mln_map_set_image_source_coordinates(map, stringView("image-url-source"), &coordinates, 3),
     );
 }
+
+test "raster DEM sources support hillshade and color relief layers" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
+
+    var options = c.mln_style_tile_source_options_default();
+    options.fields = c.MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM |
+        c.MLN_STYLE_TILE_SOURCE_OPTION_MAX_ZOOM |
+        c.MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE |
+        c.MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING;
+    options.min_zoom = 0.0;
+    options.max_zoom = 14.0;
+    options.tile_size = 256;
+    options.raster_encoding = c.MLN_STYLE_RASTER_DEM_ENCODING_TERRARIUM;
+    const dem_tiles = [_]c.mln_string_view{stringView("https://example.com/dem/{z}/{x}/{y}.png")};
+
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_raster_dem_source_tiles(map, stringView("dem"), &dem_tiles, dem_tiles.len, &options),
+    );
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_add_raster_dem_source_url(map, stringView("dem-url"), stringView("https://example.com/dem.json"), &options),
+    );
+
+    var found = false;
+    var source_type: u32 = c.MLN_STYLE_SOURCE_TYPE_UNKNOWN;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_source_type(map, stringView("dem"), &source_type, &found));
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_RASTER_DEM, source_type);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_add_hillshade_layer(map, stringView("dem-hillshade"), stringView("dem"), stringView("point-circle")));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_add_color_relief_layer(map, stringView("dem-relief"), stringView("dem"), stringView("")));
+
+    var layer_type: c.mln_string_view = .{ .data = null, .size = 0 };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_layer_type(map, stringView("dem-hillshade"), &layer_type, &found));
+    try testing.expect(found);
+    try testing.expect(std.mem.eql(u8, viewBytes(layer_type), "hillshade"));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_layer_type(map, stringView("dem-relief"), &layer_type, &found));
+    try testing.expect(found);
+    try testing.expect(std.mem.eql(u8, viewBytes(layer_type), "color-relief"));
+
+    const interpolation = [_]c.mln_json_value{jsonString("linear")};
+    const linear = jsonArray(&interpolation);
+    const elevation = [_]c.mln_json_value{jsonString("elevation")};
+    const elevation_expr = jsonArray(&elevation);
+    const color_values = [_]c.mln_json_value{
+        jsonString("interpolate"), linear,              elevation_expr,
+        jsonDouble(0.0),           jsonString("black"), jsonDouble(1000.0),
+        jsonString("white"),
+    };
+    const color_ramp = jsonArray(&color_values);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_layer_property(map, stringView("dem-relief"), stringView("color-relief-color"), &color_ramp));
+
+    const zoom = [_]c.mln_json_value{jsonString("zoom")};
+    const zoom_expr = jsonArray(&zoom);
+    const invalid_color_values = [_]c.mln_json_value{
+        jsonString("interpolate"), linear,              zoom_expr,
+        jsonDouble(0.0),           jsonString("black"), jsonDouble(1.0),
+        jsonString("white"),
+    };
+    const invalid_color_ramp = jsonArray(&invalid_color_values);
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_layer_property(map, stringView("dem-relief"), stringView("color-relief-color"), &invalid_color_ramp));
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_add_hillshade_layer(map, stringView("bad-hillshade"), stringView("point"), stringView("")));
+    options.raster_encoding = 99;
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_add_raster_dem_source_url(map, stringView("bad-dem"), stringView("https://example.com/bad.json"), &options),
+    );
+    options.raster_encoding = c.MLN_STYLE_RASTER_DEM_ENCODING_MAPBOX;
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_add_raster_source_tiles(map, stringView("bad-raster"), &dem_tiles, dem_tiles.len, &options),
+    );
+}


### PR DESCRIPTION
## Summary
- Add raster DEM source helpers with DEM raster encoding validation.
- Add hillshade and color-relief layer helpers that require raster DEM sources.
- Cover color-relief ramp conversion through the existing generic layer property API.

## Issue
resolves #35

## Testing
- mise run test