### PR TITLE
Add custom geometry source APIs

### DIFF
--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -67,6 +67,17 @@ typedef enum mln_style_raster_dem_encoding : uint32_t {
   MLN_STYLE_RASTER_DEM_ENCODING_TERRARIUM = 1,
 } mln_style_raster_dem_encoding;
 
+/** Field mask values for mln_custom_geometry_source_options. */
+typedef enum mln_custom_geometry_source_option_field : uint32_t {
+  MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MIN_ZOOM = 1U << 0U,
+  MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MAX_ZOOM = 1U << 1U,
+  MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TOLERANCE = 1U << 2U,
+  MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TILE_SIZE = 1U << 3U,
+  MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_BUFFER = 1U << 4U,
+  MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_CLIP = 1U << 5U,
+  MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_WRAP = 1U << 6U,
+} mln_custom_geometry_source_option_field;
+
 /** Field mask values for mln_style_image_options. */
 typedef enum mln_style_image_option_field : uint32_t {
   MLN_STYLE_IMAGE_OPTION_PIXEL_RATIO = 1U << 0U,
@@ -111,6 +122,37 @@ typedef struct mln_style_tile_source_options {
   uint32_t raster_encoding;
 } mln_style_tile_source_options;
 
+/** Canonical tile identity used by custom geometry source callbacks. */
+typedef struct mln_canonical_tile_id {
+  uint32_t z;
+  uint32_t x;
+  uint32_t y;
+} mln_canonical_tile_id;
+
+/** Callback invoked for custom geometry source tile requests and cancels. */
+typedef void (*mln_custom_geometry_source_tile_callback)(
+  void* user_data, mln_canonical_tile_id tile_id
+);
+
+/** Options for custom geometry sources. */
+typedef struct mln_custom_geometry_source_options {
+  uint32_t size;
+  uint32_t fields;
+  /** Required tile fetch callback. */
+  mln_custom_geometry_source_tile_callback fetch_tile;
+  /** Optional best-effort tile cancel callback. */
+  mln_custom_geometry_source_tile_callback cancel_tile;
+  /** Caller-owned callback context retained by pointer. */
+  void* user_data;
+  double min_zoom;
+  double max_zoom;
+  double tolerance;
+  uint32_t tile_size;
+  uint32_t buffer;
+  bool clip;
+  bool wrap;
+} mln_custom_geometry_source_options;
+
 /** Caller-owned premultiplied RGBA8 image pixels. */
 typedef struct mln_premultiplied_rgba8_image {
   uint32_t size;
@@ -149,6 +191,10 @@ typedef struct mln_style_image_info {
 /** Returns default tile source options. */
 MLN_API mln_style_tile_source_options
 mln_style_tile_source_options_default(void) MLN_NOEXCEPT;
+
+/** Returns default custom geometry source options. */
+MLN_API mln_custom_geometry_source_options
+mln_custom_geometry_source_options_default(void) MLN_NOEXCEPT;
 
 /** Returns a default premultiplied RGBA8 image descriptor. */
 MLN_API mln_premultiplied_rgba8_image
@@ -523,6 +569,91 @@ MLN_API mln_status mln_map_add_raster_dem_source_url(
 MLN_API mln_status mln_map_add_raster_dem_source_tiles(
   mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
   size_t tile_count, const mln_style_tile_source_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Adds a custom geometry source.
+ *
+ * source_id is borrowed for the call. options is borrowed for the call, but the
+ * callback function pointers and user_data pointer are retained by value. The
+ * callback functions and user_data must remain valid until the source is
+ * removed, the style is replaced, or the map is destroyed, and until any
+ * in-flight callback invocation has returned.
+ *
+ * fetch_tile and cancel_tile may run on arbitrary native worker threads, may be
+ * concurrent with owner-thread map calls, and must not call thread-affine map
+ * APIs directly. Queue work back to the map owner thread before calling
+ * mln_map_set_custom_geometry_source_tile_data() or invalidation functions.
+ * Callbacks must not throw, panic, longjmp, or otherwise unwind through the C
+ * ABI. cancel_tile is best-effort and may be repeated or race with fetch_tile.
+ *
+ * Custom geometry sources belong to the current style. Loading another style
+ * URL or JSON document drops sources that were added to the previous style.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, options is null or invalid, fetch_tile is null, or the
+ *   source ID already exists.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_add_custom_geometry_source(
+  mln_map* map, mln_string_view source_id,
+  const mln_custom_geometry_source_options* options
+) MLN_NOEXCEPT;
+
+/**
+ * Sets custom geometry source data for one canonical tile.
+ *
+ * source_id and data are borrowed for the call. The accepted GeoJSON descriptor
+ * is copied into MapLibre Native before return.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, tile_id is invalid, data is null or invalid, the source
+ *   does not exist, or the source is not a custom geometry source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_set_custom_geometry_source_tile_data(
+  mln_map* map, mln_string_view source_id, mln_canonical_tile_id tile_id,
+  const mln_geojson* data
+) MLN_NOEXCEPT;
+
+/**
+ * Invalidates custom geometry source data for one canonical tile.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, tile_id is invalid, the source does not exist, or the
+ *   source is not a custom geometry source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_invalidate_custom_geometry_source_tile(
+  mln_map* map, mln_string_view source_id, mln_canonical_tile_id tile_id
+) MLN_NOEXCEPT;
+
+/**
+ * Invalidates custom geometry source data inside one geographic region.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
+ *   invalid or empty, bounds is invalid, the source does not exist, or the
+ *   source is not a custom geometry source.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_map_invalidate_custom_geometry_source_region(
+  mln_map* map, mln_string_view source_id, mln_lat_lng_bounds bounds
 ) MLN_NOEXCEPT;
 
 /**

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -50,6 +50,11 @@ auto mln_style_tile_source_options_default(void) noexcept
   return mln::core::style_tile_source_options_default();
 }
 
+auto mln_custom_geometry_source_options_default(void) noexcept
+  -> mln_custom_geometry_source_options {
+  return mln::core::custom_geometry_source_options_default();
+}
+
 auto mln_premultiplied_rgba8_image_default(void) noexcept
   -> mln_premultiplied_rgba8_image {
   return mln::core::premultiplied_rgba8_image_default();
@@ -279,6 +284,46 @@ auto mln_map_add_raster_dem_source_tiles(
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_add_raster_dem_source_tiles(
       map, source_id, tiles, tile_count, options
+    );
+  });
+}
+
+auto mln_map_add_custom_geometry_source(
+  mln_map* map, mln_string_view source_id,
+  const mln_custom_geometry_source_options* options
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_add_custom_geometry_source(map, source_id, options);
+  });
+}
+
+auto mln_map_set_custom_geometry_source_tile_data(
+  mln_map* map, mln_string_view source_id, mln_canonical_tile_id tile_id,
+  const mln_geojson* data
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_set_custom_geometry_source_tile_data(
+      map, source_id, tile_id, data
+    );
+  });
+}
+
+auto mln_map_invalidate_custom_geometry_source_tile(
+  mln_map* map, mln_string_view source_id, mln_canonical_tile_id tile_id
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_invalidate_custom_geometry_source_tile(
+      map, source_id, tile_id
+    );
+  });
+}
+
+auto mln_map_invalidate_custom_geometry_source_region(
+  mln_map* map, mln_string_view source_id, mln_lat_lng_bounds bounds
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_invalidate_custom_geometry_source_region(
+      map, source_id, bounds
     );
   });
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -43,6 +43,7 @@
 #include <mbgl/style/layers/location_indicator_layer.hpp>
 #include <mbgl/style/light.hpp>
 #include <mbgl/style/source.hpp>
+#include <mbgl/style/sources/custom_geometry_source.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/style/sources/image_source.hpp>
 #include <mbgl/style/sources/raster_dem_source.hpp>
@@ -512,6 +513,228 @@ auto to_native_tileset(
     tileset.bounds = to_native_lat_lng_bounds(options.bounds);
   }
   return tileset;
+}
+
+auto has_custom_geometry_source_option(
+  const mln_custom_geometry_source_options& options, uint32_t field
+) -> bool {
+  return (options.fields & field) != 0U;
+}
+
+auto validate_custom_geometry_zoom(double zoom, const char* name)
+  -> mln_status {
+  if (
+    !std::isfinite(zoom) || zoom < 0.0 || zoom > 32.0 ||
+    std::floor(zoom) != zoom
+  ) {
+    auto message = std::string{name} + " must be an integer within [0, 32]";
+    mln::core::set_thread_error(message.c_str());
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto effective_custom_geometry_source_options(
+  const mln_custom_geometry_source_options& options
+) -> mln_custom_geometry_source_options;
+
+auto validate_custom_geometry_source_options(
+  const mln_custom_geometry_source_options* options
+) -> mln_status {
+  if (options == nullptr) {
+    mln::core::set_thread_error("options must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (options->size < sizeof(mln_custom_geometry_source_options)) {
+    mln::core::set_thread_error(
+      "mln_custom_geometry_source_options.size is too small"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MIN_ZOOM) |
+    MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MAX_ZOOM |
+    MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TOLERANCE |
+    MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TILE_SIZE |
+    MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_BUFFER |
+    MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_CLIP |
+    MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_WRAP;
+  if ((options->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_custom_geometry_source_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (options->fetch_tile == nullptr) {
+    mln::core::set_thread_error("fetch_tile must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    has_custom_geometry_source_option(
+      *options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MIN_ZOOM
+    )
+  ) {
+    const auto status =
+      validate_custom_geometry_zoom(options->min_zoom, "min_zoom");
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  if (
+    has_custom_geometry_source_option(
+      *options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MAX_ZOOM
+    )
+  ) {
+    const auto status =
+      validate_custom_geometry_zoom(options->max_zoom, "max_zoom");
+    if (status != MLN_STATUS_OK) {
+      return status;
+    }
+  }
+  const auto effective = effective_custom_geometry_source_options(*options);
+  if (effective.min_zoom > effective.max_zoom) {
+    mln::core::set_thread_error(
+      "min_zoom must be less than or equal to max_zoom"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!std::isfinite(effective.tolerance) || effective.tolerance < 0.0) {
+    mln::core::set_thread_error("tolerance must be finite and non-negative");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (effective.tile_size == 0 || effective.tile_size > 65535U) {
+    mln::core::set_thread_error("tile_size must be within [1, 65535]");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (effective.buffer > 65535U) {
+    mln::core::set_thread_error("buffer must be at most 65535");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto effective_custom_geometry_source_options(
+  const mln_custom_geometry_source_options& options
+) -> mln_custom_geometry_source_options {
+  auto result = mln::core::custom_geometry_source_options_default();
+  result.fields = options.fields;
+  result.fetch_tile = options.fetch_tile;
+  result.cancel_tile = options.cancel_tile;
+  result.user_data = options.user_data;
+  if (
+    has_custom_geometry_source_option(
+      options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MIN_ZOOM
+    )
+  ) {
+    result.min_zoom = options.min_zoom;
+  }
+  if (
+    has_custom_geometry_source_option(
+      options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MAX_ZOOM
+    )
+  ) {
+    result.max_zoom = options.max_zoom;
+  }
+  if (
+    has_custom_geometry_source_option(
+      options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TOLERANCE
+    )
+  ) {
+    result.tolerance = options.tolerance;
+  }
+  if (
+    has_custom_geometry_source_option(
+      options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TILE_SIZE
+    )
+  ) {
+    result.tile_size = options.tile_size;
+  }
+  if (
+    has_custom_geometry_source_option(
+      options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_BUFFER
+    )
+  ) {
+    result.buffer = options.buffer;
+  }
+  if (
+    has_custom_geometry_source_option(
+      options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_CLIP
+    )
+  ) {
+    result.clip = options.clip;
+  }
+  if (
+    has_custom_geometry_source_option(
+      options, MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_WRAP
+    )
+  ) {
+    result.wrap = options.wrap;
+  }
+  return result;
+}
+
+auto to_c_canonical_tile_id(const mbgl::CanonicalTileID& tile_id)
+  -> mln_canonical_tile_id {
+  return mln_canonical_tile_id{.z = tile_id.z, .x = tile_id.x, .y = tile_id.y};
+}
+
+auto to_native_tile_function(
+  mln_custom_geometry_source_tile_callback callback, void* user_data
+) -> mbgl::style::TileFunction {
+  if (callback == nullptr) {
+    return nullptr;
+  }
+  return [callback, user_data](const mbgl::CanonicalTileID& tile_id) -> void {
+    try {
+      callback(user_data, to_c_canonical_tile_id(tile_id));
+    } catch (const std::exception& exception) {
+      mln::core::set_thread_error(exception);
+    } catch (...) {
+      mln::core::set_thread_error("custom geometry source callback threw");
+    }
+  };
+}
+
+auto to_native_custom_geometry_source_options(
+  const mln_custom_geometry_source_options& options
+) -> mbgl::style::CustomGeometrySource::Options {
+  auto result = mbgl::style::CustomGeometrySource::Options{};
+  result.fetchTileFunction =
+    to_native_tile_function(options.fetch_tile, options.user_data);
+  result.cancelTileFunction =
+    to_native_tile_function(options.cancel_tile, options.user_data);
+  result.zoomRange = mbgl::Range<uint8_t>{
+    static_cast<uint8_t>(options.min_zoom),
+    static_cast<uint8_t>(options.max_zoom)
+  };
+  result.tileOptions = mbgl::style::CustomGeometrySource::TileOptions{
+    .tolerance = options.tolerance,
+    .tileSize = static_cast<uint16_t>(options.tile_size),
+    .buffer = static_cast<uint16_t>(options.buffer),
+    .clip = options.clip,
+    .wrap = options.wrap
+  };
+  return result;
+}
+
+auto validate_canonical_tile_id(mln_canonical_tile_id tile_id) -> mln_status {
+  if (tile_id.z > 32U) {
+    mln::core::set_thread_error("tile_id.z must be within [0, 32]");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  const auto coordinate_limit = uint64_t{1} << tile_id.z;
+  if (tile_id.x >= coordinate_limit || tile_id.y >= coordinate_limit) {
+    mln::core::set_thread_error("tile_id x and y must be within zoom bounds");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto to_native_canonical_tile_id(mln_canonical_tile_id tile_id)
+  -> mbgl::CanonicalTileID {
+  return mbgl::CanonicalTileID{
+    static_cast<uint8_t>(tile_id.z), tile_id.x, tile_id.y
+  };
 }
 
 auto validate_source_id(mln_string_view source_id) -> mln_status {
@@ -2332,6 +2555,24 @@ auto style_tile_source_options_default() noexcept
   };
 }
 
+auto custom_geometry_source_options_default() noexcept
+  -> mln_custom_geometry_source_options {
+  return mln_custom_geometry_source_options{
+    .size = sizeof(mln_custom_geometry_source_options),
+    .fields = 0,
+    .fetch_tile = nullptr,
+    .cancel_tile = nullptr,
+    .user_data = nullptr,
+    .min_zoom = 0,
+    .max_zoom = 18,
+    .tolerance = 0.375,
+    .tile_size = mbgl::util::tileSize_I,
+    .buffer = 128,
+    .clip = false,
+    .wrap = false
+  };
+}
+
 auto premultiplied_rgba8_image_default() noexcept
   -> mln_premultiplied_rgba8_image {
   return mln_premultiplied_rgba8_image{
@@ -3359,6 +3600,134 @@ auto map_add_raster_dem_source_tiles(
       id, *tileset, static_cast<uint16_t>(effective.tile_size)
     )
   );
+  return MLN_STATUS_OK;
+}
+
+auto map_add_custom_geometry_source(
+  mln_map* map, mln_string_view source_id,
+  const mln_custom_geometry_source_options* options
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto options_status = validate_custom_geometry_source_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
+
+  auto& style = map->map->getStyle();
+  const auto id = string_from_view(source_id);
+  const auto add_status = validate_source_can_be_added(style, id);
+  if (add_status != MLN_STATUS_OK) {
+    return add_status;
+  }
+
+  const auto effective = effective_custom_geometry_source_options(*options);
+  style.addSource(
+    std::make_unique<mbgl::style::CustomGeometrySource>(
+      id, to_native_custom_geometry_source_options(effective)
+    )
+  );
+  return MLN_STATUS_OK;
+}
+
+auto map_set_custom_geometry_source_tile_data(
+  mln_map* map, mln_string_view source_id, mln_canonical_tile_id tile_id,
+  const mln_geojson* data
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto tile_status = validate_canonical_tile_id(tile_id);
+  if (tile_status != MLN_STATUS_OK) {
+    return tile_status;
+  }
+  auto geojson = to_native_geojson(data);
+  if (!geojson) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  if (source == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* custom_source = source->as<mbgl::style::CustomGeometrySource>();
+  if (custom_source == nullptr) {
+    set_thread_error("source is not a custom geometry source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  custom_source->setTileData(to_native_canonical_tile_id(tile_id), *geojson);
+  return MLN_STATUS_OK;
+}
+
+auto map_invalidate_custom_geometry_source_tile(
+  mln_map* map, mln_string_view source_id, mln_canonical_tile_id tile_id
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto tile_status = validate_canonical_tile_id(tile_id);
+  if (tile_status != MLN_STATUS_OK) {
+    return tile_status;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  if (source == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* custom_source = source->as<mbgl::style::CustomGeometrySource>();
+  if (custom_source == nullptr) {
+    set_thread_error("source is not a custom geometry source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  custom_source->invalidateTile(to_native_canonical_tile_id(tile_id));
+  return MLN_STATUS_OK;
+}
+
+auto map_invalidate_custom_geometry_source_region(
+  mln_map* map, mln_string_view source_id, mln_lat_lng_bounds bounds
+) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto source_id_status = validate_source_id(source_id);
+  if (source_id_status != MLN_STATUS_OK) {
+    return source_id_status;
+  }
+  const auto bounds_status = validate_lat_lng_bounds(bounds);
+  if (bounds_status != MLN_STATUS_OK) {
+    return bounds_status;
+  }
+
+  auto* source = map->map->getStyle().getSource(string_from_view(source_id));
+  if (source == nullptr) {
+    set_thread_error("source does not exist");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* custom_source = source->as<mbgl::style::CustomGeometrySource>();
+  if (custom_source == nullptr) {
+    set_thread_error("source is not a custom geometry source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  custom_source->invalidateRegion(to_native_lat_lng_bounds(bounds));
   return MLN_STATUS_OK;
 }
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -26,6 +26,8 @@ auto map_viewport_options_default() noexcept -> mln_map_viewport_options;
 auto map_tile_options_default() noexcept -> mln_map_tile_options;
 auto style_tile_source_options_default() noexcept
   -> mln_style_tile_source_options;
+auto custom_geometry_source_options_default() noexcept
+  -> mln_custom_geometry_source_options;
 auto premultiplied_rgba8_image_default() noexcept
   -> mln_premultiplied_rgba8_image;
 auto style_image_options_default() noexcept -> mln_style_image_options;
@@ -102,6 +104,20 @@ auto map_add_raster_dem_source_url(
 auto map_add_raster_dem_source_tiles(
   mln_map* map, mln_string_view source_id, const mln_string_view* tiles,
   size_t tile_count, const mln_style_tile_source_options* options
+) -> mln_status;
+auto map_add_custom_geometry_source(
+  mln_map* map, mln_string_view source_id,
+  const mln_custom_geometry_source_options* options
+) -> mln_status;
+auto map_set_custom_geometry_source_tile_data(
+  mln_map* map, mln_string_view source_id, mln_canonical_tile_id tile_id,
+  const mln_geojson* data
+) -> mln_status;
+auto map_invalidate_custom_geometry_source_tile(
+  mln_map* map, mln_string_view source_id, mln_canonical_tile_id tile_id
+) -> mln_status;
+auto map_invalidate_custom_geometry_source_region(
+  mln_map* map, mln_string_view source_id, mln_lat_lng_bounds bounds
 ) -> mln_status;
 auto map_set_style_image(
   mln_map* map, mln_string_view image_id,

--- a/tests/c/style_values.zig
+++ b/tests/c/style_values.zig
@@ -98,6 +98,34 @@ fn snapshotRoot(snapshot: *c.mln_json_snapshot) !*const c.mln_json_value {
     return root orelse error.MissingSnapshotRoot;
 }
 
+const CustomGeometryCallbackState = struct {
+    fetch_count: usize = 0,
+    cancel_count: usize = 0,
+    last_tile: c.mln_canonical_tile_id = .{ .z = 0, .x = 0, .y = 0 },
+};
+
+fn customGeometryFetch(user_data: ?*anyopaque, tile_id: c.mln_canonical_tile_id) callconv(.c) void {
+    if (user_data == null) return;
+    const state: *CustomGeometryCallbackState = @ptrCast(@alignCast(user_data.?));
+    state.fetch_count += 1;
+    state.last_tile = tile_id;
+}
+
+fn customGeometryCancel(user_data: ?*anyopaque, tile_id: c.mln_canonical_tile_id) callconv(.c) void {
+    if (user_data == null) return;
+    const state: *CustomGeometryCallbackState = @ptrCast(@alignCast(user_data.?));
+    state.cancel_count += 1;
+    state.last_tile = tile_id;
+}
+
+fn emptyFeatureCollectionGeoJSON() c.mln_geojson {
+    return .{
+        .size = @sizeOf(c.mln_geojson),
+        .type = c.MLN_GEOJSON_TYPE_FEATURE_COLLECTION,
+        .data = .{ .feature_collection = .{ .features = null, .feature_count = 0 } },
+    };
+}
+
 test "layer properties accept style JSON values" {
     try support.suppressLogs();
     defer support.restoreLogs();
@@ -805,6 +833,107 @@ test "raster DEM sources support hillshade and color relief layers" {
     try testing.expectEqual(
         c.MLN_STATUS_INVALID_ARGUMENT,
         c.mln_map_add_raster_source_tiles(map, stringView("bad-raster"), &dem_tiles, dem_tiles.len, &options),
+    );
+}
+
+test "custom geometry source helpers add sources and accept tile updates" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, support.style_json));
+    _ = try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_STYLE_LOADED);
+
+    var options = c.mln_custom_geometry_source_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_custom_geometry_source_options)), options.size);
+    try testing.expectEqual(@as(u32, 0), options.fields);
+    try testing.expectEqual(@as(f64, 0.0), options.min_zoom);
+    try testing.expectEqual(@as(f64, 18.0), options.max_zoom);
+    try testing.expectEqual(@as(u32, 512), options.tile_size);
+    try testing.expectEqual(@as(u32, 128), options.buffer);
+    try testing.expect(!options.clip);
+    try testing.expect(!options.wrap);
+
+    var state = CustomGeometryCallbackState{};
+    options.fetch_tile = customGeometryFetch;
+    options.cancel_tile = customGeometryCancel;
+    options.user_data = &state;
+    options.fields = c.MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MIN_ZOOM |
+        c.MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MAX_ZOOM |
+        c.MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TOLERANCE |
+        c.MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TILE_SIZE |
+        c.MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_BUFFER |
+        c.MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_CLIP |
+        c.MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_WRAP;
+    options.min_zoom = 0.0;
+    options.max_zoom = 14.0;
+    options.tolerance = 0.5;
+    options.tile_size = 256;
+    options.buffer = 64;
+    options.clip = true;
+    options.wrap = true;
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_add_custom_geometry_source(map, stringView("custom"), &options));
+
+    var found = false;
+    var source_type: u32 = c.MLN_STYLE_SOURCE_TYPE_UNKNOWN;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_get_style_source_type(map, stringView("custom"), &source_type, &found));
+    try testing.expect(found);
+    try testing.expectEqual(c.MLN_STYLE_SOURCE_TYPE_CUSTOM_VECTOR, source_type);
+
+    const layer_id = jsonString("custom-circle");
+    const layer_type = jsonString("circle");
+    const layer_source = jsonString("custom");
+    const layer_members = [_]c.mln_json_member{
+        jsonMember("id", &layer_id),
+        jsonMember("type", &layer_type),
+        jsonMember("source", &layer_source),
+    };
+    const layer = jsonObject(&layer_members);
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_add_style_layer_json(map, &layer, stringView("point-circle")));
+
+    const tile_id = c.mln_canonical_tile_id{ .z = 0, .x = 0, .y = 0 };
+    var empty_collection = emptyFeatureCollectionGeoJSON();
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_set_custom_geometry_source_tile_data(map, stringView("custom"), tile_id, &empty_collection),
+    );
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_invalidate_custom_geometry_source_tile(map, stringView("custom"), tile_id));
+    try testing.expectEqual(
+        c.MLN_STATUS_OK,
+        c.mln_map_invalidate_custom_geometry_source_region(
+            map,
+            stringView("custom"),
+            .{
+                .southwest = .{ .latitude = -1.0, .longitude = -1.0 },
+                .northeast = .{ .latitude = 1.0, .longitude = 1.0 },
+            },
+        ),
+    );
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_add_custom_geometry_source(map, stringView("custom"), &options));
+
+    var invalid_options = c.mln_custom_geometry_source_options_default();
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_add_custom_geometry_source(map, stringView("missing-callback"), &invalid_options));
+    invalid_options.fetch_tile = customGeometryFetch;
+    invalid_options.fields = 1 << 31;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_add_custom_geometry_source(map, stringView("bad-fields"), &invalid_options));
+    invalid_options.fields = c.MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MAX_ZOOM;
+    invalid_options.max_zoom = 33.0;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_map_add_custom_geometry_source(map, stringView("bad-zoom"), &invalid_options));
+
+    const invalid_tile_id = c.mln_canonical_tile_id{ .z = 1, .x = 2, .y = 0 };
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_set_custom_geometry_source_tile_data(map, stringView("custom"), invalid_tile_id, &empty_collection),
+    );
+    try testing.expectEqual(
+        c.MLN_STATUS_INVALID_ARGUMENT,
+        c.mln_map_invalidate_custom_geometry_source_tile(map, stringView("point"), tile_id),
     );
 }
 


### PR DESCRIPTION
## Summary
- Adds C ABI helpers for custom geometry sources, including canonical tile callbacks, options/defaults, tile data submission, and invalidation APIs.
- Documents callback threading/lifetime constraints and validates custom geometry zoom, tile, and tile option inputs before reaching native code.
- Adds C API coverage for defaults, source registration/type exposure, tile update/invalidation, and validation failures.

## Tests
- `mise run test` (118/130 passed, 12 skipped)