### PR TITLE
Add feature query APIs

### DIFF
--- a/docs/issue-17-feature-query-api.md
+++ b/docs/issue-17-feature-query-api.md
@@ -1,0 +1,274 @@
+# Issue 17 Feature Query API Plan
+
+This note is for contributors implementing issue 17. It defines the intended C
+ABI shape for MapLibre Native rendered feature queries, source feature queries,
+and feature extension queries.
+
+## Scope
+
+Expose the useful native query surface without exposing renderer or frontend
+objects directly. The C API should provide:
+
+- rendered feature queries for screen points, boxes, and line strings;
+- source feature queries for style source IDs;
+- feature extension queries such as supercluster children, leaves, and expansion
+  zoom.
+
+The implementation can land in two stages. The ABI should be designed for all
+three query families before stage 1 lands.
+
+## Placement
+
+Put the query entry points on `mln_render_session`.
+
+MapLibre Native exposes these operations from `mbgl::Renderer`. This repository
+already treats renderer-backed operations as render-session responsibilities, as
+shown by feature-state APIs on `mln_render_session`. Query calls read the
+session renderer's latest state, so they fit the same lifecycle and threading
+rules.
+
+Queries are immediate state snapshots. They return synchronous acceptance or
+failure and copy result data into owned C handles. They do not enqueue commands
+or runtime events.
+
+## Public Header
+
+Add `include/maplibre_native_c/query.h` and include it from
+`include/maplibre_native_c.h`. Keep query-specific result handles and option
+types in that header.
+
+## Stage 1: Rendered And Source Features
+
+Rendered and source queries share one result handle because both native APIs
+return `std::vector<mbgl::Feature>`.
+
+```c
+typedef struct mln_feature_query_result mln_feature_query_result;
+
+typedef enum mln_rendered_query_geometry_type : uint32_t {
+  MLN_RENDERED_QUERY_GEOMETRY_TYPE_POINT = 1,
+  MLN_RENDERED_QUERY_GEOMETRY_TYPE_BOX = 2,
+  MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING = 3,
+} mln_rendered_query_geometry_type;
+
+typedef struct mln_screen_box {
+  mln_screen_point min;
+  mln_screen_point max;
+} mln_screen_box;
+
+typedef struct mln_screen_line_string {
+  const mln_screen_point* points;
+  size_t point_count;
+} mln_screen_line_string;
+
+typedef struct mln_rendered_query_geometry {
+  uint32_t size;
+  uint32_t type;
+  union {
+    mln_screen_point point;
+    mln_screen_box box;
+    mln_screen_line_string line_string;
+  } data;
+} mln_rendered_query_geometry;
+
+typedef enum mln_rendered_feature_query_option_field : uint32_t {
+  MLN_RENDERED_FEATURE_QUERY_OPTION_LAYER_IDS = 1U << 0U,
+} mln_rendered_feature_query_option_field;
+
+typedef struct mln_rendered_feature_query_options {
+  uint32_t size;
+  uint32_t fields;
+  const mln_string_view* layer_ids;
+  size_t layer_id_count;
+  const mln_json_value* filter;
+} mln_rendered_feature_query_options;
+
+typedef enum mln_source_feature_query_option_field : uint32_t {
+  MLN_SOURCE_FEATURE_QUERY_OPTION_SOURCE_LAYER_IDS = 1U << 0U,
+} mln_source_feature_query_option_field;
+
+typedef struct mln_source_feature_query_options {
+  uint32_t size;
+  uint32_t fields;
+  const mln_string_view* source_layer_ids;
+  size_t source_layer_id_count;
+  const mln_json_value* filter;
+} mln_source_feature_query_options;
+
+typedef enum mln_queried_feature_field : uint32_t {
+  MLN_QUERIED_FEATURE_SOURCE_ID = 1U << 0U,
+  MLN_QUERIED_FEATURE_SOURCE_LAYER_ID = 1U << 1U,
+  MLN_QUERIED_FEATURE_STATE = 1U << 2U,
+} mln_queried_feature_field;
+
+typedef struct mln_queried_feature {
+  uint32_t size;
+  uint32_t fields;
+  mln_feature feature;
+  mln_string_view source_id;
+  mln_string_view source_layer_id;
+  const mln_json_value* state;
+} mln_queried_feature;
+```
+
+Expose default constructors and geometry helpers:
+
+```c
+MLN_API mln_rendered_feature_query_options
+mln_rendered_feature_query_options_default(void) MLN_NOEXCEPT;
+
+MLN_API mln_source_feature_query_options
+mln_source_feature_query_options_default(void) MLN_NOEXCEPT;
+
+MLN_API mln_rendered_query_geometry
+mln_rendered_query_geometry_point(mln_screen_point point) MLN_NOEXCEPT;
+
+MLN_API mln_rendered_query_geometry
+mln_rendered_query_geometry_box(mln_screen_box box) MLN_NOEXCEPT;
+
+MLN_API mln_rendered_query_geometry
+mln_rendered_query_geometry_line_string(
+  const mln_screen_point* points, size_t point_count
+) MLN_NOEXCEPT;
+```
+
+Expose query and result access functions:
+
+```c
+MLN_API mln_status mln_render_session_query_rendered_features(
+  mln_render_session* session,
+  const mln_rendered_query_geometry* geometry,
+  const mln_rendered_feature_query_options* options,
+  mln_feature_query_result** out_result
+) MLN_NOEXCEPT;
+
+MLN_API mln_status mln_render_session_query_source_features(
+  mln_render_session* session,
+  mln_string_view source_id,
+  const mln_source_feature_query_options* options,
+  mln_feature_query_result** out_result
+) MLN_NOEXCEPT;
+
+MLN_API mln_status mln_feature_query_result_count(
+  const mln_feature_query_result* result,
+  size_t* out_count
+) MLN_NOEXCEPT;
+
+MLN_API mln_status mln_feature_query_result_get(
+  const mln_feature_query_result* result,
+  size_t index,
+  mln_queried_feature* out_feature
+) MLN_NOEXCEPT;
+
+MLN_API void mln_feature_query_result_destroy(
+  mln_feature_query_result* result
+) MLN_NOEXCEPT;
+```
+
+## Stage 2: Feature Extensions
+
+Feature extensions use a separate result handle because the native return type
+is `mbgl::FeatureExtensionValue`, a variant of `mbgl::Value` or
+`mbgl::FeatureCollection`. A single feature-list handle would not represent
+scalar extension results such as supercluster expansion zoom.
+
+```c
+typedef struct mln_feature_extension_result mln_feature_extension_result;
+
+typedef enum mln_feature_extension_result_type : uint32_t {
+  MLN_FEATURE_EXTENSION_RESULT_TYPE_VALUE = 1,
+  MLN_FEATURE_EXTENSION_RESULT_TYPE_FEATURE_COLLECTION = 2,
+} mln_feature_extension_result_type;
+
+typedef struct mln_feature_extension_result_info {
+  uint32_t size;
+  uint32_t type;
+  union {
+    const mln_json_value* value;
+    mln_feature_collection feature_collection;
+  } data;
+} mln_feature_extension_result_info;
+```
+
+Expose query and result access functions:
+
+```c
+MLN_API mln_status mln_render_session_query_feature_extensions(
+  mln_render_session* session,
+  mln_string_view source_id,
+  const mln_feature* feature,
+  mln_string_view extension,
+  mln_string_view extension_field,
+  const mln_json_value* arguments,
+  mln_feature_extension_result** out_result
+) MLN_NOEXCEPT;
+
+MLN_API mln_status mln_feature_extension_result_get(
+  const mln_feature_extension_result* result,
+  mln_feature_extension_result_info* out_info
+) MLN_NOEXCEPT;
+
+MLN_API void mln_feature_extension_result_destroy(
+  mln_feature_extension_result* result
+) MLN_NOEXCEPT;
+```
+
+## Filters And Arguments
+
+`filter` uses the MapLibre style-spec filter JSON representation already used by
+`mln_map_set_layer_filter()`. Null means no filter.
+
+`arguments` is optional. When non-null, it must be a JSON object descriptor and
+is copied before return. This covers native extension arguments such as
+supercluster `limit` and `offset`.
+
+## Ownership
+
+Input strings, arrays, geometry descriptors, filters, and argument descriptors
+are borrowed for the duration of the call.
+
+Query result handles own copied result data. Pointers returned by
+`mln_feature_query_result_get()` and `mln_feature_extension_result_get()` remain
+valid until the corresponding result handle is destroyed.
+
+`mln_feature_query_result_destroy()` and
+`mln_feature_extension_result_destroy()` accept null as a no-op.
+
+## Errors
+
+Query functions return:
+
+- `MLN_STATUS_OK` on success;
+- `MLN_STATUS_INVALID_ARGUMENT` for null handles, non-live handles, undersized
+  structs, unknown field bits, invalid strings, invalid filters, invalid
+  geometry, invalid arguments, null outputs, or non-null `*out_result`;
+- `MLN_STATUS_INVALID_STATE` when the session is detached or no renderer has
+  been created for the session yet;
+- `MLN_STATUS_WRONG_THREAD` when called from a thread other than the session
+  owner thread;
+- `MLN_STATUS_NATIVE_ERROR` when a native MapLibre error or C++ exception is
+  converted to status.
+
+Unknown rendered layer IDs and unknown source IDs should follow native behavior
+and produce empty or null-like results rather than hard failures.
+
+## Validation
+
+Stage 1 should add C ABI tests for:
+
+- rendered point query with no options;
+- rendered query with layer IDs;
+- rendered query with a filter;
+- source query for GeoJSON;
+- source query for vector source layers;
+- result ownership after later map/session changes;
+- invalid structs, invalid field bits, invalid filter, wrong thread, and
+  not-yet-rendered session errors.
+
+Stage 2 should add C ABI tests for:
+
+- supercluster `children` returning a feature collection;
+- supercluster `leaves` with `limit` and `offset` arguments;
+- supercluster `expansion-zoom` returning a value;
+- unknown extension returning the native null-like value;
+- invalid argument objects and wrong result-handle initialization.

