### PR TITLE
[codex] Remove pkg-config files

### DIFF
--- a/.mise/tasks/ensure-native-library
+++ b/.mise/tasks/ensure-native-library
@@ -5,11 +5,6 @@ if [[ "${CI:-}" != "true" ]]; then
   exec mise run //:build
 fi
 
-if [[ ! -f build/pkgconfig/maplibre-native-c.pc ]]; then
-  echo "missing build/pkgconfig/maplibre-native-c.pc; native artifact was not downloaded" >&2
-  exit 1
-fi
-
 found=false
 for lib in build/libmaplibre-native-c.*; do
   if [[ -f "$lib" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/mln_version.cmake)
 
-set(MLN_PC_PREFIX "${PROJECT_SOURCE_DIR}")
-set(MLN_PC_INCLUDEDIR "${PROJECT_SOURCE_DIR}/include")
-set(MLN_PC_LIBDIR "${PROJECT_BINARY_DIR}")
-configure_file(
-  "${PROJECT_SOURCE_DIR}/cmake/maplibre-native-c.pc.in"
-  "${PROJECT_BINARY_DIR}/pkgconfig/maplibre-native-c.pc"
-  @ONLY)
-
 set(MLN_WITH_CORE_ONLY ON CACHE BOOL "Build only MapLibre Native core" FORCE)
 set(MLN_WITH_GLFW OFF CACHE BOOL "Disable MapLibre Native GLFW platform" FORCE)
 set(MLN_WITH_PMTILES ON

--- a/cmake/maplibre-native-c.ci-artifact.pc
+++ b/cmake/maplibre-native-c.ci-artifact.pc
@@ -1,9 +1,0 @@
-prefix=${pcfiledir}/../..
-includedir=${prefix}/include
-libdir=${prefix}/build
-
-Name: maplibre-native-c
-Description: C ABI for MapLibre Native
-Version: 0
-Cflags: -I${includedir}
-Libs: -L${libdir} -lmaplibre-native-c

--- a/cmake/maplibre-native-c.pc.in
+++ b/cmake/maplibre-native-c.pc.in
@@ -1,9 +1,0 @@
-prefix=@MLN_PC_PREFIX@
-includedir=@MLN_PC_INCLUDEDIR@
-libdir=@MLN_PC_LIBDIR@
-
-Name: maplibre-native-c
-Description: C ABI for MapLibre Native
-Version: 0
-Cflags: -I${includedir}
-Libs: -L${libdir} -lmaplibre-native-c

--- a/examples/swift-map/Package.swift
+++ b/examples/swift-map/Package.swift
@@ -10,13 +10,13 @@ let package = Package(
   ],
   targets: [
     .systemLibrary(
-      name: "CMapLibreNativeC",
-      pkgConfig: "maplibre-native-c"
+      name: "CMapLibreNativeC"
     ),
     .executableTarget(
       name: "SwiftMap",
       dependencies: ["CMapLibreNativeC"],
       linkerSettings: [
+        .unsafeFlags(["-L../../build", "-lmaplibre-native-c"]),
         .linkedFramework("AppKit"),
         .linkedFramework("Metal"),
         .linkedFramework("QuartzCore"),

--- a/examples/swift-map/mise.toml
+++ b/examples/swift-map/mise.toml
@@ -1,6 +1,3 @@
-[env]
-PKG_CONFIG_PATH = "{{config_root}}/../../build/pkgconfig"
-
 [tasks.ci]
 run = ["mise run :build"]
 

--- a/examples/zig-map/build.zig
+++ b/examples/zig-map/build.zig
@@ -5,8 +5,11 @@ const BuildOptions = struct {
     optimize: std.builtin.OptimizeMode,
 };
 
-fn linkMapLibreC(module: *std.Build.Module) void {
-    module.linkSystemLibrary("maplibre-native-c", .{ .use_pkg_config = .force });
+fn linkMapLibreC(b: *std.Build, module: *std.Build.Module) void {
+    module.addIncludePath(b.path("../../include"));
+    module.addLibraryPath(b.path("../../build"));
+    module.addRPath(b.path("../../build"));
+    module.linkSystemLibrary("maplibre-native-c", .{});
     module.link_libc = true;
 }
 
@@ -28,7 +31,7 @@ fn addZigMapExample(b: *std.Build, options: BuildOptions) *std.Build.Step.Compil
         }),
     });
 
-    linkMapLibreC(example.root_module);
+    linkMapLibreC(b, example.root_module);
     example.root_module.addIncludePath(b.path("../../.pixi/envs/default/include"));
     example.root_module.addLibraryPath(b.path("../../.pixi/envs/default/lib"));
     example.root_module.addRPath(b.path("../../.pixi/envs/default/lib"));

--- a/examples/zig-map/mise.toml
+++ b/examples/zig-map/mise.toml
@@ -1,10 +1,3 @@
-[env]
-DYLD_LIBRARY_PATH = "{{config_root}}/../../build"
-LD_LIBRARY_PATH = "{{config_root}}/../../build"
-PKG_CONFIG = "{{config_root}}/../../.pixi/envs/default/bin/pkg-config"
-PKG_CONFIG_PATH = "{{config_root}}/../../build/pkgconfig"
-XDG_DATA_DIRS = "{{config_root}}/../../.pixi/envs/default/share:{{env.XDG_DATA_DIRS | default(value=\"/usr/local/share:/usr/share\")}}"
-
 [tasks.ci]
 run = ["mise run :build"]
 

--- a/examples/zig-readback/build.zig
+++ b/examples/zig-readback/build.zig
@@ -5,8 +5,11 @@ const BuildOptions = struct {
     optimize: std.builtin.OptimizeMode,
 };
 
-fn linkMapLibreC(module: *std.Build.Module) void {
-    module.linkSystemLibrary("maplibre-native-c", .{ .use_pkg_config = .force });
+fn linkMapLibreC(b: *std.Build, module: *std.Build.Module) void {
+    module.addIncludePath(b.path("../../include"));
+    module.addLibraryPath(b.path("../../build"));
+    module.addRPath(b.path("../../build"));
+    module.linkSystemLibrary("maplibre-native-c", .{});
     module.link_libc = true;
 }
 
@@ -20,7 +23,7 @@ fn addReadbackExample(b: *std.Build, options: BuildOptions) *std.Build.Step.Comp
         }),
     });
 
