### PR TITLE
Add location indicator APIs

### DIFF
--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -73,6 +73,13 @@ typedef enum mln_style_image_option_field : uint32_t {
   MLN_STYLE_IMAGE_OPTION_SDF = 1U << 1U,
 } mln_style_image_option_field;
 
+/** Location indicator image-name properties. */
+typedef enum mln_location_indicator_image_kind : uint32_t {
+  MLN_LOCATION_INDICATOR_IMAGE_KIND_TOP = 0,
+  MLN_LOCATION_INDICATOR_IMAGE_KIND_BEARING = 1,
+  MLN_LOCATION_INDICATOR_IMAGE_KIND_SHADOW = 2,
+} mln_location_indicator_image_kind;
+
 /** Fixed source metadata returned by mln_map_get_style_source_info(). */
 typedef struct mln_style_source_info {
   uint32_t size;
@@ -800,6 +807,98 @@ MLN_API mln_status mln_map_add_hillshade_layer(
 MLN_API mln_status mln_map_add_color_relief_layer(
   mln_map* map, mln_string_view layer_id, mln_string_view source_id,
   mln_string_view before_layer_id
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a source-free location indicator layer.
+ *
+ * layer_id and before_layer_id are borrowed for the call. Passing an empty
+ * before_layer_id appends the layer; otherwise the layer is inserted before
+ * that existing layer.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, before_layer_id is invalid or does not exist, or layer_id
+ *   already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_location_indicator_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view before_layer_id
+) MLN_NOEXCEPT;
+
+/**
+ * Sets a location indicator layer location.
+ *
+ * coordinate uses normal C API latitude/longitude order. The underlying style
+ * property is written as [longitude, latitude, altitude].
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, coordinate or altitude is invalid, the layer does not
+ *   exist, or the layer is not a location indicator layer.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_location_indicator_location(
+  mln_map* map, mln_string_view layer_id, mln_lat_lng coordinate,
+  double altitude
+) MLN_NOEXCEPT;
+
+/**
+ * Sets a location indicator layer bearing in degrees.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, bearing is not finite float32, the layer does not exist,
+ *   or the layer is not a location indicator layer.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_location_indicator_bearing(
+  mln_map* map, mln_string_view layer_id, double bearing
+) MLN_NOEXCEPT;
+
+/**
+ * Sets a location indicator layer accuracy radius in logical pixels.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id is
+ *   invalid or empty, radius is negative or not finite float32, the layer does
+ *   not exist, or the layer is not a location indicator layer.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_location_indicator_accuracy_radius(
+  mln_map* map, mln_string_view layer_id, double radius
+) MLN_NOEXCEPT;
+
+/**
+ * Sets one location indicator image-name property.
+ *
+ * image_id is borrowed for the call and copied into native style storage. The
+ * named style image does not need to exist when this function is called.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, layer_id or
+ *   image_id is invalid or empty, image_kind is invalid, the layer does not
+ *   exist, or the layer is not a location indicator layer.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_location_indicator_image_name(
+  mln_map* map, mln_string_view layer_id, uint32_t image_kind,
+  mln_string_view image_id
 ) MLN_NOEXCEPT;
 
 /**

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -415,6 +415,58 @@ auto mln_map_add_color_relief_layer(
   });
 }
 
+auto mln_map_add_location_indicator_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view before_layer_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_location_indicator_layer(
+      map, layer_id, before_layer_id
+    );
+  });
+}
+
+auto mln_map_set_location_indicator_location(
+  mln_map* map, mln_string_view layer_id, mln_lat_lng coordinate,
+  double altitude
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_location_indicator_location(
+      map, layer_id, coordinate, altitude
+    );
+  });
+}
+
+auto mln_map_set_location_indicator_bearing(
+  mln_map* map, mln_string_view layer_id, double bearing
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_location_indicator_bearing(
+      map, layer_id, bearing
+    );
+  });
+}
+
+auto mln_map_set_location_indicator_accuracy_radius(
+  mln_map* map, mln_string_view layer_id, double radius
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_location_indicator_accuracy_radius(
+      map, layer_id, radius
+    );
+  });
+}
+
+auto mln_map_set_location_indicator_image_name(
+  mln_map* map, mln_string_view layer_id, uint32_t image_kind,
+  mln_string_view image_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_location_indicator_image_name(
+      map, layer_id, image_kind, image_id
+    );
+  });
+}
+
 auto mln_map_add_style_layer_json(
   mln_map* map, const mln_json_value* layer_json,
   mln_string_view before_layer_id

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -40,6 +40,7 @@
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/layers/color_relief_layer.hpp>
 #include <mbgl/style/layers/hillshade_layer.hpp>
+#include <mbgl/style/layers/location_indicator_layer.hpp>
 #include <mbgl/style/light.hpp>
 #include <mbgl/style/source.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
@@ -3837,6 +3838,227 @@ auto map_add_color_relief_layer(
     std::make_unique<mbgl::style::ColorReliefLayer>(layer, source), before
   );
   return MLN_STATUS_OK;
+}
+
+auto map_add_location_indicator_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view before_layer_id
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (
+    !validate_string_view(layer_id, "layer_id") ||
+    !validate_string_view(before_layer_id, "before_layer_id")
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0) {
+    set_thread_error("layer_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto layer = string_from_view(layer_id);
+  if (style.getLayer(layer) != nullptr) {
+    set_thread_error("layer already exists");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto before = std::optional<std::string>{};
+  if (before_layer_id.size > 0) {
+    before = string_from_view(before_layer_id);
+    if (style.getLayer(*before) == nullptr) {
+      set_thread_error("before_layer_id does not exist");
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  style.addLayer(
+    std::make_unique<mbgl::style::LocationIndicatorLayer>(layer), before
+  );
+  return MLN_STATUS_OK;
+}
+
+auto validate_location_indicator_layer(mln_map* map, mln_string_view layer_id)
+  -> mln_status {
+  if (!validate_string_view(layer_id, "layer_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (layer_id.size == 0) {
+    set_thread_error("layer_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto* layer = map->map->getStyle().getLayer(string_from_view(layer_id));
+  if (layer == nullptr) {
+    set_thread_error("layer does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (std::strcmp(layer->getTypeInfo()->type, "location-indicator") != 0) {
+    set_thread_error("layer is not a location indicator layer");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_float64_to_float32(double value, const char* name) -> mln_status {
+  if (
+    !std::isfinite(value) || value < -std::numeric_limits<float>::max() ||
+    value > std::numeric_limits<float>::max()
+  ) {
+    const auto message = std::string{name} + " must fit in finite float32";
+    set_thread_error(message.c_str());
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto map_set_location_indicator_location(
+  mln_map* map, mln_string_view layer_id, mln_lat_lng coordinate,
+  double altitude
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto layer_status = validate_location_indicator_layer(map, layer_id);
+  if (layer_status != MLN_STATUS_OK) {
+    return layer_status;
+  }
+  const auto coordinate_status = validate_lat_lng(coordinate);
+  if (coordinate_status != MLN_STATUS_OK) {
+    return coordinate_status;
+  }
+  if (!std::isfinite(altitude)) {
+    set_thread_error("altitude must be finite");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto values = std::array<mln_json_value, 3>{
+    mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_DOUBLE,
+      .data = {.double_value = coordinate.longitude}
+    },
+    mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_DOUBLE,
+      .data = {.double_value = coordinate.latitude}
+    },
+    mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_DOUBLE,
+      .data = {.double_value = altitude}
+    },
+  };
+  auto location = mln_json_value{
+    .size = sizeof(mln_json_value),
+    .type = MLN_JSON_VALUE_TYPE_ARRAY,
+    .data = {
+      .array_value = {.values = values.data(), .value_count = values.size()}
+    }
+  };
+  return map_set_layer_property(
+    map, layer_id, string_view_from_literal("location"), &location
+  );
+}
+
+auto map_set_location_indicator_bearing(
+  mln_map* map, mln_string_view layer_id, double bearing
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto layer_status = validate_location_indicator_layer(map, layer_id);
+  if (layer_status != MLN_STATUS_OK) {
+    return layer_status;
+  }
+  const auto bearing_status = validate_float64_to_float32(bearing, "bearing");
+  if (bearing_status != MLN_STATUS_OK) {
+    return bearing_status;
+  }
+  auto value = mln_json_value{
+    .size = sizeof(mln_json_value),
+    .type = MLN_JSON_VALUE_TYPE_DOUBLE,
+    .data = {.double_value = bearing}
+  };
+  return map_set_layer_property(
+    map, layer_id, string_view_from_literal("bearing"), &value
+  );
+}
+
+auto map_set_location_indicator_accuracy_radius(
+  mln_map* map, mln_string_view layer_id, double radius
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto layer_status = validate_location_indicator_layer(map, layer_id);
+  if (layer_status != MLN_STATUS_OK) {
+    return layer_status;
+  }
+  const auto radius_status = validate_float64_to_float32(radius, "radius");
+  if (radius_status != MLN_STATUS_OK) {
+    return radius_status;
+  }
+  if (radius < 0.0) {
+    set_thread_error("radius must be non-negative");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto value = mln_json_value{
+    .size = sizeof(mln_json_value),
+    .type = MLN_JSON_VALUE_TYPE_DOUBLE,
+    .data = {.double_value = radius}
+  };
+  return map_set_layer_property(
+    map, layer_id, string_view_from_literal("accuracy-radius"), &value
+  );
+}
+
+auto location_indicator_image_property(uint32_t image_kind)
+  -> std::optional<mln_string_view> {
+  switch (image_kind) {
+    case MLN_LOCATION_INDICATOR_IMAGE_KIND_TOP:
+      return string_view_from_literal("top-image");
+    case MLN_LOCATION_INDICATOR_IMAGE_KIND_BEARING:
+      return string_view_from_literal("bearing-image");
+    case MLN_LOCATION_INDICATOR_IMAGE_KIND_SHADOW:
+      return string_view_from_literal("shadow-image");
+    default:
+      return std::nullopt;
+  }
+}
+
+auto map_set_location_indicator_image_name(
+  mln_map* map, mln_string_view layer_id, uint32_t image_kind,
+  mln_string_view image_id
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto layer_status = validate_location_indicator_layer(map, layer_id);
+  if (layer_status != MLN_STATUS_OK) {
+    return layer_status;
+  }
+  if (!validate_string_view(image_id, "image_id")) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (image_id.size == 0) {
+    set_thread_error("image_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto property = location_indicator_image_property(image_kind);
+  if (!property) {
+    set_thread_error("image_kind is invalid");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto value = mln_json_value{
+    .size = sizeof(mln_json_value),
+    .type = MLN_JSON_VALUE_TYPE_STRING,
+    .data = {.string_value = image_id}
+  };
+  return map_set_layer_property(map, layer_id, *property, &value);
 }
 
 auto map_add_style_layer_json(

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -153,6 +153,23 @@ auto map_add_color_relief_layer(
   mln_map* map, mln_string_view layer_id, mln_string_view source_id,
   mln_string_view before_layer_id
 ) -> mln_status;
+auto map_add_location_indicator_layer(
+  mln_map* map, mln_string_view layer_id, mln_string_view before_layer_id
+) -> mln_status;
+auto map_set_location_indicator_location(
+  mln_map* map, mln_string_view layer_id, mln_lat_lng coordinate,
+  double altitude
+) -> mln_status;
+auto map_set_location_indicator_bearing(
+  mln_map* map, mln_string_view layer_id, double bearing
+) -> mln_status;
+auto map_set_location_indicator_accuracy_radius(
+  mln_map* map, mln_string_view layer_id, double radius
+) -> mln_status;
+auto map_set_location_indicator_image_name(
+  mln_map* map, mln_string_view layer_id, uint32_t image_kind,
+  mln_string_view image_id
+) -> mln_status;
 auto map_add_style_layer_json(
   mln_map* map, const mln_json_value* layer_json,
   mln_string_view before_layer_id

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -807,3 +807,68 @@ test "raster DEM sources support hillshade and color relief layers" {
         c.mln_map_add_raster_source_tiles(map, stringView("bad-raster"), &dem_tiles, dem_tiles.len, &options),
     );
 }
+
+test "location indicator helpers set focused properties" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_add_location_indicator_layer(map, stringView("location"), stringView("point-circle")));
+
+    var found = false;
+    var layer_type: c.mln_string_view = .{ .data = null, .size = 0 };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_layer_type(map, stringView("location"), &layer_type, &found));
+    try testing.expect(found);
+    try testing.expect(std.mem.eql(u8, viewBytes(layer_type), "location-indicator"));
+
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_set_location_indicator_location(map, stringView("location"), .{ .latitude = 37.7749, .longitude = -122.4194 }, 12.0),
+    );
+    var snapshot: ?*c.mln_json_snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_layer_property(map, stringView("location"), stringView("location"), &snapshot));
+    var root = try snapshotRoot(snapshot.?);
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_ARRAY, root.type);
+    try testing.expectEqual(@as(usize, 3), root.data.array_value.value_count);
+    try testing.expectApproxEqAbs(@as(f64, -122.4194), root.data.array_value.values[0].data.double_value, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, 37.7749), root.data.array_value.values[1].data.double_value, 0.000001);
+    try testing.expectApproxEqAbs(@as(f64, 12.0), root.data.array_value.values[2].data.double_value, 0.000001);
+    c.mln_json_snapshot_destroy(snapshot.?);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_location_indicator_bearing(map, stringView("location"), 45.0));
+    snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_layer_property(map, stringView("location"), stringView("bearing"), &snapshot));
+    root = try snapshotRoot(snapshot.?);
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_DOUBLE, root.type);
+    try testing.expectApproxEqAbs(@as(f64, 45.0), root.data.double_value, 0.000001);
+    c.mln_json_snapshot_destroy(snapshot.?);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_location_indicator_accuracy_radius(map, stringView("location"), 33.0));
+    snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_layer_property(map, stringView("location"), stringView("accuracy-radius"), &snapshot));
+    root = try snapshotRoot(snapshot.?);
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_DOUBLE, root.type);
+    try testing.expectApproxEqAbs(@as(f64, 33.0), root.data.double_value, 0.000001);
+    c.mln_json_snapshot_destroy(snapshot.?);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_location_indicator_image_name(map, stringView("location"), c.MLN_LOCATION_INDICATOR_IMAGE_KIND_TOP, stringView("top-icon")));
+    snapshot = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_layer_property(map, stringView("location"), stringView("top-image"), &snapshot));
+    root = try snapshotRoot(snapshot.?);
+    try testing.expect(root.type != c.MLN_JSON_VALUE_TYPE_NULL);
+    c.mln_json_snapshot_destroy(snapshot.?);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_location_indicator_image_name(map, stringView("location"), c.MLN_LOCATION_INDICATOR_IMAGE_KIND_BEARING, stringView("bearing-icon")));
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_location_indicator_image_name(map, stringView("location"), c.MLN_LOCATION_INDICATOR_IMAGE_KIND_SHADOW, stringView("shadow-icon")));
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_location_indicator_accuracy_radius(map, stringView("location"), -1.0));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_location_indicator_image_name(map, stringView("location"), 99, stringView("bad")));
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_set_location_indicator_bearing(map, stringView("point-circle"), 1.0));
+}


### PR DESCRIPTION
## Summary
- Add location indicator layer insertion without source requirements.
- Add focused helpers for location, bearing, accuracy radius, and image-name properties.
- Cover property snapshots and validation through C API tests.

## Issue
resolves #33

## Testing
- mise run test