--- a/include/maplibre_native_c.h
+++ b/include/maplibre_native_c.h
@@ -23,6 +23,7 @@
 #include "maplibre_native_c/logging.h"         // IWYU pragma: export
 #include "maplibre_native_c/map.h"             // IWYU pragma: export
 #include "maplibre_native_c/projection.h"      // IWYU pragma: export
+#include "maplibre_native_c/query.h"           // IWYU pragma: export
 #include "maplibre_native_c/render_session.h"  // IWYU pragma: export
 #include "maplibre_native_c/runtime.h"         // IWYU pragma: export
 #include "maplibre_native_c/style.h"           // IWYU pragma: export

--- a/include/maplibre_native_c/query.h
+++ b/include/maplibre_native_c/query.h
@@ -1,0 +1,221 @@
+/**
+ * @file maplibre_native_c/query.h
+ * Public C API declarations for rendered and source feature queries.
+ */
+
+#ifndef MAPLIBRE_NATIVE_C_QUERY_H
+#define MAPLIBRE_NATIVE_C_QUERY_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "base.h"
+#include "map.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#pragma region Rendered and source feature queries
+
+typedef struct mln_feature_query_result mln_feature_query_result;
+
+/** Rendered feature query geometry variants. */
+typedef enum mln_rendered_query_geometry_type : uint32_t {
+  MLN_RENDERED_QUERY_GEOMETRY_TYPE_POINT = 1,
+  MLN_RENDERED_QUERY_GEOMETRY_TYPE_BOX = 2,
+  MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING = 3,
+} mln_rendered_query_geometry_type;
+
+/** Screen-space box in logical map pixels. */
+typedef struct mln_screen_box {
+  mln_screen_point min;
+  mln_screen_point max;
+} mln_screen_box;
+
+/** Screen-space line string in logical map pixels. */
+typedef struct mln_screen_line_string {
+  /** Points. Null only when point_count is 0. */
+  const mln_screen_point* points;
+  size_t point_count;
+} mln_screen_line_string;
+
+/** Rendered feature query geometry descriptor. */
+typedef struct mln_rendered_query_geometry {
+  uint32_t size;
+  /** One of mln_rendered_query_geometry_type. */
+  uint32_t type;
+  union {
+    mln_screen_point point;
+    mln_screen_box box;
+    mln_screen_line_string line_string;
+  } data;
+} mln_rendered_query_geometry;
+
+/** Optional fields for mln_rendered_feature_query_options. */
+typedef enum mln_rendered_feature_query_option_field : uint32_t {
+  MLN_RENDERED_FEATURE_QUERY_OPTION_LAYER_IDS = 1U << 0U,
+} mln_rendered_feature_query_option_field;
+
+/** Options for rendered feature queries. */
+typedef struct mln_rendered_feature_query_options {
+  uint32_t size;
+  uint32_t fields;
+  /** Optional style layer IDs. When absent, all rendered layers are queried. */
+  const mln_string_view* layer_ids;
+  size_t layer_id_count;
+  /** Optional MapLibre style-spec filter JSON. Null means no filter. */
+  const mln_json_value* filter;
+} mln_rendered_feature_query_options;
+
+/** Optional fields for mln_source_feature_query_options. */
+typedef enum mln_source_feature_query_option_field : uint32_t {
+  MLN_SOURCE_FEATURE_QUERY_OPTION_SOURCE_LAYER_IDS = 1U << 0U,
+} mln_source_feature_query_option_field;
+
+/** Options for source feature queries. */
+typedef struct mln_source_feature_query_options {
+  uint32_t size;
+  uint32_t fields;
+  /** Optional source-layer IDs. Required by vector sources; ignored by GeoJSON.
+   */
+  const mln_string_view* source_layer_ids;
+  size_t source_layer_id_count;
+  /** Optional MapLibre style-spec filter JSON. Null means no filter. */
+  const mln_json_value* filter;
+} mln_source_feature_query_options;
+
+/** Optional fields returned by mln_queried_feature. */
+typedef enum mln_queried_feature_field : uint32_t {
+  MLN_QUERIED_FEATURE_SOURCE_ID = 1U << 0U,
+  MLN_QUERIED_FEATURE_SOURCE_LAYER_ID = 1U << 1U,
+  MLN_QUERIED_FEATURE_STATE = 1U << 2U,
+} mln_queried_feature_field;
+
+/** One copied query result feature. */
+typedef struct mln_queried_feature {
+  uint32_t size;
+  uint32_t fields;
+  /** GeoJSON feature descriptor. Nested pointers are result-owned. */
+  mln_feature feature;
+  /** Native render source ID when available. */
+  mln_string_view source_id;
+  /** Native source layer ID when available. */
+  mln_string_view source_layer_id;
+  /** Rendered feature state when available. */
+  const mln_json_value* state;
+} mln_queried_feature;
+
+/** Returns default rendered feature query options. */
+MLN_API mln_rendered_feature_query_options
+mln_rendered_feature_query_options_default(void) MLN_NOEXCEPT;
+
+/** Returns default source feature query options. */
+MLN_API mln_source_feature_query_options
+mln_source_feature_query_options_default(void) MLN_NOEXCEPT;
+
+/** Returns a rendered point query geometry descriptor. */
+MLN_API mln_rendered_query_geometry
+mln_rendered_query_geometry_point(mln_screen_point point) MLN_NOEXCEPT;
+
+/** Returns a rendered box query geometry descriptor. */
+MLN_API mln_rendered_query_geometry
+mln_rendered_query_geometry_box(mln_screen_box box) MLN_NOEXCEPT;
+
+/** Returns a rendered line-string query geometry descriptor. */
+MLN_API mln_rendered_query_geometry mln_rendered_query_geometry_line_string(
+  const mln_screen_point* points, size_t point_count
+) MLN_NOEXCEPT;
+
+/**
+ * Queries rendered features from the latest render session state.
+ *
+ * The session renderer must already exist. geometry and options are borrowed
+ * for the duration of the call. Passing null for options uses default options.
+ * On success, *out_result receives an owned result handle. Destroy it with
+ * mln_feature_query_result_destroy().
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, geometry is
+ *   null or invalid, options are invalid, out_result is null, or *out_result is
+ *   not null.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_render_session_query_rendered_features(
+  mln_render_session* session, const mln_rendered_query_geometry* geometry,
+  const mln_rendered_feature_query_options* options,
+  mln_feature_query_result** out_result
+) MLN_NOEXCEPT;
+
+/**
+ * Queries source features from the latest render session state.
+ *
+ * The session renderer must already exist. source_id and options are borrowed
+ * for the duration of the call. Passing null for options uses default options.
+ * On success, *out_result receives an owned result handle. Destroy it with
+ * mln_feature_query_result_destroy().
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, source_id is
+ *   invalid or empty, options are invalid, out_result is null, or *out_result
+ * is not null.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_render_session_query_source_features(
+  mln_render_session* session, mln_string_view source_id,
+  const mln_source_feature_query_options* options,
+  mln_feature_query_result** out_result
+) MLN_NOEXCEPT;
+
+/**
+ * Gets the number of features in a query result handle.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when result is null or not live, or out_count
+ *   is null.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_feature_query_result_count(
+  const mln_feature_query_result* result, size_t* out_count
+) MLN_NOEXCEPT;
+
+/**
+ * Borrows one feature from a query result handle.
+ *
+ * On success, out_feature receives views into result-owned storage. Those views
+ * remain valid until result is destroyed.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when result is null or not live, index is out
+ *   of range, out_feature is null, or out_feature->size is too small.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_feature_query_result_get(
+  const mln_feature_query_result* result, size_t index,
+  mln_queried_feature* out_feature
+) MLN_NOEXCEPT;
+
+/** Destroys a feature query result handle. Null is accepted as a no-op. */
+MLN_API void mln_feature_query_result_destroy(
+  mln_feature_query_result* result
+) MLN_NOEXCEPT;
+
+#pragma endregion
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MAPLIBRE_NATIVE_C_QUERY_H

