### PR TITLE
Remove stale native lint profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ci-deps
-      - run: mise run ci:lint common
+      - run: mise run ci:lint
 
   docs:
     name: docs
@@ -68,7 +68,6 @@ jobs:
           key: mln-src-v2-${{ hashFiles('.gitmodules', 'cmake/mln_version.cmake') }}
       - uses: ./.github/actions/setup-ci-deps
       - run: mise run configure
-      - run: mise run ci:lint native
       # Windows builds successfully, but native tests/examples are runtime-broken for now.
       - if: ${{ matrix.variant == 'windows-x64-vulkan' }}
         run: mise run build

--- a/hk.pkl
+++ b/hk.pkl
@@ -5,49 +5,32 @@ amends "package://github.com/jdx/hk/releases/download/v1.40.0/hk@1.40.0#/Config.
 
 import "package://github.com/jdx/hk/releases/download/v1.40.0/hk@1.40.0#/Builtins.pkl"
 
-local commonProfiles = List("!ci-native")
-local nativeProfiles = List("!ci-common")
-
-local commonSteps = new Mapping<String, Step> {
-  ["dprint"] = (Builtins.dprint) {
-    profiles = commonProfiles
-  }
+local lintSteps = new Mapping<String, Step> {
+  ["dprint"] = Builtins.dprint
   ["actionlint"] {
     glob = List(".github/workflows/*.yml", ".github/workflows/*.yaml")
-    profiles = commonProfiles
     check = "actionlint {{files}}"
   }
   ["jvl"] {
     glob = List("**/*.json", "**/*.jsonc")
-    profiles = commonProfiles
     check = "jvl check {{files}}"
   }
   ["vp-check"] {
     glob = List("docs/**/*.ts", "docs/**/*.tsx", "docs/**/*.js", "docs/**/*.jsx", "docs/**/*.mjs", "docs/**/*.cjs")
-    profiles = commonProfiles
     check = "pnpm --dir docs exec vp check --no-fmt"
     fix = "pnpm --dir docs exec vp check --no-fmt --fix"
   }
   ["ruff"] {
     glob = List("**/*.py")
     exclude = List("third_party/**")
-    profiles = commonProfiles
     check = "uv run ruff check {{files}} && uv run ruff format --check {{files}}"
     fix = "uv run ruff check --fix {{files}} && uv run ruff format {{files}}"
   }
   ["ty"] {
     glob = List("**/*.py")
     exclude = List("third_party/**")
-    profiles = commonProfiles
     check = "uv run ty check --error-on-warning .mise"
   }
-}
-
-local nativeSteps = new Mapping<String, Step> {}
-
-local allSteps = new Mapping<String, Step> {
-  ...commonSteps
-  ...nativeSteps
 }
 
 hooks {
@@ -55,18 +38,18 @@ hooks {
     fix = true
     stash = "git"
     steps {
-      ...allSteps
+      ...lintSteps
     }
   }
   ["check"] {
     steps {
-      ...allSteps
+      ...lintSteps
     }
   }
   ["fix"] {
     fix = true
     steps {
-      ...allSteps
+      ...lintSteps
     }
   }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -137,13 +137,8 @@ hide = true
 run = 'java -jar {{ tools["aqua:facebook/ktfmt"].path }}/ktfmt'
 
 [tasks."ci:lint"]
-usage = '''
-arg "<profile>" help="Lint profile" {
-  choices "common" "native"
-}
-'''
 run = [
-  "hk fix --all --profile \"ci-${usage_profile?}\"",
+  "hk fix --all",
   "git update-index -q --refresh",
   "git diff --exit-code",
   "git diff --cached --exit-code",


### PR DESCRIPTION
## Summary
- collapse hk lint steps into a single shared set
- remove the unused ci:lint profile argument
- stop running the removed native lint profile in CI

## Test
- hk check --all