### PR TITLE
Fix zig-map Vulkan shutdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,10 @@
 ## Workflow
 
 Use `mise run test` to build and test. Use `mise run fix` to run formatters and
-linters. Run examples only when useful, with a brief timeout because most are
+linters. Read the
+[development overview](docs/src/content/docs/development/overview.md) for
+contributor setup, workflow commands, examples, and platform/render backend
+variants. Run examples only when useful, with a brief timeout because most are
 GUI apps, not one-shot tests.
 
 Feature changes need tests through the C ABI when practical.

--- a/examples/zig-map/main.zig
+++ b/examples/zig-map/main.zig
@@ -55,6 +55,9 @@ pub fn main(init_args: std.process.Init) !void {
 
     var map = try map_state.MapState.init(current_viewport, &backend);
     defer map.deinit();
+    defer backend.finishFrame() catch |err| {
+        std.debug.print("failed to finish final frame: {s}\n", .{@errorName(err)});
+    };
 
     var running = true;
     var has_presented_frame = false;


### PR DESCRIPTION
## Summary
- release the final pending Vulkan frame before destroying the map render session
- link AGENTS.md to the development overview for backend variant workflow guidance

## Verification
- mise run fix
- mise -E macos-arm64-vulkan run test
- manual zig-map Vulkan runs for owned-texture, borrowed-texture, and native-surface exited 0 after shutdown