--- a/src/c_api/render_session.cpp
+++ b/src/c_api/render_session.cpp
@@ -1,11 +1,62 @@
 #define MLN_BUILDING_C
 
+#include <cstddef>
 #include <cstdint>
 
 #include "c_api/boundary.hpp"
 #include "geojson/geojson.hpp"
 #include "maplibre_native_c.h"
 #include "render/render_session_common.hpp"
+
+auto mln_rendered_feature_query_options_default() noexcept
+  -> mln_rendered_feature_query_options {
+  return mln_rendered_feature_query_options{
+    .size = sizeof(mln_rendered_feature_query_options),
+    .fields = 0,
+    .layer_ids = nullptr,
+    .layer_id_count = 0,
+    .filter = nullptr
+  };
+}
+
+auto mln_source_feature_query_options_default() noexcept
+  -> mln_source_feature_query_options {
+  return mln_source_feature_query_options{
+    .size = sizeof(mln_source_feature_query_options),
+    .fields = 0,
+    .source_layer_ids = nullptr,
+    .source_layer_id_count = 0,
+    .filter = nullptr
+  };
+}
+
+auto mln_rendered_query_geometry_point(mln_screen_point point) noexcept
+  -> mln_rendered_query_geometry {
+  return mln_rendered_query_geometry{
+    .size = sizeof(mln_rendered_query_geometry),
+    .type = MLN_RENDERED_QUERY_GEOMETRY_TYPE_POINT,
+    .data = {.point = point}
+  };
+}
+
+auto mln_rendered_query_geometry_box(mln_screen_box box) noexcept
+  -> mln_rendered_query_geometry {
+  return mln_rendered_query_geometry{
+    .size = sizeof(mln_rendered_query_geometry),
+    .type = MLN_RENDERED_QUERY_GEOMETRY_TYPE_BOX,
+    .data = {.box = box}
+  };
+}
+
+auto mln_rendered_query_geometry_line_string(
+  const mln_screen_point* points, size_t point_count
+) noexcept -> mln_rendered_query_geometry {
+  return mln_rendered_query_geometry{
+    .size = sizeof(mln_rendered_query_geometry),
+    .type = MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING,
+    .data = {.line_string = {.points = points, .point_count = point_count}}
+  };
+}
 
 auto mln_render_session_resize(
   mln_render_session* session, uint32_t width, uint32_t height,
@@ -88,6 +139,52 @@ auto mln_render_session_remove_feature_state(
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::render_session_remove_feature_state(session, selector);
   });
