### PR TITLE
Clarify binding bridge and thread-affinity conventions

### DIFF
--- a/docs/src/content/docs/development/bindings-csharp.md
+++ b/docs/src/content/docs/development/bindings-csharp.md
@@ -28,6 +28,10 @@ status through exceptions. Use finalizers and `SafeHandle` release paths for
 leak reporting. Use them for cleanup only for native resources whose release
 function is documented as thread-independent and infallible.
 
+Ordinary calls execute on the calling .NET thread and translate native
+wrong-thread statuses into exceptions. Managed scheduler and UI dispatch
+policies belong in adapters above this layer.
+
 Callbacks use static unmanaged thunks with binding-owned callback state stored
 through `GCHandle` or a registry. Use `UnmanagedCallersOnly` for C-callable
 static methods when the signature supports it. Callback state stays live for the

--- a/docs/src/content/docs/development/bindings-dart.md
+++ b/docs/src/content/docs/development/bindings-dart.md
@@ -28,6 +28,9 @@ Use explicit `close()` or `destroy()` methods for native handles. Use
 resources whose release function is documented as thread-independent and
 infallible.
 
+Ordinary calls preserve caller execution and report native wrong-thread errors.
+Isolate coordination and Flutter scheduling belong in adapters above this layer.
+
 Define public descriptor and event types as Dart classes or records. Convert
 descriptors to generated C structs at the FFI boundary, and copy native events
 into Dart values before returning them. Typed-data views over native memory are

--- a/docs/src/content/docs/development/bindings-go.md
+++ b/docs/src/content/docs/development/bindings-go.md
@@ -18,9 +18,11 @@ The Go binding targets Go 1.21 or newer. Go 1.21 provides `runtime.Pinner`, the
 interop floor for retained Go pointers. `cgo` gives direct header checking,
 struct layout, callback exports, and C compiler diagnostics.
 
-The binding is a low-level layer. Adapters above it may provide
-goroutine-friendly execution models, such as a locked owner goroutine that pumps
-a runtime.
+The direct handle API is the base layer. Because goroutines and OS threads have
+separate identities, the Go package may also provide a small opt-in owner
+goroutine helper that locks an OS thread, runs owner-thread calls, and pumps
+runtime events. Application scheduling and framework integration stay above that
+helper.
 
 Represent public handles as structs with explicit `Close() error` methods. Use
 Go finalizers for leak reporting. Reserve finalizer cleanup for native resources

