### PR TITLE
Refactor render session backend adapters

### DIFF
--- a/src/render/metal/metal_surface_session.mm
+++ b/src/render/metal/metal_surface_session.mm
@@ -249,14 +249,24 @@ class MetalSurfaceBackend final : public mbgl::mtl::RendererBackend,
   void updateAssumedState() override {}
 };
 
-void resize_metal_surface(
-  mln_render_session* surface, uint32_t physical_width, uint32_t physical_height
-) {
-  // Metal sessions always store a Metal backend.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-  static_cast<MetalSurfaceBackend&>(*surface->surface.backend)
-    .setSize(mbgl::Size{physical_width, physical_height});
-}
+class MetalSurfaceSessionBackend final : public mln::core::SurfaceSessionBackend {
+ public:
+  MetalSurfaceSessionBackend(
+    CA::MetalLayer* layer, MTL::Device* host_device, mbgl::Size size
+  )
+      : backend_(layer, host_device, size) {}
+
+  auto renderer_backend() -> mbgl::gfx::RendererBackend& override {
+    return backend_;
+  }
+
+  void resize(uint32_t physical_width, uint32_t physical_height) override {
+    backend_.setSize(mbgl::Size{physical_width, physical_height});
+  }
+
+ private:
+  MetalSurfaceBackend backend_;
+};
 
 auto validate_vulkan_descriptor(const mln_vulkan_surface_descriptor* descriptor)
   -> mln_status {
@@ -331,12 +341,11 @@ auto metal_surface_attach(
     physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->surface.backend = std::make_unique<MetalSurfaceBackend>(
+  session->surface.backend = std::make_unique<MetalSurfaceSessionBackend>(
     static_cast<CA::MetalLayer*>(descriptor->layer),
     static_cast<MTL::Device*>(descriptor->device),
     mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->surface.resize_backend = resize_metal_surface;
   return attach_render_session(
     std::move(session), out_session, RenderSessionKind::Surface,
     RenderSessionAttachMessages{

--- a/src/render/metal/metal_texture_session.mm
+++ b/src/render/metal/metal_texture_session.mm
@@ -168,21 +168,33 @@ auto validate_vulkan_borrowed_descriptor(
   return MLN_STATUS_OK;
 }
 
-auto finish_metal_render(mln_render_session* texture) -> mln_status {
-  // Metal sessions always store a Metal backend.
-  auto& backend =
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-    static_cast<mln::core::MetalTextureBackend&>(*texture->texture.backend);
-  auto* rendered_texture = backend.metal_texture();
-  if (rendered_texture == nullptr) {
-    mln::core::set_thread_error(
-      "render update did not produce a Metal texture"
-    );
-    return MLN_STATUS_INVALID_STATE;
+class MetalTextureSessionBackend final : public mln::core::TextureSessionBackend {
+ public:
+  MetalTextureSessionBackend(MTL::Device* host_device, mbgl::Size size)
+      : backend_(host_device, size) {}
+
+  MetalTextureSessionBackend(MTL::Texture* borrowed_texture, mbgl::Size size)
+      : backend_(borrowed_texture, size) {}
+
+  auto headless_backend() -> mbgl::gfx::HeadlessBackend& override {
+    return backend_;
   }
-  texture->texture.rendered_native_texture = rendered_texture;
-  return MLN_STATUS_OK;
-}
+
+  auto after_render(mln_render_session& texture) -> mln_status override {
+    auto* rendered_texture = backend_.metal_texture();
+    if (rendered_texture == nullptr) {
+      mln::core::set_thread_error(
+        "render update did not produce a Metal texture"
+      );
+      return MLN_STATUS_INVALID_STATE;
+    }
+    texture.texture.rendered_native_texture = rendered_texture;
+    return MLN_STATUS_OK;
+  }
+
+ private:
+  mln::core::MetalTextureBackend backend_;
+};
 
 auto fill_frame(
   mln_render_session* texture, mln_metal_owned_texture_frame* out_frame
@@ -272,11 +284,10 @@ auto metal_owned_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->texture.api_kind = TextureSessionApi::Metal;
   session->texture.mode = TextureSessionMode::Owned;
-  session->texture.backend = std::make_unique<MetalTextureBackend>(
+  session->texture.backend = std::make_unique<MetalTextureSessionBackend>(
     static_cast<MTL::Device*>(descriptor->device),
     mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->texture.after_render = finish_metal_render;
   return attach_render_session(
     std::move(session), out_session, RenderSessionKind::Texture,
     RenderSessionAttachMessages{
@@ -319,11 +330,10 @@ auto metal_borrowed_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->texture.api_kind = TextureSessionApi::Metal;
   session->texture.mode = TextureSessionMode::Borrowed;
-  session->texture.backend = std::make_unique<MetalTextureBackend>(
+  session->texture.backend = std::make_unique<MetalTextureSessionBackend>(
     static_cast<MTL::Texture*>(descriptor->texture),
     mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->texture.after_render = finish_metal_render;
   return attach_render_session(
     std::move(session), out_session, RenderSessionKind::Texture,
     RenderSessionAttachMessages{

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -127,9 +127,9 @@ auto validate_dimensions(
 auto renderer_backend(mln_render_session* session)
   -> mbgl::gfx::RendererBackend* {
   if (session->kind == mln::core::RenderSessionKind::Surface) {
-    return session->surface.backend.get();
+    return &session->surface.backend->renderer_backend();
   }
-  return session->texture.backend->getRendererBackend();
+  return session->texture.backend->renderer_backend();
 }
 
 auto validate_renderer_backend(mln_render_session* session)
@@ -805,11 +805,9 @@ auto render_session_resize(
   const auto physical_width = physical_dimension(width, scale_factor);
   const auto physical_height = physical_dimension(height, scale_factor);
   if (session->kind == RenderSessionKind::Surface) {
-    if (session->surface.resize_backend != nullptr) {
-      session->surface.resize_backend(session, physical_width, physical_height);
-    }
+    session->surface.backend->resize(physical_width, physical_height);
   } else {
-    session->texture.backend->setSize(
+    session->texture.backend->headless_backend().setSize(
       mbgl::Size{physical_width, physical_height}
     );
     session->texture.rendered_native_texture = nullptr;
@@ -848,11 +846,8 @@ auto render_session_render_update(mln_render_session* session) -> mln_status {
     return MLN_STATUS_INVALID_STATE;
   }
 
-  if (
-    session->kind == RenderSessionKind::Texture &&
-    session->texture.prepare_render_resources != nullptr
-  ) {
-    session->texture.prepare_render_resources(session);
+  if (session->kind == RenderSessionKind::Texture) {
+    session->texture.backend->prepare_render_resources();
   }
   auto* backend = renderer_backend(session);
   if (backend == nullptr) {
@@ -871,11 +866,8 @@ auto render_session_render_update(mln_render_session* session) -> mln_status {
   }
 
   session->renderer->render(update);
-  if (
-    session->kind == RenderSessionKind::Texture &&
-    session->texture.after_render != nullptr
-  ) {
-    const auto after_status = session->texture.after_render(session);
+  if (session->kind == RenderSessionKind::Texture) {
+    const auto after_status = session->texture.backend->after_render(*session);
     if (after_status != MLN_STATUS_OK) {
       return after_status;
     }

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -14,6 +14,8 @@
 #include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
 
+struct mln_render_session;
+
 namespace mln::core {
 
 enum class RenderSessionKind : uint8_t { Surface, Texture };
@@ -21,18 +23,52 @@ enum class TextureSessionApi : uint8_t { Generic, Metal, Vulkan };
 enum class TextureSessionFrameKind : uint8_t { None, MetalOwned, VulkanOwned };
 enum class TextureSessionMode : uint8_t { Owned, Borrowed };
 
-using SurfaceSessionResizeCallback =
-  void (*)(mln_render_session*, uint32_t, uint32_t);
-using TextureSessionPrepareCallback = void (*)(mln_render_session*);
-using TextureSessionAfterRenderCallback = mln_status (*)(mln_render_session*);
+class SurfaceSessionBackend {
+ public:
+  SurfaceSessionBackend() = default;
+  SurfaceSessionBackend(const SurfaceSessionBackend&) = delete;
+  auto operator=(const SurfaceSessionBackend&) -> SurfaceSessionBackend& = delete;
+  SurfaceSessionBackend(SurfaceSessionBackend&&) = delete;
+  auto operator=(SurfaceSessionBackend&&) -> SurfaceSessionBackend& = delete;
+  virtual ~SurfaceSessionBackend() = default;
+
+  virtual auto renderer_backend() -> mbgl::gfx::RendererBackend& = 0;
+  virtual void resize(uint32_t physical_width, uint32_t physical_height) = 0;
+};
+
+class TextureSessionBackend {
+ public:
+  TextureSessionBackend() = default;
+  TextureSessionBackend(const TextureSessionBackend&) = delete;
+  auto operator=(const TextureSessionBackend&) -> TextureSessionBackend& = delete;
+  TextureSessionBackend(TextureSessionBackend&&) = delete;
+  auto operator=(TextureSessionBackend&&) -> TextureSessionBackend& = delete;
+  virtual ~TextureSessionBackend() = default;
+
+  virtual auto headless_backend() -> mbgl::gfx::HeadlessBackend& = 0;
+  virtual auto renderer_backend() -> mbgl::gfx::RendererBackend* {
+    return headless_backend().getRendererBackend();
+  }
+  virtual void prepare_render_resources() {}
+  virtual auto after_render(mln_render_session& session) -> mln_status {
+    (void)session;
+    return MLN_STATUS_OK;
+  }
+  virtual auto acquire_vulkan_owned_frame(
+    const mln_render_session& session, mln_vulkan_owned_texture_frame& out_frame
+  ) -> mln_status {
+    (void)session;
+    (void)out_frame;
+    return MLN_STATUS_UNSUPPORTED;
+  }
+};
 
 struct RenderSurfaceState {
-  std::unique_ptr<mbgl::gfx::RendererBackend> backend = nullptr;
-  SurfaceSessionResizeCallback resize_backend = nullptr;
+  std::unique_ptr<SurfaceSessionBackend> backend = nullptr;
 };
 
 struct RenderTextureState {
-  std::unique_ptr<mbgl::gfx::HeadlessBackend> backend = nullptr;
+  std::unique_ptr<TextureSessionBackend> backend = nullptr;
   uint64_t next_frame_id = 1;
   uint64_t acquired_frame_id = 0;
   bool acquired = false;
@@ -41,8 +77,6 @@ struct RenderTextureState {
   TextureSessionMode mode = TextureSessionMode::Owned;
   void* rendered_native_texture = nullptr;
   void* acquired_native_texture = nullptr;
-  TextureSessionPrepareCallback prepare_render_resources = nullptr;
-  TextureSessionAfterRenderCallback after_render = nullptr;
 };
 
 }  // namespace mln::core

--- a/src/render/texture_session.cpp
+++ b/src/render/texture_session.cpp
@@ -45,6 +45,22 @@ auto validate_owned_descriptor(const mln_owned_texture_descriptor* descriptor)
   return MLN_STATUS_OK;
 }
 
+class GenericTextureSessionBackend final : public mln::core::TextureSessionBackend {
+ public:
+  explicit GenericTextureSessionBackend(mbgl::Size size)
+      : backend_(mbgl::gfx::HeadlessBackend::Create(
+          size, mbgl::gfx::Renderable::SwapBehaviour::Flush,
+          mbgl::gfx::ContextMode::Unique
+        )) {}
+
+  auto headless_backend() -> mbgl::gfx::HeadlessBackend& override {
+    return *backend_;
+  }
+
+ private:
+  std::unique_ptr<mbgl::gfx::HeadlessBackend> backend_;
+};
+
 }  // namespace
 
 namespace mln::core {
@@ -132,9 +148,8 @@ auto owned_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->texture.api_kind = TextureSessionApi::Generic;
   session->texture.mode = TextureSessionMode::Owned;
-  session->texture.backend = mbgl::gfx::HeadlessBackend::Create(
-    mbgl::Size{session->physical_width, session->physical_height},
-    mbgl::gfx::Renderable::SwapBehaviour::Flush, mbgl::gfx::ContextMode::Unique
+  session->texture.backend = std::make_unique<GenericTextureSessionBackend>(
+    mbgl::Size{session->physical_width, session->physical_height}
   );
   return attach_render_session(
     std::move(session), out_session, RenderSessionKind::Texture,
@@ -199,7 +214,7 @@ auto texture_read_premultiplied_rgba8(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  auto* renderer_backend = texture->texture.backend->getRendererBackend();
+  auto* renderer_backend = texture->texture.backend->renderer_backend();
   if (renderer_backend == nullptr) {
     set_thread_error("texture session renderer backend is not available");
     return MLN_STATUS_INVALID_STATE;
@@ -207,7 +222,7 @@ auto texture_read_premultiplied_rgba8(
   auto guard = mbgl::gfx::BackendScope{
     *renderer_backend, mbgl::gfx::BackendScope::ScopeType::Implicit
   };
-  auto image = texture->texture.backend->readStillImage();
+  auto image = texture->texture.backend->headless_backend().readStillImage();
   if (!image.valid()) {
     set_thread_error("texture readback did not produce an image");
     return MLN_STATUS_INVALID_STATE;

--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -379,12 +379,25 @@ class VulkanSurfaceBackend final : public mbgl::vulkan::RendererBackend,
   mln_vulkan_surface_descriptor descriptor_;
 };
 
-void resize_vulkan_surface(
-  mln_render_session* surface, uint32_t physical_width, uint32_t physical_height
-) {
-  static_cast<VulkanSurfaceBackend&>(*surface->surface.backend)
-    .setSize(mbgl::Size{physical_width, physical_height});
-}
+class VulkanSurfaceSessionBackend final
+    : public mln::core::SurfaceSessionBackend {
+ public:
+  VulkanSurfaceSessionBackend(
+    const mln_vulkan_surface_descriptor& descriptor, mbgl::Size size
+  )
+      : backend_(descriptor, size) {}
+
+  auto renderer_backend() -> mbgl::gfx::RendererBackend& override {
+    return backend_;
+  }
+
+  void resize(uint32_t physical_width, uint32_t physical_height) override {
+    backend_.setSize(mbgl::Size{physical_width, physical_height});
+  }
+
+ private:
+  VulkanSurfaceBackend backend_;
+};
 
 }  // namespace
 
@@ -461,10 +474,9 @@ auto vulkan_surface_attach(
     physical_dimension(descriptor->width, descriptor->scale_factor);
   session->physical_height =
     physical_dimension(descriptor->height, descriptor->scale_factor);
-  session->surface.backend = std::make_unique<VulkanSurfaceBackend>(
+  session->surface.backend = std::make_unique<VulkanSurfaceSessionBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->surface.resize_backend = resize_vulkan_surface;
   return attach_render_session(
     std::move(session), out_session, RenderSessionKind::Surface,
     RenderSessionAttachMessages{

--- a/src/render/vulkan/vulkan_texture_session.cpp
+++ b/src/render/vulkan/vulkan_texture_session.cpp
@@ -214,13 +214,52 @@ auto validate_vulkan_handles(
   return MLN_STATUS_OK;
 }
 
-void prepare_vulkan_render_resources(mln_render_session* texture) {
-  // Renderer::render creates the Vulkan context before requesting the default
-  // renderable, so shared-device resources must be ready first.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-  static_cast<mln::core::VulkanTextureBackend&>(*texture->texture.backend)
-    .prepareRenderResources();
-}
+class VulkanTextureSessionBackend final
+    : public mln::core::TextureSessionBackend {
+ public:
+  VulkanTextureSessionBackend(
+    const mln_vulkan_owned_texture_descriptor& descriptor, mbgl::Size size
+  )
+      : backend_(descriptor, size) {}
+
+  VulkanTextureSessionBackend(
+    const mln_vulkan_borrowed_texture_descriptor& descriptor, mbgl::Size size
+  )
+      : backend_(descriptor, size) {}
+
+  auto headless_backend() -> mbgl::gfx::HeadlessBackend& override {
+    return backend_;
+  }
+
+  void prepare_render_resources() override {
+    // Renderer::render creates the Vulkan context before requesting the default
+    // renderable, so shared-device resources must be ready first.
+    backend_.prepareRenderResources();
+  }
+
+  auto acquire_vulkan_owned_frame(
+    const mln_render_session& texture, mln_vulkan_owned_texture_frame& out_frame
+  ) -> mln_status override {
+    const auto resources = backend_.frame_resources();
+    out_frame = mln_vulkan_owned_texture_frame{
+      .size = sizeof(mln_vulkan_owned_texture_frame),
+      .generation = texture.generation,
+      .width = texture.physical_width,
+      .height = texture.physical_height,
+      .scale_factor = texture.scale_factor,
+      .frame_id = texture.texture.next_frame_id,
+      .image = resources.image,
+      .image_view = resources.image_view,
+      .device = resources.device,
+      .format = static_cast<uint32_t>(resources.format),
+      .layout = static_cast<uint32_t>(vk::ImageLayout::eShaderReadOnlyOptimal),
+    };
+    return MLN_STATUS_OK;
+  }
+
+ private:
+  VulkanTextureBackend backend_;
+};
 
 }  // namespace
 
@@ -304,10 +343,9 @@ auto vulkan_owned_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->texture.api_kind = TextureSessionApi::Vulkan;
   session->texture.mode = TextureSessionMode::Owned;
-  session->texture.backend = std::make_unique<VulkanTextureBackend>(
+  session->texture.backend = std::make_unique<VulkanTextureSessionBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->texture.prepare_render_resources = prepare_vulkan_render_resources;
   return attach_render_session(
     std::move(session), out_session, RenderSessionKind::Texture,
     RenderSessionAttachMessages{
@@ -372,10 +410,9 @@ auto vulkan_borrowed_texture_attach(
     physical_dimension(descriptor->height, descriptor->scale_factor);
   session->texture.api_kind = TextureSessionApi::Vulkan;
   session->texture.mode = TextureSessionMode::Borrowed;
-  session->texture.backend = std::make_unique<VulkanTextureBackend>(
+  session->texture.backend = std::make_unique<VulkanTextureSessionBackend>(
     *descriptor, mbgl::Size{session->physical_width, session->physical_height}
   );
-  session->texture.prepare_render_resources = prepare_vulkan_render_resources;
   return attach_render_session(
     std::move(session), out_session, RenderSessionKind::Texture,
     RenderSessionAttachMessages{
@@ -416,24 +453,11 @@ auto vulkan_owned_texture_acquire_frame(
     return MLN_STATUS_UNSUPPORTED;
   }
 
-  // The Vulkan acquire path is only valid for owned Vulkan sessions, and this
-  // Linux build only creates Vulkan sessions.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-  auto& backend = static_cast<VulkanTextureBackend&>(*texture->texture.backend);
-  const auto resources = backend.frame_resources();
-  *out_frame = mln_vulkan_owned_texture_frame{
-    .size = sizeof(mln_vulkan_owned_texture_frame),
-    .generation = texture->generation,
-    .width = texture->physical_width,
-    .height = texture->physical_height,
-    .scale_factor = texture->scale_factor,
-    .frame_id = texture->texture.next_frame_id,
-    .image = resources.image,
-    .image_view = resources.image_view,
-    .device = resources.device,
-    .format = static_cast<uint32_t>(resources.format),
-    .layout = static_cast<uint32_t>(vk::ImageLayout::eShaderReadOnlyOptimal),
-  };
+  const auto acquire_status =
+    texture->texture.backend->acquire_vulkan_owned_frame(*texture, *out_frame);
+  if (acquire_status != MLN_STATUS_OK) {
+    return acquire_status;
+  }
   texture->texture.acquired = true;
   texture->texture.acquired_frame_id = out_frame->frame_id;
   texture->texture.acquired_frame_kind = TextureSessionFrameKind::VulkanOwned;


### PR DESCRIPTION
## Summary

Refactors render session platform backend ownership behind surface and texture session adapter interfaces. The common render path now calls backend capabilities directly instead of storing callback slots and downcasting the session backend for platform-specific behavior.

## Why

This removes the repeated `cppcoreguidelines-pro-type-static-cast-downcast` suppressions from session control flow while keeping the C ABI and platform attachment APIs unchanged. Platform-specific casts are now limited to resource boundaries where MapLibre returns platform-typed objects through generic pointers.

## Validation

- `mise run build`
- `hk check --all --profile ci-native --step clang-tidy --step clang-tidy-macos --no-progress`