+}
+
+auto mln_render_session_query_rendered_features(
+  mln_render_session* session, const mln_rendered_query_geometry* geometry,
+  const mln_rendered_feature_query_options* options,
+  mln_feature_query_result** out_result
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_query_rendered_features(
+      session, geometry, options, out_result
+    );
+  });
+}
+
+auto mln_render_session_query_source_features(
+  mln_render_session* session, mln_string_view source_id,
+  const mln_source_feature_query_options* options,
+  mln_feature_query_result** out_result
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_query_source_features(
+      session, source_id, options, out_result
+    );
+  });
+}
+
+auto mln_feature_query_result_count(
+  const mln_feature_query_result* result, size_t* out_count
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::feature_query_result_count(result, out_count);
+  });
+}
+
+auto mln_feature_query_result_get(
+  const mln_feature_query_result* result, size_t index,
+  mln_queried_feature* out_feature
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::feature_query_result_get(result, index, out_feature);
+  });
+}
+
+auto mln_feature_query_result_destroy(mln_feature_query_result* result) noexcept
+  -> void {
+  mln::core::feature_query_result_destroy(result);
 }
 
 auto mln_json_snapshot_get(

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -1,17 +1,25 @@
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <mbgl/gfx/backend_scope.hpp>
 #include <mbgl/gfx/renderer_backend.hpp>
 #include <mbgl/map/map.hpp>
+#include <mbgl/renderer/query.hpp>
 #include <mbgl/renderer/renderer.hpp>
+#include <mbgl/style/filter.hpp>
+#include <mbgl/util/feature.hpp>
+#include <mbgl/util/geo.hpp>
 #include <mbgl/util/size.hpp>
 
 #include "render/render_session_common.hpp"
@@ -20,6 +28,30 @@
 #include "geojson/geojson.hpp"
 #include "map/map.hpp"
 #include "maplibre_native_c.h"
+#include "style/style_value.hpp"
+
+namespace mln::core {
+
+struct OwnedQueriedFeatureDescriptor {
+  mln_queried_feature queried{};
+  mln_feature feature{};
+  std::unique_ptr<OwnedGeometryDescriptor> geometry;
+  std::vector<std::string> property_keys;
+  std::vector<std::unique_ptr<OwnedJsonDescriptor>> property_values;
+  std::vector<mln_json_value> property_value_roots;
+  std::vector<mln_json_member> properties;
+  std::string identifier_string;
+  std::string source_id;
+  std::string source_layer_id;
+  std::unique_ptr<OwnedJsonDescriptor> state;
+};
+
+}  // namespace mln::core
+
+struct mln_feature_query_result {
+  std::vector<std::unique_ptr<mln::core::OwnedQueriedFeatureDescriptor>>
+    features;
+};
 
 namespace {
 
@@ -32,6 +64,19 @@ auto render_sessions() -> std::unordered_map<
   mln_render_session*, std::unique_ptr<mln_render_session>>& {
   static auto value = std::unordered_map<
     mln_render_session*, std::unique_ptr<mln_render_session>>{};
+  return value;
+}
+
+auto feature_query_result_mutex() -> std::mutex& {
+  static auto value = std::mutex{};
+  return value;
+}
+
+auto feature_query_results() -> std::unordered_map<
+  const mln_feature_query_result*, std::unique_ptr<mln_feature_query_result>>& {
+  static auto value = std::unordered_map<
+    const mln_feature_query_result*,
+    std::unique_ptr<mln_feature_query_result>>{};
   return value;
 }
 
@@ -91,11 +136,64 @@ auto validate_string_view(mln_string_view string) -> bool {
   return true;
 }
 
+auto validate_string_views(
+  std::span<const mln_string_view> strings, const char* name
+) -> bool {
+  return std::ranges::all_of(strings, [name](const auto string) -> bool {
+    if (!validate_string_view(string)) {
+      return false;
+    }
+    if (string.size == 0) {
+      auto message = std::string{name} + " must not contain empty strings";
+      mln::core::set_thread_error(message.c_str());
+      return false;
+    }
+    return true;
+  });
+}
+
 auto string_from_view(mln_string_view string) -> std::string {
   if (string.size == 0) {
     return {};
   }
   return std::string{string.data, string.size};
+}
+
+auto string_view_from_string(const std::string& string) -> mln_string_view {
+  return mln_string_view{
+    .data = string.empty() ? nullptr : string.data(), .size = string.size()
+  };
+}
+
+auto validate_screen_point(mln_screen_point point) -> bool {
+  if (!std::isfinite(point.x) || !std::isfinite(point.y)) {
+    mln::core::set_thread_error("screen point coordinates must be finite");
+    return false;
+  }
+  return true;
+}
+
+auto validate_query_result_output(mln_feature_query_result** out_result)
+  -> mln_status {
+  if (out_result == nullptr) {
+    mln::core::set_thread_error("out_result must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (*out_result != nullptr) {
+    mln::core::set_thread_error("*out_result must be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto make_string_vector(std::span<const mln_string_view> strings)
+  -> std::vector<std::string> {
+  auto result = std::vector<std::string>{};
+  result.reserve(strings.size());
+  for (const auto string : strings) {
+    result.emplace_back(string_from_view(string));
+  }
+  return result;
 }
 
 auto selector_has_field(
@@ -179,6 +277,242 @@ auto feature_state_source_layer(const mln_feature_state_selector& selector)
     selector, MLN_FEATURE_STATE_SELECTOR_SOURCE_LAYER_ID,
     selector.source_layer_id
   );
+}
+
+auto to_rendered_query_options(
+  const mln_rendered_feature_query_options* options
+) -> std::optional<mbgl::RenderedQueryOptions> {
+  auto layer_ids = std::optional<std::vector<std::string>>{};
+  auto filter = std::optional<mbgl::style::Filter>{};
+  if (options == nullptr) {
+    return mbgl::RenderedQueryOptions{};
+  }
+  if (options->size < sizeof(mln_rendered_feature_query_options)) {
+    mln::core::set_thread_error(
+      "mln_rendered_feature_query_options.size is too small"
+    );
+    return std::nullopt;
+  }
+  constexpr auto known_fields = MLN_RENDERED_FEATURE_QUERY_OPTION_LAYER_IDS;
+  if ((options->fields & ~known_fields) != 0) {
+    mln::core::set_thread_error("rendered feature query has unknown fields");
+    return std::nullopt;
+  }
+  if ((options->fields & MLN_RENDERED_FEATURE_QUERY_OPTION_LAYER_IDS) != 0) {
+    if (options->layer_id_count > 0 && options->layer_ids == nullptr) {
+      mln::core::set_thread_error("query layer IDs must not be null");
+      return std::nullopt;
+    }
+    auto views = std::span<const mln_string_view>{
+      options->layer_ids, options->layer_id_count
+    };
+    if (!validate_string_views(views, "query layer IDs")) {
+      return std::nullopt;
+    }
+    layer_ids = make_string_vector(views);
+  }
+  if (options->filter != nullptr) {
+    auto converted_filter = mln::core::to_native_style_filter(options->filter);
+    if (!converted_filter) {
+      return std::nullopt;
+    }
+    filter = std::move(*converted_filter);
+  }
+  return mbgl::RenderedQueryOptions{std::move(layer_ids), std::move(filter)};
+}
+
+auto to_source_query_options(const mln_source_feature_query_options* options)
+  -> std::optional<mbgl::SourceQueryOptions> {
+  auto source_layer_ids = std::optional<std::vector<std::string>>{};
+  auto filter = std::optional<mbgl::style::Filter>{};
+  if (options == nullptr) {
+    return mbgl::SourceQueryOptions{};
+  }
+  if (options->size < sizeof(mln_source_feature_query_options)) {
+    mln::core::set_thread_error(
+      "mln_source_feature_query_options.size is too small"
+    );
+    return std::nullopt;
+  }
+  constexpr auto known_fields =
+    MLN_SOURCE_FEATURE_QUERY_OPTION_SOURCE_LAYER_IDS;
+  if ((options->fields & ~known_fields) != 0) {
+    mln::core::set_thread_error("source feature query has unknown fields");
+    return std::nullopt;
+  }
+  if (
+    (options->fields & MLN_SOURCE_FEATURE_QUERY_OPTION_SOURCE_LAYER_IDS) != 0
+  ) {
+    if (
+      options->source_layer_id_count > 0 && options->source_layer_ids == nullptr
+    ) {
+      mln::core::set_thread_error("query source layer IDs must not be null");
+      return std::nullopt;
+    }
+    auto views = std::span<const mln_string_view>{
+      options->source_layer_ids, options->source_layer_id_count
+    };
+    if (!validate_string_views(views, "query source layer IDs")) {
+      return std::nullopt;
+    }
+    source_layer_ids = make_string_vector(views);
+  }
+  if (options->filter != nullptr) {
+    auto converted_filter = mln::core::to_native_style_filter(options->filter);
+    if (!converted_filter) {
+      return std::nullopt;
+    }
+    filter = std::move(*converted_filter);
+  }
+  return mbgl::SourceQueryOptions{
+    std::move(source_layer_ids), std::move(filter)
+  };
+}
+
+auto to_screen_line_string(
+  const mln_screen_line_string& line_string, mbgl::ScreenLineString& out_line
+) -> bool {
+  if (line_string.point_count == 0) {
+    mln::core::set_thread_error("query line string must contain points");
+    return false;
+  }
+  if (line_string.points == nullptr) {
+    mln::core::set_thread_error("query line string points must not be null");
+    return false;
+  }
+  auto result = mbgl::ScreenLineString{};
+  result.reserve(line_string.point_count);
+  for (const auto point : std::span<const mln_screen_point>{
+         line_string.points, line_string.point_count
+       }) {
+    if (!validate_screen_point(point)) {
+      return false;
+    }
+    result.emplace_back(point.x, point.y);
+  }
+  out_line = std::move(result);
+  return true;
+}
+
+auto feature_identifier_type(
+  const mbgl::FeatureIdentifier& identifier,
+  mln::core::OwnedQueriedFeatureDescriptor& storage
+) -> uint32_t {
+  if (identifier.is<mbgl::NullValue>()) {
+    return MLN_FEATURE_IDENTIFIER_TYPE_NULL;
+  }
+  if (identifier.is<uint64_t>()) {
+    storage.feature.identifier.uint_value = identifier.get<uint64_t>();
+    return MLN_FEATURE_IDENTIFIER_TYPE_UINT;
+  }
+  if (identifier.is<int64_t>()) {
+    storage.feature.identifier.int_value = identifier.get<int64_t>();
+    return MLN_FEATURE_IDENTIFIER_TYPE_INT;
+  }
+  if (identifier.is<double>()) {
+    storage.feature.identifier.double_value = identifier.get<double>();
+    return MLN_FEATURE_IDENTIFIER_TYPE_DOUBLE;
+  }
+  storage.identifier_string = identifier.get<std::string>();
+  storage.feature.identifier.string_value =
+    string_view_from_string(storage.identifier_string);
+  return MLN_FEATURE_IDENTIFIER_TYPE_STRING;
+}
+
+auto make_queried_feature(
+  const mbgl::Feature& feature, const std::optional<std::string>& source_id
+) -> std::unique_ptr<mln::core::OwnedQueriedFeatureDescriptor> {
+  auto result = std::make_unique<mln::core::OwnedQueriedFeatureDescriptor>();
+  result->geometry = mln::core::to_c_geometry(feature.geometry);
+  result->property_keys.reserve(feature.properties.size());
+  result->property_values.reserve(feature.properties.size());
+  result->property_value_roots.reserve(feature.properties.size());
+  result->properties.reserve(feature.properties.size());
+  for (const auto& [key, value] : feature.properties) {
+    result->property_keys.emplace_back(key);
+    result->property_values.emplace_back(mln::core::to_c_json_value(value));
+  }
+  for (std::size_t index = 0; index < result->property_values.size(); ++index) {
+    result->property_value_roots.emplace_back(
+      result->property_values.at(index)->root
+    );
+    result->properties.emplace_back(
+      mln_json_member{
+        .key = string_view_from_string(result->property_keys.at(index)),
+        .value = &result->property_value_roots.back()
+      }
+    );
+  }
+
+  result->feature = mln_feature{
+    .size = sizeof(mln_feature),
+    .geometry = &result->geometry->root,
+    .properties =
+      result->properties.empty() ? nullptr : result->properties.data(),
+    .property_count = result->properties.size(),
+    .identifier_type = MLN_FEATURE_IDENTIFIER_TYPE_NULL,
+    .identifier = {.uint_value = 0}
+  };
+  result->feature.identifier_type =
+    feature_identifier_type(feature.id, *result);
+
+  result->queried = mln_queried_feature{
+    .size = sizeof(mln_queried_feature),
+    .fields = 0,
+    .feature = result->feature,
+    .source_id = {},
+    .source_layer_id = {},
+    .state = nullptr
+  };
+  result->source_id =
+    feature.source.empty() && source_id ? *source_id : feature.source;
+  if (!result->source_id.empty()) {
+    result->queried.fields |= MLN_QUERIED_FEATURE_SOURCE_ID;
+    result->queried.source_id = string_view_from_string(result->source_id);
+  }
+  result->source_layer_id = feature.sourceLayer;
+  if (!result->source_layer_id.empty()) {
+    result->queried.fields |= MLN_QUERIED_FEATURE_SOURCE_LAYER_ID;
+    result->queried.source_layer_id =
+      string_view_from_string(result->source_layer_id);
+  }
+  if (!feature.state.empty()) {
+    result->state = mln::core::to_c_json_value(mbgl::Value{feature.state});
+    result->queried.fields |= MLN_QUERIED_FEATURE_STATE;
+    result->queried.state = &result->state->root;
+  }
+  return result;
+}
+
+auto create_feature_query_result(
+  std::vector<mbgl::Feature> features,
+  const std::optional<std::string>& source_id,
+  mln_feature_query_result** out_result
+) -> mln_status {
+  const auto output_status = validate_query_result_output(out_result);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+
+  auto result = std::make_unique<mln_feature_query_result>();
+  result->features.reserve(features.size());
+  for (const auto& feature : features) {
+    result->features.emplace_back(make_queried_feature(feature, source_id));
+  }
+  auto* handle = result.get();
+  const auto lock = std::scoped_lock{feature_query_result_mutex()};
+  feature_query_results().emplace(handle, std::move(result));
+  *out_result = handle;
+  return MLN_STATUS_OK;
+}
+
+auto find_feature_query_result_locked(const mln_feature_query_result* result)
+  -> const mln_feature_query_result* {
+  const auto found = feature_query_results().find(result);
+  if (found == feature_query_results().end()) {
+    return nullptr;
+  }
+  return found->second.get();
 }
 
 }  // namespace
@@ -597,6 +931,196 @@ auto render_session_remove_feature_state(
     native_map->triggerRepaint();
   }
   return MLN_STATUS_OK;
+}
+
+auto render_session_query_rendered_features(
+  mln_render_session* session, const mln_rendered_query_geometry* geometry,
+  const mln_rendered_feature_query_options* options,
+  mln_feature_query_result** out_result
+) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto output_status = validate_query_result_output(out_result);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+  if (geometry == nullptr) {
+    set_thread_error("rendered query geometry must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (geometry->size < sizeof(mln_rendered_query_geometry)) {
+    set_thread_error("mln_rendered_query_geometry.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto native_options = to_rendered_query_options(options);
+  if (!native_options) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto line_string = mbgl::ScreenLineString{};
+  switch (geometry->type) {
+    case MLN_RENDERED_QUERY_GEOMETRY_TYPE_POINT:
+      if (!validate_screen_point(geometry->data.point)) {
+        return MLN_STATUS_INVALID_ARGUMENT;
+      }
+      break;
+    case MLN_RENDERED_QUERY_GEOMETRY_TYPE_BOX:
+      if (
+        !validate_screen_point(geometry->data.box.min) ||
+        !validate_screen_point(geometry->data.box.max)
+      ) {
+        return MLN_STATUS_INVALID_ARGUMENT;
+      }
+      break;
+    case MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING: {
+      if (!to_screen_line_string(geometry->data.line_string, line_string)) {
+        return MLN_STATUS_INVALID_ARGUMENT;
+      }
+      break;
+    }
+    default:
+      set_thread_error("rendered query geometry type is invalid");
+      return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
+  auto features = std::vector<mbgl::Feature>{};
+  switch (geometry->type) {
+    case MLN_RENDERED_QUERY_GEOMETRY_TYPE_POINT:
+      features = session->renderer->queryRenderedFeatures(
+        mbgl::ScreenCoordinate{geometry->data.point.x, geometry->data.point.y},
+        *native_options
+      );
+      break;
+    case MLN_RENDERED_QUERY_GEOMETRY_TYPE_BOX:
+      features = session->renderer->queryRenderedFeatures(
+        mbgl::ScreenBox{
+          {geometry->data.box.min.x, geometry->data.box.min.y},
+          {geometry->data.box.max.x, geometry->data.box.max.y}
+        },
+        *native_options
+      );
+      break;
+    case MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING:
+      features =
+        session->renderer->queryRenderedFeatures(line_string, *native_options);
+      break;
+    default:
+      set_thread_error("rendered query geometry type is invalid");
+      return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return create_feature_query_result(
+    std::move(features), std::nullopt, out_result
+  );
+}
+
+auto render_session_query_source_features(
+  mln_render_session* session, mln_string_view source_id,
+  const mln_source_feature_query_options* options,
+  mln_feature_query_result** out_result
+) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto output_status = validate_query_result_output(out_result);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+  if (!validate_string_view(source_id)) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (source_id.size == 0) {
+    set_thread_error("source_id must not be empty");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto native_options = to_source_query_options(options);
+  if (!native_options) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto native_source_id = string_from_view(source_id);
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
+  auto features =
+    session->renderer->querySourceFeatures(native_source_id, *native_options);
+  return create_feature_query_result(
+    std::move(features), native_source_id, out_result
+  );
+}
+
+auto feature_query_result_count(
+  const mln_feature_query_result* result, std::size_t* out_count
+) -> mln_status {
+  if (result == nullptr) {
+    set_thread_error("feature query result must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_count == nullptr) {
+    set_thread_error("out_count must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto lock = std::scoped_lock{feature_query_result_mutex()};
+  const auto* live_result = find_feature_query_result_locked(result);
+  if (live_result == nullptr) {
+    set_thread_error("feature query result is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_count = live_result->features.size();
+  return MLN_STATUS_OK;
+}
+
+auto feature_query_result_get(
+  const mln_feature_query_result* result, std::size_t index,
+  mln_queried_feature* out_feature
+) -> mln_status {
+  if (result == nullptr) {
+    set_thread_error("feature query result must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_feature == nullptr) {
+    set_thread_error("out_feature must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_feature->size < sizeof(mln_queried_feature)) {
+    set_thread_error("mln_queried_feature.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto lock = std::scoped_lock{feature_query_result_mutex()};
+  const auto* live_result = find_feature_query_result_locked(result);
+  if (live_result == nullptr) {
+    set_thread_error("feature query result is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (index >= live_result->features.size()) {
+    set_thread_error("index is out of range");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_feature = live_result->features.at(index)->queried;
+  return MLN_STATUS_OK;
+}
+
+auto feature_query_result_destroy(mln_feature_query_result* result) -> void {
+  if (result == nullptr) {
+    return;
+  }
+  const auto lock = std::scoped_lock{feature_query_result_mutex()};
+  feature_query_results().erase(result);
 }
 
 }  // namespace mln::core

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -144,5 +145,23 @@ auto render_session_get_feature_state(
 auto render_session_remove_feature_state(
   mln_render_session* session, const mln_feature_state_selector* selector
 ) -> mln_status;
+auto render_session_query_rendered_features(
+  mln_render_session* session, const mln_rendered_query_geometry* geometry,
+  const mln_rendered_feature_query_options* options,
+  mln_feature_query_result** out_result
+) -> mln_status;
+auto render_session_query_source_features(
+  mln_render_session* session, mln_string_view source_id,
+  const mln_source_feature_query_options* options,
+  mln_feature_query_result** out_result
+) -> mln_status;
+auto feature_query_result_count(
+  const mln_feature_query_result* result, std::size_t* out_count
+) -> mln_status;
+auto feature_query_result_get(
+  const mln_feature_query_result* result, std::size_t index,
+  mln_queried_feature* out_feature
+) -> mln_status;
+auto feature_query_result_destroy(mln_feature_query_result* result) -> void;
 
 }  // namespace mln::core

--- a/tests/c/main.zig
+++ b/tests/c/main.zig
@@ -6,6 +6,7 @@ comptime {
     _ = @import("resources.zig");
     _ = @import("geojson.zig");
     _ = @import("feature_state.zig");
+    _ = @import("query.zig");
     _ = @import("camera.zig");
     _ = @import("projection.zig");
     _ = @import("map_tuning.zig");

--- a/tests/c/query.zig
+++ b/tests/c/query.zig
@@ -1,0 +1,201 @@
+const std = @import("std");
+const testing = std.testing;
+const support = @import("support.zig");
+const c = support.c;
+
+const query_style_json =
+    \\{
+    \\  "version": 8,
+    \\  "name": "zig-c-query-test",
+    \\  "sources": {
+    \\    "point": {
+    \\      "type": "geojson",
+    \\      "data": {
+    \\        "type": "FeatureCollection",
+    \\        "features": [
+    \\          {
+    \\            "type": "Feature",
+    \\            "id": "feature-1",
+    \\            "geometry": {"type": "Point", "coordinates": [-122.4194, 37.7749]},
+    \\            "properties": {"kind": "capital", "visible": true}
+    \\          }
+    \\        ]
+    \\      }
+    \\    }
+    \\  },
+    \\  "layers": [
+    \\    {"id": "background", "type": "background", "paint": {"background-color": "#d8f1ff"}},
+    \\    {"id": "point-circle", "type": "circle", "source": "point", "paint": {"circle-color": "#f97316", "circle-radius": 12}}
+    \\  ]
+    \\}
+;
+
+fn stringView(value: []const u8) c.mln_string_view {
+    return .{ .data = value.ptr, .size = value.len };
+}
+
+fn jsonString(value: []const u8) c.mln_json_value {
+    return .{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_STRING,
+        .data = .{ .string_value = stringView(value) },
+    };
+}
+
+fn jsonArray(values: []const c.mln_json_value) c.mln_json_value {
+    return .{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_ARRAY,
+        .data = .{ .array_value = .{ .values = values.ptr, .value_count = values.len } },
+    };
+}
+
+fn viewBytes(view: c.mln_string_view) []const u8 {
+    return view.data[0..view.size];
+}
+
+fn attachTextureSession(map: *c.mln_map) !*c.mln_render_session {
+    var descriptor = c.mln_owned_texture_descriptor_default();
+    descriptor.width = 64;
+    descriptor.height = 64;
+
+    var session: ?*c.mln_render_session = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_owned_texture_attach(map, &descriptor, &session));
+    return session orelse error.SessionAttachFailed;
+}
+
+fn loadStyleAndRender(runtime: *c.mln_runtime, map: *c.mln_map, session: *c.mln_render_session) !void {
+    var camera = c.mln_camera_options_default();
+    camera.fields = c.MLN_CAMERA_OPTION_CENTER | c.MLN_CAMERA_OPTION_ZOOM;
+    camera.latitude = 37.7749;
+    camera.longitude = -122.4194;
+    camera.zoom = 10.0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_jump_to(map, &camera));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, query_style_json));
+    for (0..5) |_| {
+        if (!try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE)) break;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(session));
+    }
+}
+
+fn expectFeatureKind(feature: *const c.mln_queried_feature, expected: []const u8) !void {
+    const properties = feature.feature.properties[0..feature.feature.property_count];
+    for (properties) |property| {
+        if (std.mem.eql(u8, viewBytes(property.key), "kind")) {
+            const value = property.value.?;
+            try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_STRING, value.*.type);
+            try testing.expect(std.mem.eql(u8, viewBytes(value.*.data.string_value), expected));
+            return;
+        }
+    }
+    return error.MissingFeatureKind;
+}
+
+test "feature query ABI structs import" {
+    const rendered_options = c.mln_rendered_feature_query_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_rendered_feature_query_options)), rendered_options.size);
+    try testing.expectEqual(@as(u32, 0), rendered_options.fields);
+
+    const source_options = c.mln_source_feature_query_options_default();
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_source_feature_query_options)), source_options.size);
+    try testing.expectEqual(@as(u32, 0), source_options.fields);
+
+    const geometry = c.mln_rendered_query_geometry_point(.{ .x = 256.0, .y = 256.0 });
+    try testing.expectEqual(@as(u32, @sizeOf(c.mln_rendered_query_geometry)), geometry.size);
+    try testing.expectEqual(c.MLN_RENDERED_QUERY_GEOMETRY_TYPE_POINT, geometry.type);
+}
+
+test "render session queries rendered and source features" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+    const session = try attachTextureSession(map);
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(session)) catch @panic("session destroy failed");
+
+    const point_geometry = c.mln_rendered_query_geometry_point(.{ .x = 256.0, .y = 256.0 });
+    var rendered_result: ?*c.mln_feature_query_result = null;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_STATE, c.mln_render_session_query_rendered_features(session, &point_geometry, null, &rendered_result));
+
+    try loadStyleAndRender(runtime, map, session);
+
+    var query_point: c.mln_screen_point = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_pixel_for_lat_lng(map, .{ .latitude = 37.7749, .longitude = -122.4194 }, &query_point));
+    const rendered_geometry = c.mln_rendered_query_geometry_box(.{
+        .min = .{ .x = query_point.x - 20.0, .y = query_point.y - 20.0 },
+        .max = .{ .x = query_point.x + 20.0, .y = query_point.y + 20.0 },
+    });
+
+    var rendered_options = c.mln_rendered_feature_query_options_default();
+    const layer_ids = [_]c.mln_string_view{stringView("point-circle")};
+    rendered_options.fields = c.MLN_RENDERED_FEATURE_QUERY_OPTION_LAYER_IDS;
+    rendered_options.layer_ids = &layer_ids;
+    rendered_options.layer_id_count = layer_ids.len;
+    const rendered_get_values = [_]c.mln_json_value{ jsonString("get"), jsonString("kind") };
+    const rendered_get_expr = jsonArray(&rendered_get_values);
+    const rendered_filter_values = [_]c.mln_json_value{ jsonString("=="), rendered_get_expr, jsonString("capital") };
+    const rendered_filter = jsonArray(&rendered_filter_values);
+    rendered_options.filter = &rendered_filter;
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_rendered_features(session, &rendered_geometry, &rendered_options, &rendered_result));
+    defer c.mln_feature_query_result_destroy(rendered_result.?);
+
+    var count: usize = 0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_count(rendered_result.?, &count));
+    try testing.expectEqual(@as(usize, 1), count);
+
+    var rendered_feature: c.mln_queried_feature = .{ .size = @sizeOf(c.mln_queried_feature), .fields = 0, .feature = undefined, .source_id = .{ .data = null, .size = 0 }, .source_layer_id = .{ .data = null, .size = 0 }, .state = null };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_get(rendered_result.?, 0, &rendered_feature));
+    try testing.expect((rendered_feature.fields & c.MLN_QUERIED_FEATURE_SOURCE_ID) != 0);
+    try testing.expect(std.mem.eql(u8, viewBytes(rendered_feature.source_id), "point"));
+    try expectFeatureKind(&rendered_feature, "capital");
+
+    var source_options = c.mln_source_feature_query_options_default();
+    const source_get_values = [_]c.mln_json_value{ jsonString("get"), jsonString("kind") };
+    const source_get_expr = jsonArray(&source_get_values);
+    const source_filter_values = [_]c.mln_json_value{ jsonString("=="), source_get_expr, jsonString("capital") };
+    const source_filter = jsonArray(&source_filter_values);
+    source_options.filter = &source_filter;
+
+    var source_result: ?*c.mln_feature_query_result = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_source_features(session, stringView("point"), &source_options, &source_result));
+    defer c.mln_feature_query_result_destroy(source_result.?);
+
+    count = 0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_count(source_result.?, &count));
+    try testing.expectEqual(@as(usize, 1), count);
+
+    var source_feature: c.mln_queried_feature = .{ .size = @sizeOf(c.mln_queried_feature), .fields = 0, .feature = undefined, .source_id = .{ .data = null, .size = 0 }, .source_layer_id = .{ .data = null, .size = 0 }, .state = null };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_get(source_result.?, 0, &source_feature));
+    try testing.expect((source_feature.fields & c.MLN_QUERIED_FEATURE_SOURCE_ID) != 0);
+    try testing.expect(std.mem.eql(u8, viewBytes(source_feature.source_id), "point"));
+    try expectFeatureKind(&source_feature, "capital");
+}
+
+test "feature query validation" {
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+    const session = try attachTextureSession(map);
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(session)) catch @panic("session destroy failed");
+
+    var result: ?*c.mln_feature_query_result = null;
+    var geometry = c.mln_rendered_query_geometry_point(.{ .x = 256.0, .y = 256.0 });
+    geometry.size = @sizeOf(c.mln_rendered_query_geometry) - 1;
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_query_rendered_features(session, &geometry, null, &result));
+
+    geometry = c.mln_rendered_query_geometry_point(.{ .x = std.math.inf(f64), .y = 0.0 });
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_query_rendered_features(session, &geometry, null, &result));
+
+    var rendered_options = c.mln_rendered_feature_query_options_default();
+    rendered_options.fields = @as(u32, 1) << 31;
+    geometry = c.mln_rendered_query_geometry_point(.{ .x = 256.0, .y = 256.0 });
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_query_rendered_features(session, &geometry, &rendered_options, &result));
+
+    try testing.expectEqual(c.MLN_STATUS_INVALID_ARGUMENT, c.mln_render_session_query_source_features(session, .{ .data = null, .size = 1 }, null, &result));
+}


### PR DESCRIPTION
## Summary
- Documents the issue 17 feature query API plan for rendered, source, and extension queries.
- Adds stage 1 C ABI support for rendered and source feature queries on render sessions.
- Adds copied query result handles and Zig C ABI coverage for GeoJSON rendered/source query behavior.

## Tests
- `mise run test`