### PR TITLE
Add feature extension query APIs

### DIFF
--- a/include/maplibre_native_c/query.h
+++ b/include/maplibre_native_c/query.h
@@ -19,6 +19,7 @@ extern "C" {
 #pragma region Rendered and source feature queries
 
 typedef struct mln_feature_query_result mln_feature_query_result;
+typedef struct mln_feature_extension_result mln_feature_extension_result;
 
 /** Rendered feature query geometry variants. */
 typedef enum mln_rendered_query_geometry_type : uint32_t {
@@ -106,6 +107,27 @@ typedef struct mln_queried_feature {
   const mln_json_value* state;
 } mln_queried_feature;
 
+/** Feature extension query result variants. */
+typedef enum mln_feature_extension_result_type : uint32_t {
+  MLN_FEATURE_EXTENSION_RESULT_TYPE_VALUE = 1,
+  MLN_FEATURE_EXTENSION_RESULT_TYPE_FEATURE_COLLECTION = 2,
+} mln_feature_extension_result_type;
+
+/** Tagged feature extension query result view. */
+typedef struct mln_feature_extension_result_info {
+  uint32_t size;
+  /** One of mln_feature_extension_result_type. */
+  uint32_t type;
+  union {
+    /** JSON-like value view selected by
+     * MLN_FEATURE_EXTENSION_RESULT_TYPE_VALUE. */
+    const mln_json_value* value;
+    /** Feature collection view selected by
+     * MLN_FEATURE_EXTENSION_RESULT_TYPE_FEATURE_COLLECTION. */
+    mln_feature_collection feature_collection;
+  } data;
+} mln_feature_extension_result_info;
+
 /** Returns default rendered feature query options. */
 MLN_API mln_rendered_feature_query_options
 mln_rendered_feature_query_options_default(void) MLN_NOEXCEPT;
@@ -178,6 +200,33 @@ MLN_API mln_status mln_render_session_query_source_features(
 ) MLN_NOEXCEPT;
 
 /**
+ * Queries a feature extension from the latest render session state.
+ *
+ * The session renderer must already exist. source_id, feature, extension,
+ * extension_field, and arguments are borrowed for the duration of the call.
+ * arguments may be null. When non-null, arguments must be a JSON object
+ * descriptor. On success, *out_result receives an owned result handle. Destroy
+ * it with mln_feature_extension_result_destroy().
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, source_id,
+ *   feature, extension, extension_field, or arguments are invalid, out_result
+ *   is null, or *out_result is not null.
+ * - MLN_STATUS_INVALID_STATE when the session is detached or no renderer has
+ *   been created for the session yet.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the session
+ *   owner thread.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_render_session_query_feature_extensions(
+  mln_render_session* session, mln_string_view source_id,
+  const mln_feature* feature, mln_string_view extension,
+  mln_string_view extension_field, const mln_json_value* arguments,
+  mln_feature_extension_result** out_result
+) MLN_NOEXCEPT;
+
+/**
  * Gets the number of features in a query result handle.
  *
  * Returns:
@@ -210,6 +259,28 @@ MLN_API mln_status mln_feature_query_result_get(
 /** Destroys a feature query result handle. Null is accepted as a no-op. */
 MLN_API void mln_feature_query_result_destroy(
   mln_feature_query_result* result
+) MLN_NOEXCEPT;
+
+/**
+ * Borrows a feature extension query result view.
+ *
+ * On success, out_info receives views into result-owned storage. Those views
+ * remain valid until result is destroyed.
+ *
+ * Returns:
+ * - MLN_STATUS_OK on success.
+ * - MLN_STATUS_INVALID_ARGUMENT when result is null or not live, out_info is
+ *   null, or out_info->size is too small.
+ * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
+ */
+MLN_API mln_status mln_feature_extension_result_get(
+  const mln_feature_extension_result* result,
+  mln_feature_extension_result_info* out_info
+) MLN_NOEXCEPT;
+
+/** Destroys a feature extension result handle. Null is accepted as a no-op. */
+MLN_API void mln_feature_extension_result_destroy(
+  mln_feature_extension_result* result
 ) MLN_NOEXCEPT;
 
 #pragma endregion

--- a/src/c_api/render_session.cpp
+++ b/src/c_api/render_session.cpp
@@ -187,6 +187,35 @@ auto mln_feature_query_result_destroy(mln_feature_query_result* result) noexcept
   mln::core::feature_query_result_destroy(result);
 }
 
+auto mln_render_session_query_feature_extensions(
+  mln_render_session* session, mln_string_view source_id,
+  const mln_feature* feature, mln_string_view extension,
+  mln_string_view extension_field, const mln_json_value* arguments,
+  mln_feature_extension_result** out_result
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::render_session_query_feature_extensions(
+      session, source_id, feature, extension, extension_field, arguments,
+      out_result
+    );
+  });
+}
+
+auto mln_feature_extension_result_get(
+  const mln_feature_extension_result* result,
+  mln_feature_extension_result_info* out_info
+) noexcept -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::feature_extension_result_get(result, out_info);
+  });
+}
+
+auto mln_feature_extension_result_destroy(
+  mln_feature_extension_result* result
+) noexcept -> void {
+  mln::core::feature_extension_result_destroy(result);
+}
+
 auto mln_json_snapshot_get(
   const mln_json_snapshot* snapshot, const mln_json_value** out_value
 ) noexcept -> mln_status {

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -20,6 +21,7 @@
 #include <mbgl/style/filter.hpp>
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/geojson.hpp>
 #include <mbgl/util/size.hpp>
 
 #include "render/render_session_common.hpp"
@@ -53,6 +55,14 @@ struct mln_feature_query_result {
     features;
 };
 
+struct mln_feature_extension_result {
+  mln_feature_extension_result_info info{};
+  std::unique_ptr<mln::core::OwnedJsonDescriptor> value;
+  std::vector<std::unique_ptr<mln::core::OwnedQueriedFeatureDescriptor>>
+    features;
+  std::vector<mln_feature> feature_roots;
+};
+
 namespace {
 
 auto render_session_mutex() -> std::mutex& {
@@ -77,6 +87,20 @@ auto feature_query_results() -> std::unordered_map<
   static auto value = std::unordered_map<
     const mln_feature_query_result*,
     std::unique_ptr<mln_feature_query_result>>{};
+  return value;
+}
+
+auto feature_extension_result_mutex() -> std::mutex& {
+  static auto value = std::mutex{};
+  return value;
+}
+
+auto feature_extension_results() -> std::unordered_map<
+  const mln_feature_extension_result*,
+  std::unique_ptr<mln_feature_extension_result>>& {
+  static auto value = std::unordered_map<
+    const mln_feature_extension_result*,
+    std::unique_ptr<mln_feature_extension_result>>{};
   return value;
 }
 
@@ -174,6 +198,19 @@ auto validate_screen_point(mln_screen_point point) -> bool {
 }
 
 auto validate_query_result_output(mln_feature_query_result** out_result)
+  -> mln_status {
+  if (out_result == nullptr) {
+    mln::core::set_thread_error("out_result must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (*out_result != nullptr) {
+    mln::core::set_thread_error("*out_result must be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+auto validate_extension_result_output(mln_feature_extension_result** out_result)
   -> mln_status {
   if (out_result == nullptr) {
     mln::core::set_thread_error("out_result must not be null");
@@ -510,6 +547,125 @@ auto find_feature_query_result_locked(const mln_feature_query_result* result)
   -> const mln_feature_query_result* {
   const auto found = feature_query_results().find(result);
   if (found == feature_query_results().end()) {
+    return nullptr;
+  }
+  return found->second.get();
+}
+
+auto validate_non_empty_string(mln_string_view string, const char* name)
+  -> bool {
+  if (!validate_string_view(string)) {
+    return false;
+  }
+  if (string.size == 0) {
+    auto message = std::string{name} + " must not be empty";
+    mln::core::set_thread_error(message.c_str());
+    return false;
+  }
+  return true;
+}
+
+auto to_feature_extension_arguments(const mln_json_value* arguments)
+  -> std::optional<std::optional<std::map<std::string, mbgl::Value>>> {
+  if (arguments == nullptr) {
+    return std::optional<std::map<std::string, mbgl::Value>>{std::nullopt};
+  }
+  auto converted = mln::core::to_native_json_value(arguments);
+  if (!converted) {
+    return std::nullopt;
+  }
+  const auto* object = converted->getObject();
+  if (object == nullptr) {
+    mln::core::set_thread_error(
+      "feature extension arguments must be a JSON object"
+    );
+    return std::nullopt;
+  }
+  auto result = std::map<std::string, mbgl::Value>{};
+  for (const auto& [key, value] : *object) {
+    result.emplace(key, value);
+  }
+  return std::optional<std::map<std::string, mbgl::Value>>{std::move(result)};
+}
+
+auto create_feature_extension_value_result(
+  mbgl::Value value, mln_feature_extension_result** out_result
+) -> mln_status {
+  const auto output_status = validate_extension_result_output(out_result);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+
+  auto result = std::make_unique<mln_feature_extension_result>();
+  result->value = mln::core::to_c_json_value(value);
+  result->info = mln_feature_extension_result_info{
+    .size = sizeof(mln_feature_extension_result_info),
+    .type = MLN_FEATURE_EXTENSION_RESULT_TYPE_VALUE,
+    .data = {.value = &result->value->root}
+  };
+  auto* handle = result.get();
+  const auto lock = std::scoped_lock{feature_extension_result_mutex()};
+  feature_extension_results().emplace(handle, std::move(result));
+  *out_result = handle;
+  return MLN_STATUS_OK;
+}
+
+auto create_feature_extension_collection_result(
+  mbgl::FeatureCollection features, mln_feature_extension_result** out_result
+) -> mln_status {
+  const auto output_status = validate_extension_result_output(out_result);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+
+  auto result = std::make_unique<mln_feature_extension_result>();
+  result->features.reserve(features.size());
+  result->feature_roots.reserve(features.size());
+  for (const auto& feature : features) {
+    result->features.emplace_back(
+      make_queried_feature(mbgl::Feature{feature}, std::nullopt)
+    );
+  }
+  for (const auto& feature : result->features) {
+    result->feature_roots.emplace_back(feature->feature);
+  }
+  result->info = mln_feature_extension_result_info{
+    .size = sizeof(mln_feature_extension_result_info),
+    .type = MLN_FEATURE_EXTENSION_RESULT_TYPE_FEATURE_COLLECTION,
+    .data = {
+      .feature_collection = {
+        .features = result->feature_roots.empty()
+                      ? nullptr
+                      : result->feature_roots.data(),
+        .feature_count = result->feature_roots.size()
+      }
+    }
+  };
+  auto* handle = result.get();
+  const auto lock = std::scoped_lock{feature_extension_result_mutex()};
+  feature_extension_results().emplace(handle, std::move(result));
+  *out_result = handle;
+  return MLN_STATUS_OK;
+}
+
+auto create_feature_extension_result(
+  mbgl::FeatureExtensionValue value, mln_feature_extension_result** out_result
+) -> mln_status {
+  if (value.is<mbgl::Value>()) {
+    return create_feature_extension_value_result(
+      std::move(value.get<mbgl::Value>()), out_result
+    );
+  }
+  return create_feature_extension_collection_result(
+    std::move(value.get<mbgl::FeatureCollection>()), out_result
+  );
+}
+
+auto find_feature_extension_result_locked(
+  const mln_feature_extension_result* result
+) -> const mln_feature_extension_result* {
+  const auto found = feature_extension_results().find(result);
+  if (found == feature_extension_results().end()) {
     return nullptr;
   }
   return found->second.get();
@@ -1062,6 +1218,51 @@ auto render_session_query_source_features(
   );
 }
 
+auto render_session_query_feature_extensions(
+  mln_render_session* session, mln_string_view source_id,
+  const mln_feature* feature, mln_string_view extension,
+  mln_string_view extension_field, const mln_json_value* arguments,
+  mln_feature_extension_result** out_result
+) -> mln_status {
+  const auto status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  const auto output_status = validate_extension_result_output(out_result);
+  if (output_status != MLN_STATUS_OK) {
+    return output_status;
+  }
+  if (
+    !validate_non_empty_string(source_id, "source_id") ||
+    !validate_non_empty_string(extension, "extension") ||
+    !validate_non_empty_string(extension_field, "extension_field")
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto native_feature = to_native_feature(feature);
+  if (!native_feature) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto native_arguments = to_feature_extension_arguments(arguments);
+  if (!native_arguments) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  auto* backend = validate_renderer_backend(session);
+  if (backend == nullptr) {
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto query_feature = mbgl::Feature{std::move(*native_feature)};
+  auto guard = mbgl::gfx::BackendScope{
+    *backend, mbgl::gfx::BackendScope::ScopeType::Implicit
+  };
+  auto result = session->renderer->queryFeatureExtensions(
+    string_from_view(source_id), query_feature, string_from_view(extension),
+    string_from_view(extension_field), std::move(*native_arguments)
+  );
+  return create_feature_extension_result(std::move(result), out_result);
+}
+
 auto feature_query_result_count(
   const mln_feature_query_result* result, std::size_t* out_count
 ) -> mln_status {
@@ -1121,6 +1322,42 @@ auto feature_query_result_destroy(mln_feature_query_result* result) -> void {
   }
   const auto lock = std::scoped_lock{feature_query_result_mutex()};
   feature_query_results().erase(result);
+}
+
+auto feature_extension_result_get(
+  const mln_feature_extension_result* result,
+  mln_feature_extension_result_info* out_info
+) -> mln_status {
+  if (result == nullptr) {
+    set_thread_error("feature extension result must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_info == nullptr) {
+    set_thread_error("out_info must not be null");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (out_info->size < sizeof(mln_feature_extension_result_info)) {
+    set_thread_error("mln_feature_extension_result_info.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto lock = std::scoped_lock{feature_extension_result_mutex()};
+  const auto* live_result = find_feature_extension_result_locked(result);
+  if (live_result == nullptr) {
+    set_thread_error("feature extension result is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  *out_info = live_result->info;
+  return MLN_STATUS_OK;
+}
+
+auto feature_extension_result_destroy(mln_feature_extension_result* result)
+  -> void {
+  if (result == nullptr) {
+    return;
+  }
+  const auto lock = std::scoped_lock{feature_extension_result_mutex()};
+  feature_extension_results().erase(result);
 }
 
 }  // namespace mln::core

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -155,6 +155,12 @@ auto render_session_query_source_features(
   const mln_source_feature_query_options* options,
   mln_feature_query_result** out_result
 ) -> mln_status;
+auto render_session_query_feature_extensions(
+  mln_render_session* session, mln_string_view source_id,
+  const mln_feature* feature, mln_string_view extension,
+  mln_string_view extension_field, const mln_json_value* arguments,
+  mln_feature_extension_result** out_result
+) -> mln_status;
 auto feature_query_result_count(
   const mln_feature_query_result* result, std::size_t* out_count
 ) -> mln_status;
@@ -163,5 +169,11 @@ auto feature_query_result_get(
   mln_queried_feature* out_feature
 ) -> mln_status;
 auto feature_query_result_destroy(mln_feature_query_result* result) -> void;
+auto feature_extension_result_get(
+  const mln_feature_extension_result* result,
+  mln_feature_extension_result_info* out_info
+) -> mln_status;
+auto feature_extension_result_destroy(mln_feature_extension_result* result)
+  -> void;
 
 }  // namespace mln::core

--- a/tests/c/query.zig
+++ b/tests/c/query.zig
@@ -30,6 +30,31 @@ const query_style_json =
     \\}
 ;
 
+const cluster_style_json =
+    \\{
+    \\  "version": 8,
+    \\  "name": "zig-c-cluster-query-test",
+    \\  "sources": {
+    \\    "cluster-source": {
+    \\      "type": "geojson",
+    \\      "cluster": true,
+    \\      "data": {
+    \\        "type": "FeatureCollection",
+    \\        "features": [
+    \\          {"type":"Feature","geometry":{"type":"Point","coordinates":[0.0,0.0]},"properties":{"name":"one"}},
+    \\          {"type":"Feature","geometry":{"type":"Point","coordinates":[0.001,0.001]},"properties":{"name":"two"}},
+    \\          {"type":"Feature","geometry":{"type":"Point","coordinates":[0.002,0.002]},"properties":{"name":"three"}}
+    \\        ]
+    \\      }
+    \\    }
+    \\  },
+    \\  "layers": [
+    \\    {"id":"background","type":"background","paint":{"background-color":"#ffffff"}},
+    \\    {"id":"cluster-circle","type":"circle","source":"cluster-source","filter":["has","point_count"],"paint":{"circle-color":"#2563eb","circle-radius":20}}
+    \\  ]
+    \\}
+;
+
 fn stringView(value: []const u8) c.mln_string_view {
     return .{ .data = value.ptr, .size = value.len };
 }
@@ -42,12 +67,32 @@ fn jsonString(value: []const u8) c.mln_json_value {
     };
 }
 
+fn jsonUint(value: u64) c.mln_json_value {
+    return .{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_UINT,
+        .data = .{ .uint_value = value },
+    };
+}
+
 fn jsonArray(values: []const c.mln_json_value) c.mln_json_value {
     return .{
         .size = @sizeOf(c.mln_json_value),
         .type = c.MLN_JSON_VALUE_TYPE_ARRAY,
         .data = .{ .array_value = .{ .values = values.ptr, .value_count = values.len } },
     };
+}
+
+fn jsonObject(members: []const c.mln_json_member) c.mln_json_value {
+    return .{
+        .size = @sizeOf(c.mln_json_value),
+        .type = c.MLN_JSON_VALUE_TYPE_OBJECT,
+        .data = .{ .object_value = .{ .members = members.ptr, .member_count = members.len } },
+    };
+}
+
+fn jsonMember(key: []const u8, value: *const c.mln_json_value) c.mln_json_member {
+    return .{ .key = stringView(key), .value = value };
 }
 
 fn viewBytes(view: c.mln_string_view) []const u8 {
@@ -73,6 +118,21 @@ fn loadStyleAndRender(runtime: *c.mln_runtime, map: *c.mln_map, session: *c.mln_
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_jump_to(map, &camera));
 
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, query_style_json));
+    for (0..5) |_| {
+        if (!try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE)) break;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(session));
+    }
+}
+
+fn loadClusterStyleAndRender(runtime: *c.mln_runtime, map: *c.mln_map, session: *c.mln_render_session) !void {
+    var camera = c.mln_camera_options_default();
+    camera.fields = c.MLN_CAMERA_OPTION_CENTER | c.MLN_CAMERA_OPTION_ZOOM;
+    camera.latitude = 0.0;
+    camera.longitude = 0.0;
+    camera.zoom = 0.0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_jump_to(map, &camera));
+
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_set_style_json(map, cluster_style_json));
     for (0..5) |_| {
         if (!try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE)) break;
         try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(session));
@@ -174,6 +234,74 @@ test "render session queries rendered and source features" {
     try testing.expect((source_feature.fields & c.MLN_QUERIED_FEATURE_SOURCE_ID) != 0);
     try testing.expect(std.mem.eql(u8, viewBytes(source_feature.source_id), "point"));
     try expectFeatureKind(&source_feature, "capital");
+}
+
+test "render session queries feature extensions" {
+    try support.suppressLogs();
+    defer support.restoreLogs();
+
+    const runtime = try support.createRuntime();
+    defer support.destroyRuntime(runtime);
+    const map = try support.createMap(runtime);
+    defer support.destroyMap(map);
+    const session = try attachTextureSession(map);
+    defer testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_destroy(session)) catch @panic("session destroy failed");
+
+    try loadClusterStyleAndRender(runtime, map, session);
+
+    var query_point: c.mln_screen_point = undefined;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_map_pixel_for_lat_lng(map, .{ .latitude = 0.0, .longitude = 0.0 }, &query_point));
+    const geometry = c.mln_rendered_query_geometry_box(.{
+        .min = .{ .x = query_point.x - 30.0, .y = query_point.y - 30.0 },
+        .max = .{ .x = query_point.x + 30.0, .y = query_point.y + 30.0 },
+    });
+    var options = c.mln_rendered_feature_query_options_default();
+    const layer_ids = [_]c.mln_string_view{stringView("cluster-circle")};
+    options.fields = c.MLN_RENDERED_FEATURE_QUERY_OPTION_LAYER_IDS;
+    options.layer_ids = &layer_ids;
+    options.layer_id_count = layer_ids.len;
+
+    var cluster_result: ?*c.mln_feature_query_result = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_rendered_features(session, &geometry, &options, &cluster_result));
+    defer c.mln_feature_query_result_destroy(cluster_result.?);
+
+    var count: usize = 0;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_count(cluster_result.?, &count));
+    try testing.expectEqual(@as(usize, 1), count);
+
+    var cluster: c.mln_queried_feature = .{ .size = @sizeOf(c.mln_queried_feature), .fields = 0, .feature = undefined, .source_id = .{ .data = null, .size = 0 }, .source_layer_id = .{ .data = null, .size = 0 }, .state = null };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_get(cluster_result.?, 0, &cluster));
+
+    var children_result: ?*c.mln_feature_extension_result = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_feature_extensions(session, stringView("cluster-source"), &cluster.feature, stringView("supercluster"), stringView("children"), null, &children_result));
+    defer c.mln_feature_extension_result_destroy(children_result.?);
+
+    var info: c.mln_feature_extension_result_info = .{ .size = @sizeOf(c.mln_feature_extension_result_info), .type = 0, .data = .{ .value = null } };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_extension_result_get(children_result.?, &info));
+    try testing.expectEqual(c.MLN_FEATURE_EXTENSION_RESULT_TYPE_FEATURE_COLLECTION, info.type);
+    try testing.expect(info.data.feature_collection.feature_count > 0);
+
+    var zoom_result: ?*c.mln_feature_extension_result = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_feature_extensions(session, stringView("cluster-source"), &cluster.feature, stringView("supercluster"), stringView("expansion-zoom"), null, &zoom_result));
+    defer c.mln_feature_extension_result_destroy(zoom_result.?);
+
+    info = .{ .size = @sizeOf(c.mln_feature_extension_result_info), .type = 0, .data = .{ .value = null } };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_extension_result_get(zoom_result.?, &info));
+    try testing.expectEqual(c.MLN_FEATURE_EXTENSION_RESULT_TYPE_VALUE, info.type);
+    try testing.expectEqual(c.MLN_JSON_VALUE_TYPE_UINT, info.data.value.*.type);
+
+    const limit = jsonUint(1);
+    const offset = jsonUint(0);
+    const args_members = [_]c.mln_json_member{ jsonMember("limit", &limit), jsonMember("offset", &offset) };
+    const args = jsonObject(&args_members);
+    var leaves_result: ?*c.mln_feature_extension_result = null;
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_feature_extensions(session, stringView("cluster-source"), &cluster.feature, stringView("supercluster"), stringView("leaves"), &args, &leaves_result));
+    defer c.mln_feature_extension_result_destroy(leaves_result.?);
+
+    info = .{ .size = @sizeOf(c.mln_feature_extension_result_info), .type = 0, .data = .{ .value = null } };
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_extension_result_get(leaves_result.?, &info));
+    try testing.expectEqual(c.MLN_FEATURE_EXTENSION_RESULT_TYPE_FEATURE_COLLECTION, info.type);
+    try testing.expectEqual(@as(usize, 1), info.data.feature_collection.feature_count);
 }
 
 test "feature query validation" {


### PR DESCRIPTION
## Summary
- Adds the stage 2 feature extension query C ABI on render sessions.
- Exposes tagged extension results for JSON values and feature collections.
- Adds C ABI coverage for supercluster children, leaves, and expansion zoom.

Resolves #17 

## Tests
- `mise run test`