-    linkMapLibreC(example.root_module);
+    linkMapLibreC(b, example.root_module);
     example.root_module.addLibraryPath(b.path("../../.pixi/envs/default/lib"));
     example.root_module.addRPath(b.path("../../.pixi/envs/default/lib"));
     b.installArtifact(example);

--- a/examples/zig-readback/mise.toml
+++ b/examples/zig-readback/mise.toml
@@ -1,10 +1,3 @@
-[env]
-DYLD_LIBRARY_PATH = "{{config_root}}/../../build"
-LD_LIBRARY_PATH = "{{config_root}}/../../build"
-PKG_CONFIG = "{{config_root}}/../../.pixi/envs/default/bin/pkg-config"
-PKG_CONFIG_PATH = "{{config_root}}/../../build/pkgconfig"
-XDG_DATA_DIRS = "{{config_root}}/../../.pixi/envs/default/share:{{env.XDG_DATA_DIRS | default(value=\"/usr/local/share:/usr/share\")}}"
-
 [tasks.ci]
 run = ["mise run :run"]
 

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -17,6 +17,7 @@ run = [
 [tasks."ci:prepare-native-artifact"]
 run = [
   "rm -rf ci-artifact",
+  "mkdir -p ci-artifact/build",
   "mkdir -p ci-artifact/third_party/maplibre-native/vendor/Vulkan-Headers",
   "cp build/libmaplibre-native-c.* ci-artifact/build",
   "cp -R third_party/maplibre-native/vendor/Vulkan-Headers/include ci-artifact/third_party/maplibre-native/vendor/Vulkan-Headers/include",

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -17,9 +17,7 @@ run = [
 [tasks."ci:prepare-native-artifact"]
 run = [
   "rm -rf ci-artifact",
-  "mkdir -p ci-artifact/build/pkgconfig",
   "mkdir -p ci-artifact/third_party/maplibre-native/vendor/Vulkan-Headers",
   "cp build/libmaplibre-native-c.* ci-artifact/build",
-  "cp cmake/maplibre-native-c.ci-artifact.pc ci-artifact/build/pkgconfig/maplibre-native-c.pc",
   "cp -R third_party/maplibre-native/vendor/Vulkan-Headers/include ci-artifact/third_party/maplibre-native/vendor/Vulkan-Headers/include",
 ]

--- a/mise.toml
+++ b/mise.toml
@@ -25,6 +25,11 @@ pnpm = "10.33.2"
 node = "24.11.0"
 usage = "3.3.0"
 
+[env]
+DYLD_LIBRARY_PATH = "{{config_root}}/build"
+LD_LIBRARY_PATH = "{{config_root}}/build"
+XDG_DATA_DIRS = "{{config_root}}/.pixi/envs/default/share:{{env.XDG_DATA_DIRS | default(value=\"/usr/local/share:/usr/share\")}}"
+
 [hooks]
 postinstall = [
   "hk install --mise",
@@ -45,7 +50,6 @@ run = "rm -rf build"
 
 [tasks.test]
 depends = ["//:build"]
-env = { XDG_DATA_DIRS = "{{config_root}}/.pixi/envs/default/share" }
 run = "zig build test --summary all"
 
 [tasks.check]


### PR DESCRIPTION
## Summary

Reopens #10.

This removes the generated and CI artifact `maplibre-native-c.pc` metadata and switches the example consumers to direct local paths instead.

## Changes

- Stop generating `build/pkgconfig/maplibre-native-c.pc` from CMake.
- Delete the local and CI-artifact pkg-config files under `cmake/`.
- Link the Zig examples directly against the repository `include` directory and CMake `build` output.
- Link the Swift example through its module map plus explicit local linker flags.
- Simplify the CI native artifact to carry only the built library and Vulkan headers.
- Move shared native runtime environment paths into the root `mise.toml`.

## Validation

- `mise run fix`
- `mise run test`
- `mise run //examples/zig-readback:build`
- `mise run //examples/zig-map:build`
- `mise run //examples/swift-map:build`
- `MISE_ENV=ci mise run ci:prepare-native-artifact`