### PR TITLE
docs: add Rust and Zig binding notes

### DIFF
--- a/docs/src/content/docs/development/bindings-csharp.md
+++ b/docs/src/content/docs/development/bindings-csharp.md
@@ -3,9 +3,6 @@ title: "C# Binding Notes"
 description: Language-specific implementation notes for C# bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add C# bindings](https://github.com/maplibre/maplibre-native-ffi/issues/48).
 

--- a/docs/src/content/docs/development/bindings-dart-flutter.md
+++ b/docs/src/content/docs/development/bindings-dart-flutter.md
@@ -3,9 +3,6 @@ title: Dart / Flutter Binding Notes
 description: Language-specific implementation notes for Dart and Flutter bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add Dart (Flutter) bindings](https://github.com/maplibre/maplibre-native-ffi/issues/51).
 

--- a/docs/src/content/docs/development/bindings-go.md
+++ b/docs/src/content/docs/development/bindings-go.md
@@ -3,9 +3,6 @@ title: Go Binding Notes
 description: Language-specific implementation notes for Go bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add Go bindings](https://github.com/maplibre/maplibre-native-ffi/issues/43).
 

--- a/docs/src/content/docs/development/bindings-java-ffm.md
+++ b/docs/src/content/docs/development/bindings-java-ffm.md
@@ -3,9 +3,6 @@ title: Java FFM Binding Notes
 description: Language-specific implementation notes for Java FFM bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add Java FFM bindings](https://github.com/maplibre/maplibre-native-ffi/issues/45).
 

--- a/docs/src/content/docs/development/bindings-java-jni.md
+++ b/docs/src/content/docs/development/bindings-java-jni.md
@@ -3,9 +3,6 @@ title: Java JNI Binding Notes
 description: Language-specific implementation notes for Java JNI bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add Java JNI bindings](https://github.com/maplibre/maplibre-native-ffi/issues/46).
 

--- a/docs/src/content/docs/development/bindings-kotlin-multiplatform.md
+++ b/docs/src/content/docs/development/bindings-kotlin-multiplatform.md
@@ -3,9 +3,6 @@ title: Kotlin Multiplatform Binding Notes
 description: Language-specific implementation notes for Kotlin Multiplatform bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add Kotlin Multiplatform bindings](https://github.com/maplibre/maplibre-native-ffi/issues/47).
 

--- a/docs/src/content/docs/development/bindings-node-typescript.md
+++ b/docs/src/content/docs/development/bindings-node-typescript.md
@@ -3,9 +3,6 @@ title: Node / TypeScript Binding Notes
 description: Language-specific implementation notes for Node and TypeScript bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add TypeScript (Node) bindings](https://github.com/maplibre/maplibre-native-ffi/issues/50).
 

--- a/docs/src/content/docs/development/bindings-python.md
+++ b/docs/src/content/docs/development/bindings-python.md
@@ -3,9 +3,6 @@ title: Python Binding Notes
 description: Language-specific implementation notes for Python bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add Python bindings](https://github.com/maplibre/maplibre-native-ffi/issues/49).
 

--- a/docs/src/content/docs/development/bindings-rust.md
+++ b/docs/src/content/docs/development/bindings-rust.md
@@ -56,8 +56,3 @@ Map C enums to Rust enums with explicit conversions. Use `bitflags` for
 user-visible masks and hide C field masks behind option structs, builders, or
 setters. Mark public C-backed enums `#[non_exhaustive]`; add `Unknown(raw)` for
 values read from native output where forward compatibility matters.
-
-The initial Cargo build script may link against the repository artifact in
-`MLN_FFI_BUILD_DIR`. Published packages prefer discovered or bundled
-`libmaplibre-native-c` shared libraries for the target platform. Static linking
-and Cargo-driven native builds can be added later as explicit build modes.

--- a/docs/src/content/docs/development/bindings-rust.md
+++ b/docs/src/content/docs/development/bindings-rust.md
@@ -3,10 +3,61 @@ title: Rust Binding Notes
 description: Language-specific implementation notes for Rust bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add Rust bindings and smoke example](https://github.com/maplibre/maplibre-native-ffi/issues/41).
 
-Language-specific implementation notes are pending.
+The Rust binding exposes a safe low-level API in one Cargo package while keeping
+generated C declarations private.
+
+Package and module names:
+
+```text
+maplibre-native          Cargo package
+maplibre_native          Rust crate
+maplibre_native::sys     private bindgen output
+```
+
+Generate the internal C layer with `bindgen` from the public umbrella header.
+Treat successful generation and compilation as the header bindability check for
+this path. Keep bindgen types internal; public APIs expose Rust wrappers and
+values.
+
+The public crate owns native handles through `RuntimeHandle`, `MapHandle`,
+`MapProjectionHandle`, and `RenderSessionHandle`. These owner-thread-affine
+handle types are `!Send` and `!Sync`. Maps retain their runtime, render sessions
+retain their map, and parent state tracks live children without strong
+ownership. With those invariants, `Drop` destroys native handles on the owner
+thread. Explicit `close` or `destroy` methods return `Result<()>` when callers
+want native status and diagnostics.
+
+Status-returning C calls become `Result<T, Error>` with copied same-thread
+diagnostics.
+
+Use Rust-owned semantic descriptor and event types. Materialize C descriptor
+graphs in temporary Rust-owned storage at the call boundary, and copy borrowed
+native output before its borrow window ends. Encode `&str` as UTF-8 and reject
+embedded `NUL` bytes for null-terminated `const char*` inputs. Runtime events
+use copied source metadata, such as a Rust-assigned `MapId`, rather than cloned
+map handles.
+
+Represent backend-native addresses with an opaque `NativePointer` value. Raw
+pointer conversion is unsafe and transfers no ownership. Texture frame access
+uses a closure-scoped helper that acquires the native frame, exposes unsafe
+backend-pointer accessors only during the callback, and releases the frame on
+scope exit.
+
+Callback trampolines catch Rust panics and convert them to the documented C
+callback behavior. Callback state is stored strongly for the native owner scope
+and is thread-safe where MapLibre may call from worker, network, logging, or
+render-related threads. Resource provider request wrappers are `Send`, enforce
+one-shot completion, and release the C request handle exactly once.
+
+Map C enums to Rust enums with explicit conversions. Use `bitflags` for
+user-visible masks and hide C field masks behind option structs, builders, or
+setters. Mark public C-backed enums `#[non_exhaustive]`; add `Unknown(raw)` for
+values read from native output where forward compatibility matters.
+
+The initial Cargo build script may link against the repository artifact in
+`MLN_FFI_BUILD_DIR`. Published packages prefer discovered or bundled
+`libmaplibre-native-c` shared libraries for the target platform. Static linking
+and Cargo-driven native builds can be added later as explicit build modes.

--- a/docs/src/content/docs/development/bindings-swift.md
+++ b/docs/src/content/docs/development/bindings-swift.md
@@ -3,9 +3,6 @@ title: Swift Binding Notes
 description: Language-specific implementation notes for Swift bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add Swift bindings](https://github.com/maplibre/maplibre-native-ffi/issues/44).
 

--- a/docs/src/content/docs/development/bindings-zig.md
+++ b/docs/src/content/docs/development/bindings-zig.md
@@ -6,4 +6,52 @@ description: Language-specific implementation notes for Zig bindings.
 Tracking issue:
 [Add reusable Zig bindings](https://github.com/maplibre/maplibre-native-ffi/issues/42).
 
-Language-specific implementation notes are pending.
+The Zig binding exposes one safe low-level package while keeping direct C
+interop private.
+
+Package and module names:
+
+```text
+maplibre_native          Zig package
+maplibre_native          public module
+maplibre_native.c        private @cImport layer
+```
+
+Generate the internal C layer with `@cImport` from the public umbrella header.
+Treat successful compilation as the header bindability check for this path. Keep
+imported C types internal; public APIs expose Zig handles, values, errors, and
+copied events.
+
+Owned native objects use `RuntimeHandle`, `MapHandle`, `MapProjectionHandle`,
+and `RenderSessionHandle`. Handles have explicit `deinit` or `destroy` methods.
+Release methods return the binding error set and copy native diagnostics because
+thread-affine destruction can fail. Parent state preserves native validity while
+children are live.
+
+Status-returning C calls map to a stable Zig error set. Since Zig errors do not
+carry payloads, the binding copies `mln_thread_last_error_message()` into
+binding-owned diagnostic storage.
+
+Use Zig-owned semantic descriptor and event types. Materialize C descriptor
+graphs in scoped temporary storage at the call boundary. APIs that copy
+variable-size native output take a `std.mem.Allocator`; returned owned values
+provide `deinit` where needed. Accept UTF-8 `[]const u8`, reject embedded `NUL`
+bytes for null-terminated inputs, and use byte lengths for `mln_string_view`.
+
+Runtime event polling returns copied values. Map-originated events carry copied
+source metadata, such as a binding-assigned `MapId`, rather than borrowed map
+handles. A scoped helper may expose borrowed handles for the callback duration.
+
+Backend-native addresses use a small `NativePointer` value backed by
+`?*anyopaque` and transfer no ownership. Texture frame access uses a scope-bound
+acquire/release helper.
+
+Public callbacks use Zig function pointers plus context pointers. Internal
+`callconv(.c)` trampolines adapt callbacks to the C ABI, convert Zig errors to
+the documented callback behavior, and keep callback state alive for the native
+owner scope.
+
+Map C enum domains to Zig `enum(u32)` values with explicit conversions. Use
+purpose-built mask wrappers or `packed struct(u32)` values for user-visible bit
+masks, hide C field masks behind option structs or builders, and use an
+`unknown: u32` union case for forward-compatible native output values.

--- a/docs/src/content/docs/development/bindings-zig.md
+++ b/docs/src/content/docs/development/bindings-zig.md
@@ -3,9 +3,6 @@ title: Zig Binding Notes
 description: Language-specific implementation notes for Zig bindings.
 ---
 
-All bindings follow
-[Binding Conventions](/maplibre-native-ffi/development/bindings/).
-
 Tracking issue:
 [Add reusable Zig bindings](https://github.com/maplibre/maplibre-native-ffi/issues/42).
 


### PR DESCRIPTION
- added Rust and Zig binding implementation notes
- removed repeated binding-conventions preamble from binding-note stubs
