### PR TITLE
Generate CI matrices from variant config

### DIFF
--- a/.github/config/variants.toml
+++ b/.github/config/variants.toml
@@ -1,0 +1,16 @@
+[runners]
+linux-arm64 = "ubuntu-24.04-arm"
+linux-x64 = "ubuntu-latest"
+macos-arm64 = "macos-latest"
+
+[examples.swift-map]
+task = "//examples/swift-map:build"
+requires = { platform = ["macos"], backend = ["metal"] }
+
+[examples.zig-map]
+task = "//examples/zig-map:build"
+requires = { platform = ["linux", "macos"], backend = ["metal", "vulkan"] }
+
+[examples.zig-readback]
+task = "//examples/zig-readback:run"
+requires = { platform = ["linux", "macos"], backend = ["metal", "vulkan"] }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,40 +28,31 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
       - run: mise run //docs:build
 
-  prepare-native-matrix:
-    name: prepare native matrix
+  prepare-matrices:
+    name: prepare matrices
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
+      native: ${{ steps.matrix.outputs.native }}
+      examples: ${{ steps.matrix.outputs.examples }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ci-deps
       - id: matrix
-        run: echo "matrix=$(mise run -q ci:matrix native)" >> "$GITHUB_OUTPUT"
-
-  prepare-example-matrix:
-    name: prepare example matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-ci-deps
-      - id: matrix
-        run: echo "matrix=$(mise run -q ci:matrix examples)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "native=$(mise run -q ci:matrix native)" >> "$GITHUB_OUTPUT"
+          echo "examples=$(mise run -q ci:matrix examples)" >> "$GITHUB_OUTPUT"
 
   native:
     name: native / ${{ matrix.variant }}
     runs-on: ${{ matrix.runner }}
-    needs: prepare-native-matrix
+    needs: prepare-matrices
     timeout-minutes: 60
     env:
       MISE_ENV: ${{ matrix.variant }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-native-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.prepare-matrices.outputs.native) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ci-deps
@@ -86,13 +77,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs:
       - native
-      - prepare-example-matrix
+      - prepare-matrices
     timeout-minutes: 60
     env:
       MISE_ENV: ${{ matrix.variant }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-example-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.prepare-matrices.outputs.examples) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ci-deps
@@ -110,8 +101,7 @@ jobs:
     needs:
       - hygiene
       - docs
-      - prepare-native-matrix
-      - prepare-example-matrix
+      - prepare-matrices
       - native
       - examples
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,24 +28,40 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
       - run: mise run //docs:build
 
+  prepare-native-matrix:
+    name: prepare native matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-ci-deps
+      - id: matrix
+        run: echo "matrix=$(mise run -q ci:matrix native)" >> "$GITHUB_OUTPUT"
+
+  prepare-example-matrix:
+    name: prepare example matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-ci-deps
+      - id: matrix
+        run: echo "matrix=$(mise run -q ci:matrix examples)" >> "$GITHUB_OUTPUT"
+
   native:
     name: native / ${{ matrix.variant }}
     runs-on: ${{ matrix.runner }}
+    needs: prepare-native-matrix
     timeout-minutes: 60
     env:
       MISE_ENV: ${{ matrix.variant }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - variant: linux-x64-vulkan
-            runner: ubuntu-latest
-          - variant: linux-arm64-vulkan
-            runner: ubuntu-24.04-arm
-          - variant: macos-arm64-metal
-            runner: macos-latest
-          - variant: macos-arm64-vulkan
-            runner: macos-latest
+      matrix: ${{ fromJson(needs.prepare-native-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ci-deps
@@ -68,41 +84,15 @@ jobs:
   examples:
     name: examples / ${{ matrix.example }} / ${{ matrix.variant }}
     runs-on: ${{ matrix.runner }}
-    needs: native
+    needs:
+      - native
+      - prepare-example-matrix
     timeout-minutes: 60
     env:
       MISE_ENV: ${{ matrix.variant }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - example: zig-map
-            variant: linux-x64-vulkan
-            runner: ubuntu-latest
-          - example: zig-map
-            variant: linux-arm64-vulkan
-            runner: ubuntu-24.04-arm
-          - example: zig-map
-            variant: macos-arm64-metal
-            runner: macos-latest
-          - example: zig-map
-            variant: macos-arm64-vulkan
-            runner: macos-latest
-          - example: zig-readback
-            variant: linux-x64-vulkan
-            runner: ubuntu-latest
-          - example: zig-readback
-            variant: linux-arm64-vulkan
-            runner: ubuntu-24.04-arm
-          - example: zig-readback
-            variant: macos-arm64-metal
-            runner: macos-latest
-          - example: zig-readback
-            variant: macos-arm64-vulkan
-            runner: macos-latest
-          - example: swift-map
-            variant: macos-arm64-metal
-            runner: macos-latest
+      matrix: ${{ fromJson(needs.prepare-example-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ci-deps
@@ -110,7 +100,7 @@ jobs:
         with:
           name: native-${{ matrix.variant }}
           path: .
-      - run: mise run //examples/${{ matrix.example }}:ci
+      - run: mise run "${{ matrix.task }}"
 
   required:
     name: ci-required
@@ -120,6 +110,8 @@ jobs:
     needs:
       - hygiene
       - docs
+      - prepare-native-matrix
+      - prepare-example-matrix
       - native
       - examples
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ docs/src/content/docs/reference/c.md
 zig-out/
 zig-pkg/
 *.spv
+__pycache__/
+.venv/
 
 # Fetched on demand by CMake (see cmake/mln_version.cmake) when
 # MLN_SOURCE_DIR is not set externally.

--- a/.mise/tasks/ci/matrix.py
+++ b/.mise/tasks/ci/matrix.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# [MISE] description="Generate GitHub Actions matrix JSON"
+# [USAGE] arg "<matrix>" help="Matrix to generate" {
+# [USAGE]   choices "native" "examples"
+# [USAGE] }
+# [USAGE] flag "--schema <schema>" help="Path to the GitHub matrix config"
+# [USAGE] flag "--pretty" help="Print indented JSON for local inspection"
+
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+type TomlValue = str | int | float | bool | list[TomlValue] | dict[str, TomlValue]
+type TomlTable = dict[str, TomlValue]
+type MatrixEntry = dict[str, str]
+type Matrix = dict[str, list[MatrixEntry]]
+
+
+def load_toml(path: Path) -> TomlTable:
+    """Read a TOML file."""
+    with path.open("rb") as toml_file:
+        return tomllib.load(toml_file)
+
+
+def as_table(value: TomlValue | None) -> TomlTable:
+    """Return a TOML value as a table."""
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def as_table_map(value: TomlValue | None) -> dict[str, TomlTable]:
+    """Return a TOML value as a table of tables."""
+    if not isinstance(value, dict):
+        return {}
+
+    return {key: nested for key, nested in value.items() if isinstance(nested, dict)}
+
+
+def as_exclusion_list(value: TomlValue | None) -> list[TomlTable]:
+    """Return a TOML value as a list of exclusion tables."""
+    if not isinstance(value, list):
+        return []
+
+    return [item for item in value if isinstance(item, dict)]
+
+
+def string_value(table: TomlTable, key: str) -> str:
+    """Return a required TOML table string."""
+    value = table[key]
+    if isinstance(value, str):
+        return value
+
+    message = f"{key} must be a string"
+    raise TypeError(message)
+
+
+def value_matches(requirement: TomlValue, value: TomlValue | None) -> bool:
+    """Return whether a variant value satisfies an example requirement."""
+    if isinstance(requirement, list):
+        return value in requirement
+    return value == requirement
+
+
+def exclusion_matches(exclusion: TomlTable, variant: TomlTable) -> bool:
+    """Return whether a variant matches an explicit exclusion."""
+    for key, value in exclusion.items():
+        if key != "reason" and variant.get(key) != value:
+            return False
+    return True
+
+
+def supports(example: TomlTable, variant: TomlTable) -> bool:
+    """Return whether an example supports a variant."""
+    requirements = as_table(example.get("requires"))
+    for key, requirement in requirements.items():
+        if key not in variant or not value_matches(requirement, variant[key]):
+            return False
+
+    for exclusion in as_exclusion_list(example.get("exclude")):
+        if exclusion_matches(exclusion, variant):
+            return False
+
+    return True
+
+
+def variant_from_profile(
+    profile_path: Path,
+    runners: TomlTable,
+) -> tuple[str, TomlTable]:
+    """Read variant metadata from a mise environment profile."""
+    profile = load_toml(profile_path)
+    env = as_table(profile.get("env"))
+    variant_name = string_value(env, "MLN_FFI_VARIANT")
+    target_triple = string_value(env, "MLN_FFI_TARGET_TRIPLE")
+    backend = string_value(env, "MLN_FFI_RENDER_BACKEND")
+    platform, arch = target_triple.split("-", maxsplit=1)
+
+    return variant_name, {
+        "platform": platform,
+        "arch": arch,
+        "backend": backend,
+        "runner": string_value(runners, target_triple),
+    }
+
+
+def load_variants(repo_root: Path, schema: TomlTable) -> dict[str, TomlTable]:
+    """Load variants from mise environment profiles."""
+    runners = as_table(schema.get("runners"))
+    variants: dict[str, TomlTable] = {}
+    for profile_path in repo_root.glob("mise.*.toml"):
+        variant_name, variant = variant_from_profile(profile_path, runners)
+        variants[variant_name] = variant
+    return dict(sorted(variants.items()))
+
+
+def native_matrix(variants: dict[str, TomlTable]) -> Matrix:
+    """Generate the native build matrix."""
+    return {
+        "include": [
+            {
+                "variant": variant_name,
+                "runner": string_value(variant, "runner"),
+            }
+            for variant_name, variant in sorted(variants.items())
+        ]
+    }
+
+
+def examples_matrix(schema: TomlTable, variants: dict[str, TomlTable]) -> Matrix:
+    """Generate the examples build matrix."""
+    examples = as_table_map(schema.get("examples"))
+    include: list[MatrixEntry] = []
+
+    for example_name, example in sorted(examples.items()):
+        for variant_name, variant in sorted(variants.items()):
+            if supports(example, variant):
+                include.append(
+                    {
+                        "example": example_name,
+                        "task": string_value(example, "task"),
+                        "variant": variant_name,
+                        "runner": string_value(variant, "runner"),
+                    }
+                )
+
+    return {"include": include}
+
+
+def main() -> int:
+    """Run the matrix generator CLI."""
+    matrix_name = os.environ["usage_matrix"]
+    schema_path = Path(
+        os.environ.get("usage_schema", ".github/config/variants.toml"),
+    )
+    pretty = os.environ.get("usage_pretty") == "true"
+
+    schema = load_toml(schema_path)
+    variants = load_variants(Path.cwd(), schema)
+    if matrix_name == "native":
+        matrix = native_matrix(variants)
+    else:
+        matrix = examples_matrix(schema, variants)
+
+    if pretty:
+        matrix_json = json.dumps(matrix, indent=2, sort_keys=True)
+    else:
+        matrix_json = json.dumps(matrix, sort_keys=True, separators=(",", ":"))
+
+    sys.stdout.write(matrix_json)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,22 @@ Read these docs before changing related code:
   headers, C ABI behavior, callbacks, diagnostics, or render target contracts.
 - [Bindings](docs/src/content/docs/development/) before changing a language
   binding or its generated reference docs.
+
+## External Docs
+
+Read these docs for related tooling:
+
+- [mise settings](https://mise.jdx.dev/configuration/settings.html) when
+  changing `[settings]` entries in `mise.toml`.
+- [mise task configuration](https://mise.jdx.dev/tasks/task-configuration.html)
+  when changing mise task metadata.
+- [mise file tasks](https://mise.jdx.dev/tasks/file-tasks.html) when changing
+  `.mise/tasks/**` task files.
+- [mise task arguments](https://mise.jdx.dev/tasks/task-arguments.html) when
+  changing `usage` specs or task CLI arguments.
+- [mise Python](https://mise.jdx.dev/lang/python.html) when changing Python, uv,
+  or virtual environment integration.
+- [hk configuration](https://hk.jdx.dev/configuration.html) when changing
+  `hk.pkl`.
+- [dprint configuration](https://dprint.dev/config/) when changing
+  `dprint.jsonc`.

--- a/docs/src/content/docs/development/overview.md
+++ b/docs/src/content/docs/development/overview.md
@@ -67,6 +67,23 @@ mise run //examples/zig-map:run
 mise run //docs:build
 ```
 
+## CI Variant Matrix
+
+GitHub Actions builds native artifacts and examples for the variants described
+by the mise profiles, such as `mise.linux-x64-vulkan.toml` and
+`mise.macos-arm64-metal.toml`. The CI matrix generator reads each profile's
+platform, architecture, and render backend metadata.
+
+Use `.github/config/variants.toml` to configure CI matrix policy: runner
+selection, example tasks, compatibility requirements, and explicit exclusions.
+
+Preview the generated matrices locally:
+
+```bash
+mise run ci:matrix native --pretty
+mise run ci:matrix examples --pretty
+```
+
 ## How Tools Fit Together
 
 [`mise`](https://mise.jdx.dev/) is the contributor entrypoint. It pins tools,

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -12,15 +12,18 @@
     "third_party/**",
     "zig-out/**",
     ".zig-cache/**",
+    ".venv/**",
     "**/node_modules",
     "**/dist",
     "docs/api/c/templates/**",
     "**/*-lock.yaml",
     "**/*.lock.yaml",
+    "uv.lock",
   ],
   "json": { "preferSingleLine": true },
   "markdown": { "textWrap": "always" },
   "oxc": { "experimentalSortImports": { "newlinesBetween": true } },
+  "ruff": { "indentWidth": 4, "lineLength": 88 },
   "exec": {
     "commands": [
       {
@@ -45,6 +48,7 @@
   },
   "plugins": [
     "https://plugins.dprint.dev/exec-0.6.2.json@df98f54ffd3092b8a841aedd6d098a2651f16d0a796a40535774f1a8b4b9d463",
+    "https://plugins.dprint.dev/ruff-0.7.0.wasm",
     "https://plugins.dprint.dev/oxc-0.20.0.wasm",
     "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.21.1.wasm",

--- a/examples/swift-map/mise.toml
+++ b/examples/swift-map/mise.toml
@@ -1,6 +1,3 @@
-[tasks.ci]
-run = ["mise run :build"]
-
 [tasks.build]
 depends = ["//:ensure-native-library"]
 run = '''

--- a/examples/zig-map/mise.toml
+++ b/examples/zig-map/mise.toml
@@ -1,6 +1,3 @@
-[tasks.ci]
-run = ["mise run :build"]
-
 [tasks.build]
 depends = ["//:ensure-native-library", ":compile-shaders"]
 run = "zig build --prefix \"zig-out/${MLN_FFI_VARIANT:-host}\" -Dcmake-artifact-dir=\"$MLN_FFI_BUILD_DIR\" ${MLN_FFI_RENDER_BACKEND:+-Drender-backend=$MLN_FFI_RENDER_BACKEND}"

--- a/examples/zig-readback/mise.toml
+++ b/examples/zig-readback/mise.toml
@@ -1,6 +1,3 @@
-[tasks.ci]
-run = ["mise run :run"]
-
 [tasks.build]
 depends = ["//:ensure-native-library"]
 run = "zig build --prefix \"zig-out/${MLN_FFI_VARIANT:-host}\" -Dcmake-artifact-dir=\"$MLN_FFI_BUILD_DIR\" ${MLN_FFI_RENDER_BACKEND:+-Drender-backend=$MLN_FFI_RENDER_BACKEND}"

--- a/hk.pkl
+++ b/hk.pkl
@@ -28,6 +28,17 @@ local commonSteps = new Mapping<String, Step> {
     check = "pnpm --dir docs exec vp check --no-fmt"
     fix = "pnpm --dir docs exec vp check --no-fmt --fix"
   }
+  ["ruff"] {
+    glob = List("**/*.py")
+    profiles = commonProfiles
+    check = "uv run ruff check {{files}} && uv run ruff format --check {{files}}"
+    fix = "uv run ruff check --fix {{files}} && uv run ruff format {{files}}"
+  }
+  ["ty"] {
+    glob = List("**/*.py")
+    profiles = commonProfiles
+    check = "uv run ty check --error-on-warning ."
+  }
   ["zig-ast-check"] {
     glob = List("**/*.zig")
     profiles = commonProfiles

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ experimental_monorepo_root = true
 [settings]
 pin = true
 experimental = true
+python.uv_venv_auto = "create|source"
 
 [monorepo]
 config_roots = ["examples/*", "docs"]
@@ -23,9 +24,12 @@ zig = "0.16.0"
 actionlint = "1.7.8"
 pnpm = "10.33.2"
 node = "24.11.0"
+python = "3.14.4"
+uv = "0.11.11"
 usage = "3.3.0"
 
 [env]
+UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }
 MLN_FFI_VARIANT = "{{env.MLN_FFI_VARIANT | default(value=\"host\")}}"
 MLN_FFI_TARGET_TRIPLE = "{{env.MLN_FFI_TARGET_TRIPLE | default(value=\"host\")}}"
 MLN_FFI_RENDER_BACKEND = "{{env.MLN_FFI_RENDER_BACKEND | default(value=\"\")}}"
@@ -38,6 +42,7 @@ XDG_DATA_DIRS = "{{config_root}}/.pixi/envs/default/share:{{env.XDG_DATA_DIRS | 
 postinstall = [
   "hk install --mise",
   "pixi install --locked",
+  "uv sync --locked",
   "cd docs && pnpm install",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "maplibre-native-ffi"
+version = "0.0.0"
+requires-python = ">=3.14"
+dependencies = []
+
+[dependency-groups]
+dev = [
+  "ruff==0.15.12",
+  "ty==0.0.34",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,71 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "maplibre-native-ffi"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+    { name = "ty" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ruff", specifier = "==0.15.12" },
+    { name = "ty", specifier = "==0.0.34" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/69/e24eefe2c35c0fdbdec9b60e162727af669bb76d64d993d982eb67b24c38/ty-0.0.34.tar.gz", hash = "sha256:a6efe66b0f13c03a65e6c72ec9abfe2792e2fd063c74fa67e2c4930e29d661be", size = 5585933, upload-time = "2026-05-01T23:06:46.388Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/7b/8b85003d6639ef17a97dcbb31f4511cfe78f1c81a964470db100c8c883e7/ty-0.0.34-py3-none-linux_armv6l.whl", hash = "sha256:9ecc3d14f07a95a6ceb88e07f8e62358dbd37325d3d5bd56da7217ff1fef7fb8", size = 11067094, upload-time = "2026-05-01T23:06:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/b0098f65b020b015c40567c763fc66fffbec88b2ba6f584bca1e92f05ebb/ty-0.0.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0dccffd8a9d02321cd2dee3249df205e26d62694e741f4eeca36b157fd8b419f", size = 10840909, upload-time = "2026-05-01T23:06:18.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/55/5e4adcf7d2a1006b844903b27cb81244a9b748d850433a46a6c21776c401/ty-0.0.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0ea47a2998e167ab3b21d2f4b5309a9cf33c297809f6d7e3e753252223174d0", size = 10279378, upload-time = "2026-05-01T23:06:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/f537dca0db8fe2558e8ab04d8941d687b384fcc1df5eb9023b2db75ac26c/ty-0.0.34-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37da00b41a118a459ae56d8947e70651073fb33ebfbceb820e4a10b22d5023", size = 10817423, upload-time = "2026-05-01T23:06:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c4/55a3ad1da2815af1009bdc1b8c90dc11a364cd314e4b48c5128ba9d38859/ty-0.0.34-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81cbbb93c2342fe3de43e625d3a9eb149633e9f485e816ebf6395d08685355d8", size = 10851826, upload-time = "2026-05-01T23:06:24.198Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/9c7606af22d73fb43ea4369472d9c66ece11231be73b0efe8e3c61655559/ty-0.0.34-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c5b4dea1594a021289e172582df9cde7089dce14b276fc650e7b212b1772e12", size = 11356318, upload-time = "2026-05-01T23:06:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/20/54/bb423f663721ab4138b216425c6b55eaefd3a068243b24d6d8fe988f4e13/ty-0.0.34-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:030fb00aa2d2a5b5ae9d9183d574e0c82dae80566700a7490c43669d8ece40cd", size = 11902968, upload-time = "2026-05-01T23:06:35.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/22/01122b21ab6b534a2f618c6bbe5f1f7f49fd56f4b2ec8887cd6d40d08fb3/ty-0.0.34-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae9555e24e36c63a8218e037a5a63f15579eb6aa94f41017e57cd41d335cfb5", size = 11548860, upload-time = "2026-05-01T23:06:42.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/86008b1392ec64bed1957bbcc7aaa43b466b50dfc91bb131841c21d7c5c3/ty-0.0.34-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99eb23df9ed129fc26d1ab00d6f0b8dfe5253b09c2ac6abdb11523fa70d67f10", size = 11457097, upload-time = "2026-05-01T23:06:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/92/3e/4558b2296963ba99c58d8409c57d7db4f3061b656c3613cb21c02c1ef4c2/ty-0.0.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85de45382016eceae69e104815eb2cfa200787df104002e262a86cbd43ed2c02", size = 10798192, upload-time = "2026-05-01T23:06:40.004Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bf/650d24402be2ef678528d60caac1d9477a40fc37e3792ecef07834fd7a4a/ty-0.0.34-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:14cb575fb8fa5131f5129d100cfe23c1575d23faf5dfc5158432749a3e38c9b5", size = 10890390, upload-time = "2026-05-01T23:06:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ef/ccd2ca13906079f7935fd7e067661b24233017f57d987d51d6a121d85bb5/ty-0.0.34-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fc0b69d8450e6910ba9db34572b959b81329a97ae273c391f70e9fb6c1aade", size = 11031564, upload-time = "2026-05-01T23:06:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2d/d27b72005b6f43599e3bcabab0d7135ac0c230b7a307bb99f9eea02c1cda/ty-0.0.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:30dfcec2f0fde3993f4f912ed0e057dcbebc8615299f610a4c2ddb7b5a3e1e06", size = 11553430, upload-time = "2026-05-01T23:06:31.096Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
+]


### PR DESCRIPTION
## Summary
- add a mise file task that generates native and example GitHub Actions matrices from mise variant profiles and .github/config/variants.toml
- switch CI native/example jobs to generated matrices
- add uv-managed Python tooling for the generator and document the CI matrix config

## Validation
- hk check --all --profile ci-common
- mise run -q ci:matrix native
- mise run -q ci:matrix examples
