### PR TITLE
Update docs branding

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.4",
+    "@fontsource/alata": "^5.2.8",
     "astro": "^6.1.9",
     "sharp": "^0.34.5",
     "starlight-copy-button": "github:dionysuzx/starlight-copy-button",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.38.4
         version: 0.38.4(astro@6.2.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.4))
+      '@fontsource/alata':
+        specifier: ^5.2.8
+        version: 5.2.8
       astro:
         specifier: ^6.1.9
         version: 6.2.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.2)(yaml@2.8.4)
@@ -287,6 +290,9 @@ packages:
 
   '@expressive-code/plugin-text-markers@0.41.7':
     resolution: {integrity: sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==}
+
+  '@fontsource/alata@5.2.8':
+    resolution: {integrity: sha512-E+QjT/nw8t2J7qJ+20mN0b/mVc6jXDTPyZHM3/VnOLj86GA91l2whD2EgBcLU5zi5/GVp5Gyzh/RcwiwkbQ89g==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3218,6 +3224,8 @@ snapshots:
   '@expressive-code/plugin-text-markers@0.41.7':
     dependencies:
       '@expressive-code/core': 0.41.7
+
+  '@fontsource/alata@5.2.8': {}
 
   '@img/colour@1.1.0': {}
 

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,3 +1,5 @@
+@import "@fontsource/alata/400.css";
+
 /* Dark mode colors. */
 :root {
   --sl-color-accent-low: #002a30;
@@ -26,4 +28,9 @@
   --sl-color-gray-6: #e3e5e8;
   --sl-color-gray-7: #f1f3f5;
   --sl-color-black: #ffffff;
+}
+
+.site-title {
+  font-family: "Alata", var(--sl-font-system);
+  font-weight: 400;
 }

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -2,31 +2,31 @@
 
 /* Dark mode colors. */
 :root {
-  --sl-color-accent-low: #002a30;
-  --sl-color-accent: #5fd9e8;
-  --sl-color-accent-high: #b8eef5;
+  --sl-color-accent-low: #19345f;
+  --sl-color-accent: #95befa;
+  --sl-color-accent-high: #dceaff;
   --sl-color-white: #ffffff;
-  --sl-color-gray-1: #e8eaed;
-  --sl-color-gray-2: #b8bcc2;
-  --sl-color-gray-3: #88909a;
-  --sl-color-gray-4: #4a5058;
-  --sl-color-gray-5: #2a2e34;
-  --sl-color-gray-6: #1a1d20;
-  --sl-color-black: #0e1012;
+  --sl-color-gray-1: #f4f8ff;
+  --sl-color-gray-2: #c9d5e8;
+  --sl-color-gray-3: #9aa7bc;
+  --sl-color-gray-4: #5e6b82;
+  --sl-color-gray-5: #2a374d;
+  --sl-color-gray-6: #172033;
+  --sl-color-black: #111725;
 }
 /* Light mode colors. */
 :root[data-theme="light"] {
-  --sl-color-accent-low: #c5edf2;
-  --sl-color-accent: #006a78;
-  --sl-color-accent-high: #00343c;
-  --sl-color-white: #0e1012;
-  --sl-color-gray-1: #1a1d20;
-  --sl-color-gray-2: #2a2e34;
-  --sl-color-gray-3: #4a5058;
-  --sl-color-gray-4: #7a8088;
-  --sl-color-gray-5: #b4b8be;
-  --sl-color-gray-6: #e3e5e8;
-  --sl-color-gray-7: #f1f3f5;
+  --sl-color-accent-low: #dbe9ff;
+  --sl-color-accent: #285daa;
+  --sl-color-accent-high: #263f75;
+  --sl-color-white: #111725;
+  --sl-color-gray-1: #172033;
+  --sl-color-gray-2: #2f3b50;
+  --sl-color-gray-3: #546176;
+  --sl-color-gray-4: #7f8ca1;
+  --sl-color-gray-5: #b8c6dc;
+  --sl-color-gray-6: #e8f1ff;
+  --sl-color-gray-7: #f7faff;
   --sl-color-black: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- Use the Alata Fontsource package for the docs site title next to the logo.
- Refresh the Starlight color palette around MapLibre brand blues with AA/AAA-friendly contrast targets.

## Testing
- pnpm build