--- a/docs/src/content/docs/development/bindings-go.md
+++ b/docs/src/content/docs/development/bindings-go.md
@@ -9,6 +9,7 @@ Resources:
   [#43](https://github.com/maplibre/maplibre-native-ffi/issues/43)
 - [Go `cgo` documentation](https://pkg.go.dev/cmd/cgo)
 - [`runtime.Pinner`](https://pkg.go.dev/runtime#Pinner)
+- [`runtime/cgo.Handle`](https://pkg.go.dev/runtime/cgo#Handle)
 
 The Go binding uses `cgo` over the public C headers and keeps raw C declarations
 private.
@@ -17,8 +18,12 @@ The Go binding targets Go 1.21 or newer. Go 1.21 provides `runtime.Pinner`, the
 interop floor for retained Go pointers. `cgo` gives direct header checking,
 struct layout, callback exports, and C compiler diagnostics.
 
+The binding is a low-level layer. Adapters above it may provide
+goroutine-friendly execution models, such as a locked owner goroutine that pumps
+a runtime.
+
 Represent public handles as structs with explicit `Close() error` methods. Use
-Go finalizers for leak reporting. Use them for cleanup only for native resources
+Go finalizers for leak reporting. Reserve finalizer cleanup for native resources
 whose release function is documented as thread-independent and infallible,
 because finalizers run on GC threads.
 
@@ -26,12 +31,19 @@ Document that Go goroutines do not preserve OS-thread identity. Callers use
 `runtime.LockOSThread` when they need deterministic owner-thread affinity. The
 low-level binding preserves caller execution: ordinary calls run on the calling
 goroutine and return the native wrong-thread error when the call reaches the
-wrong owner thread. The binding does not silently marshal ordinary calls to a
-different goroutine or OS thread.
+wrong owner thread.
+
+Status-returning calls capture native diagnostics on the same OS thread that
+returned the status. Use per-call C helpers that copy diagnostics before
+returning to Go, or use a short `runtime.LockOSThread` window to keep the C call
+and diagnostic read together. Expose stable Go error categories that work with
+`errors.Is` and include the copied diagnostic message.
 
 Follow cgo pointer rules strictly. Pin Go pointers for the full retention period
-before C stores them. Use C-owned storage for retained strings and buffers, and
-use `runtime/cgo.Handle` or binding-owned registry tokens for callback state.
+before C stores them. Use `runtime.Pinner` for retained Go memory. Let cgo's
+per-call pinning cover ordinary buffers, and store callback closures through
+`runtime/cgo.Handle` or binding-owned registry tokens. Use C-owned storage for
+retained strings, buffers, and callback `user_data` cells.
 
 Callbacks use exported Go trampolines and recover panics before returning to C.
 Resource-provider request wrappers enforce one-shot completion and release the C

--- a/docs/src/content/docs/development/bindings-go.md
+++ b/docs/src/content/docs/development/bindings-go.md
@@ -19,10 +19,9 @@ interop floor for retained Go pointers. `cgo` gives direct header checking,
 struct layout, callback exports, and C compiler diagnostics.
 
 The direct handle API is the base layer. Because goroutines and OS threads have
-separate identities, the Go package may also provide a small opt-in owner
-goroutine helper that locks an OS thread, runs owner-thread calls, and pumps
-runtime events. Application scheduling and framework integration stay above that
-helper.
+separate identities, the Go package also provides a small opt-in owner goroutine
+helper that locks an OS thread, runs owner-thread calls, and pumps runtime
+events. Application scheduling and framework integration stay above that helper.
 
 Represent public handles as structs with explicit `Close() error` methods. Use
 Go finalizers for leak reporting. Reserve finalizer cleanup for native resources

--- a/docs/src/content/docs/development/bindings-go.md
+++ b/docs/src/content/docs/development/bindings-go.md
@@ -36,10 +36,9 @@ goroutine and return the native wrong-thread error when the call reaches the
 wrong owner thread.
 
 Status-returning calls capture native diagnostics on the same OS thread that
-returned the status. Use per-call C helpers that copy diagnostics before
-returning to Go, or use a short `runtime.LockOSThread` window to keep the C call
-and diagnostic read together. Expose stable Go error categories that work with
-`errors.Is` and include the copied diagnostic message.
+returned the status. Use a short `runtime.LockOSThread` window to keep the C
+call and diagnostic read together. Expose stable Go error categories that work
+with `errors.Is` and include the copied diagnostic message.
 
 Follow cgo pointer rules strictly. Pin Go pointers for the full retention period
 before C stores them. Use `runtime.Pinner` for retained Go memory. Let cgo's

--- a/docs/src/content/docs/development/bindings-java-ffm.md
+++ b/docs/src/content/docs/development/bindings-java-ffm.md
@@ -30,6 +30,11 @@ Keep FFM types internal. Public APIs do not expose `Arena`, `MemorySegment`,
 public API as `NativePointer` values and convert to FFM pointer values only at
 the generated layer boundary.
 
+Owner-thread-affine calls execute where they are invoked and report native
+wrong-thread errors. Use an execution context that preserves native thread
+identity across related calls. Java scheduling and UI routing belong in adapters
+above this layer.
+
 Use FFM arenas according to lifetime:
 
 - per-call confined arenas for temporary structs, UTF-8 strings, out parameters,

--- a/docs/src/content/docs/development/bindings-java-jni.md
+++ b/docs/src/content/docs/development/bindings-java-jni.md
@@ -9,6 +9,7 @@ Resources:
   [#46](https://github.com/maplibre/maplibre-native-ffi/issues/46)
 - [JNI specification](https://docs.oracle.com/en/java/javase/25/docs/specs/jni/)
 - [Android JNI tips](https://developer.android.com/training/articles/perf-jni)
+- [Rust `jni` crate](https://docs.rs/jni/)
 - [Java FFM conventions](/maplibre-native-ffi/development/bindings-java-ffm/)
 - [JavaCPP](https://github.com/bytedeco/javacpp) and
   [SWIG](https://www.swig.org/)
@@ -17,30 +18,36 @@ The Java JNI binding targets Android and JVMs where FFM is unavailable. Modern
 JVMs with FFM support use the
 [Java FFM conventions](/maplibre-native-ffi/development/bindings-java-ffm/).
 
-Separate JNI access from the safe public binding. The internal C layer contains
-generated native-method declarations and JNI bridge entry points that call the
-public C API. Evaluate JavaCPP and SWIG for generated-assisted coverage. Treat
-successful generation and compilation as the header bindability check for this
-path.
+JNI is a native bridge path. Java calls declared `native` methods, and a
+companion native library implements those JNI entry points and calls the public
+C API.
 
-Keep JNI types internal. Public APIs do not expose `JNIEnv`, `jobject`, JNI
-reference handles, generated C layout classes, or raw `long` pointers.
-Backend-native handles cross the public API as `NativePointer` values and
-convert to internal JNI pointer values at the native-method boundary.
+Build the bridge library in Rust with the `jni` crate from jni-rs over the
+shared internal crates defined by the
+[Rust binding conventions](/maplibre-native-ffi/development/bindings-rust/). For
+JNI, jni-rs plays the same role that PyO3 plays for Python: it adapts Rust code
+to the host runtime's native ABI. JNI policy stays in project-owned bridge code.
+JavaCPP and SWIG can inform generated-assisted coverage. Rust plus jni-rs is the
+supported bridge path.
 
-JNI modified UTF-8 is not the C API string encoding. The JNI bridge transcodes
-through UTF-16 or Java UTF-8 byte arrays instead of passing
-`GetStringUTFChars()` or `NewStringUTF()` bytes as general C API text.
+Keep JNI types internal: `JNIEnv`, `JavaVM`, `jobject`, JNI reference handles,
+generated C layout classes, and raw `long` pointers stay below the public API.
+Backend-native handles cross the public API as `NativePointer` values. The
+bridge converts them to native pointer representations.
+
+Load the bridge with the package's normal Java or Android library-loading
+mechanism. Prefer explicit native-method registration from `JNI_OnLoad` for
+generated method tables and startup validation. Native calls translate C
+statuses and diagnostics into Java exceptions. Rust bridge code catches panics
+before returning through JNI.
+
+The C API expects standard UTF-8 text. The bridge transcodes Java strings
+through UTF-16 or Java UTF-8 byte arrays before passing them to C API text
+fields.
 
 JNI callback state uses global references for Java callbacks that native code
 may invoke after the registering native method returns. Store those references
-in owner-scoped native state:
-
-- process-global state for logging callbacks;
-- runtime-owned state for resource transforms and providers;
-- map/style-owned state for custom geometry source callbacks;
-- request-owned state for handled resource requests.
-
-JNI callback code attaches native threads to the JVM before invoking Java code
-and detaches threads that the binding attached. It clears or reports pending
-Java exceptions before returning to C according to the callback contract.
+in owner-scoped native state. Callback code attaches native threads to the JVM
+before invoking Java code, detaches threads that the bridge attached, and clears
+or reports pending Java exceptions before returning to C according to the
+callback contract.

--- a/docs/src/content/docs/development/bindings-java-jni.md
+++ b/docs/src/content/docs/development/bindings-java-jni.md
@@ -41,6 +41,11 @@ generated method tables and startup validation. Native calls translate C
 statuses and diagnostics into Java exceptions. Rust bridge code catches panics
 before returning through JNI.
 
+Ordinary Java calls execute where they are invoked and report native
+wrong-thread errors. Use an execution context that preserves native thread
+identity across related calls. Java scheduling and UI routing belong in adapters
+above this layer.
+
 The C API expects standard UTF-8 text. The bridge transcodes Java strings
 through UTF-16 or Java UTF-8 byte arrays before passing them to C API text
 fields.

--- a/docs/src/content/docs/development/bindings-kotlin-multiplatform.md
+++ b/docs/src/content/docs/development/bindings-kotlin-multiplatform.md
@@ -32,6 +32,10 @@ Configure Kotlin/Native `cinterop` against the public umbrella header and expose
 its output only through an internal package. Treat successful cinterop
 compilation as the header bindability check for Kotlin/Native.
 
+Common APIs preserve the owner-thread behavior of their actual implementations.
+Coroutine dispatcher and UI-thread routing belong in adapters above the common
+low-level API.
+
 Kotlin/Native C interop declarations are experimental. Keep
 `@OptIn(ExperimentalForeignApi::class)` in `nativeMain` internals and actual
 implementations. Common public APIs do not expose `kotlinx.cinterop` types,

--- a/docs/src/content/docs/development/bindings-python.md
+++ b/docs/src/content/docs/development/bindings-python.md
@@ -40,6 +40,7 @@ as thread-independent and infallible.
 
 The Python GIL is separate from the native owner-thread model. Wrappers rely on
 native owner-thread validation and synchronize Python-owned live/released state.
+Python event-loop integration belongs in adapters above this layer.
 
 Represent JSON-like descriptor values with Python values. Reject non-finite
 floats.

--- a/docs/src/content/docs/development/bindings-vala.md
+++ b/docs/src/content/docs/development/bindings-vala.md
@@ -9,18 +9,40 @@ Resources:
   [#119](https://github.com/maplibre/maplibre-native-ffi/issues/119)
 - [Vala manual](https://docs.vala.dev/)
 - [Vala bindings documentation](https://docs.vala.dev/developer-guides/bindings.html)
+- [Generating a VAPI with GObject Introspection](https://docs.vala.dev/developer-guides/bindings/generating-a-vapi-with-gobject-introspection.html)
 - [GObject API reference](https://docs.gtk.org/gobject/)
+- [GObject Introspection](https://gi.readthedocs.io/)
+- [Rust `glib` crate](https://docs.rs/glib/)
 
-The Vala binding exposes a handwritten GLib/GObject-style low-level API over a
-private raw `.vapi` for the public C headers.
+The Vala binding is generated from a low-level GLib/GObject adapter. Vala's
+idiomatic native library boundary is GObject Introspection: the project builds
+an introspectable GLib library, generates GIR and typelib files, then runs
+`vapigen` to produce the Vala API.
 
-Public handle types are `GLib.Object` wrappers. Each stores the native handle
-privately and exposes explicit `close()` methods that throw
-`MapLibreNative.Error`. Use `dispose` to release managed references. Use
-`finalize` for leak reporting. Use them for native cleanup only for resources
-whose release function is documented as thread-independent and infallible.
+This binding targets the GLib ecosystem. The GLib layer preserves the C API's
+runtime, map, render-session, and event model. UI widgets and application
+lifecycle policy belong above this layer.
 
-Define a public errordomain:
+Build the GLib adapter library in Rust with the gtk-rs `glib` crate and GObject
+infrastructure over the shared internal crates defined by the
+[Rust binding conventions](/maplibre-native-ffi/development/bindings-rust/). The
+adapter exports an annotated GObject-style C API for GObject Introspection.
+Treat successful `g-ir-scanner`, typelib generation, `vapigen`, and Vala
+compilation as the bindability check for this path.
+
+The generated GIR and typelib are useful beyond Vala. They can also serve other
+GObject Introspection consumers while still representing the same low-level
+MapLibre Native FFI model.
+
+Public handle types are GObject classes with the `Handle` suffix. Each object
+stores the native C handle privately and exposes an explicit `close()` method.
+`close()` reports native status through `GError`, which Vala presents as a
+thrown error. Use `dispose` to release managed references. Use `finalize` for
+leak reporting. Reserve finalization cleanup for resources whose release
+function is documented as thread-independent and infallible.
+
+Expose a public GLib error domain that maps the C status categories directly.
+Vala sees the same domain as an `errordomain`:
 
 ```vala
 public errordomain MapLibreNative.Error {
@@ -32,17 +54,16 @@ public errordomain MapLibreNative.Error {
 }
 ```
 
-Ordinary low-level calls keep the C API's threading model visible. Higher-level
-adapters can add `GLib.MainContext` dispatch helpers above this layer.
+Use GLib data types for copied buffers, events, snapshots, and other public
+values. Backend-native handles cross the public API as an opaque `NativePointer`
+boxed value. The GLib adapter converts them to `void*`.
 
-Callbacks use Vala delegates backed by C-compatible trampolines. Store callback
-state strongly for the native owner scope, protect shared state for MapLibre
-worker, network, logging, or render-related threads, and convert Vala/GLib
-failures to the documented C callback behavior.
+Ordinary low-level calls preserve the C API's owner-thread model and execute on
+the calling thread. Expose runtime event polling as copied event values. GLib
+signals may be emitted as a convenience while the owner thread drains runtime
+events. Main-loop and UI integration belong in adapters above this layer.
 
-Use `GLib.Bytes` for immutable copied byte data, `uint8[]` or `GLib.ByteArray`
-for mutable buffers, and copied Vala objects for events and snapshots.
-
-Represent backend-native handles with an opaque `NativePointer` value that
-stores a private address integer. Convert it to `void*` only inside the private
-raw C layer.
+Callback adapters store callback state for the native owner scope, protect it
+for calls from native threads, and convert GLib/Vala failures to the documented
+C callback behavior. Handled resource requests expose one-shot completion
+objects and release the C request handle exactly once.

--- a/docs/src/content/docs/development/bindings.md
+++ b/docs/src/content/docs/development/bindings.md
@@ -173,9 +173,13 @@ thread distinct from the runtime owner thread. If a binding needs to inspect
 owner threads directly, add a C getter.
 
 Resource provider request completion follows the C API and may run from any
-thread. Cross-thread dispatch, coroutine confinement, and UI-thread handoff
-belong in adapters above this layer unless a language binding explicitly owns a
-small safety helper.
+thread. Cross-thread dispatch, coroutine confinement, UI-thread handoff, and
+framework scheduling belong in adapters above this layer when the target
+language can preserve owner-thread affinity directly. A binding may add a small
+opt-in owner-thread helper when the language scheduler separates logical
+execution from native thread identity. That helper keeps direct handle APIs
+available and stays limited to generic owner-thread execution, runtime pumping,
+and event draining.
 
 ## Options And Transparent Structs
 

--- a/docs/src/content/docs/development/bindings.md
+++ b/docs/src/content/docs/development/bindings.md
@@ -71,12 +71,31 @@ values, descriptors, errors, and handle wrappers rather than raw ABI structs or
 generated layout classes.
 
 Rust-based native-extension bindings may share internal Rust crates. A generated
-`-sys` crate mirrors the C ABI and contains no binding policy. A support crate
-holds shared implementation glue such as status checking, diagnostic copying,
-string and descriptor helpers, memory guards, callback-boundary utilities, and
-native-pointer utilities. The support crate is not the public safety layer;
-public Rust, Python, and Node packages keep their own language-facing ownership,
-errors, callbacks, and packaging.
+`-sys` crate mirrors the C ABI. A support crate holds shared C ABI adaptation
+helpers. Public packages provide the safety layer and keep their own
+ecosystem-facing ownership, errors, callbacks, and packaging.
+
+## Direct C Imports And Bridge Libraries
+
+Bindings use one of two implementation paths.
+
+Choose a direct C import when the target language can consume C headers and call
+C functions as part of its normal package model. Generate or write the internal
+C declarations from the public headers, then wrap them in the public binding.
+This path keeps the implementation close to the C ABI and uses the language's
+FFI tooling as the package boundary.
+
+Choose a bridge library when the target runtime's package boundary is a native
+extension or native-method entry point. Python, Node.js, and Java JNI use this
+path. Also choose a bridge when the target ecosystem's package boundary is an
+object and introspection ABI; GLib/GObject uses this path for Vala and other
+GObject Introspection consumers. Build the bridge in Rust over the shared `-sys`
+and support crates, then adapt it to the runtime or ecosystem.
+
+Both paths keep raw ABI details internal. The public API uses the host
+ecosystem's values and preserves its lifetime, error, callback, threading, and
+packaging conventions. A bridge library remains a low-level binding layer;
+framework and application adapters stay above it.
 
 ## Status And Diagnostics
 


### PR DESCRIPTION
## Summary
- clarify direct C import vs bridge-library binding paths
- update JNI and Vala conventions for Rust-backed bridge layers
- document Go diagnostic/threading guidance and optional owner-thread helper boundary
- clarify thread-affinity boundaries across language binding docs

## Validation
- mise run fix