### PR TITLE
Add LWJGL Java FFM map example

### DIFF
--- a/.github/config/variants.toml
+++ b/.github/config/variants.toml
@@ -16,6 +16,10 @@ requires = { platform = ["macos"], backend = ["metal"] }
 task = "//examples/zig-map:build"
 requires = { platform = ["linux", "macos", "windows"], backend = ["metal", "vulkan"] }
 
+[examples.lwjgl-map]
+task = "//examples/lwjgl-map:build"
+requires = { platform = ["linux", "macos"], backend = ["vulkan"] }
+
 [examples.zig-readback]
 task = "//examples/zig-readback:run"
 requires = { platform = ["linux", "macos"], backend = ["metal", "vulkan"] }

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/MetalOwnedTextureFrame.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/MetalOwnedTextureFrame.java
@@ -1,6 +1,6 @@
 package org.maplibre.nativeffi.render;
 
-/** Borrowed Metal texture frame valid only during the frame callback. */
+/** Borrowed Metal texture frame valid only while its frame handle is open. */
 public final class MetalOwnedTextureFrame {
   private final FrameScope scope;
   private final long generation;

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.java
@@ -5,28 +5,28 @@ import java.lang.foreign.MemorySegment;
 import java.util.Objects;
 
 /**
- * Explicit lease for a Vulkan session-owned texture frame.
+ * Explicit handle for a Metal session-owned texture frame.
  *
  * <p>This is an advanced API for render integrations that must submit GPU work and release the
- * MapLibre-owned image only after that work no longer samples it. The frame and its native pointers
- * stay valid until {@link #close()}. Callers must synchronize GPU use before closing the lease,
- * close it on the render session owner thread, and close it before resizing, rendering another
- * update, detaching, or closing the render session.
+ * MapLibre-owned texture only after that work no longer samples it. The frame and its native
+ * pointers stay valid until {@link #close()}. Callers must synchronize GPU use before closing the
+ * handle, close it on the render session owner thread, and close it before resizing, rendering
+ * another update, detaching, or closing the render session.
  */
-public final class VulkanOwnedTextureFrameLease implements AutoCloseable {
+public final class MetalOwnedTextureFrameHandle implements AutoCloseable {
   private final RenderSessionHandle session;
   private final Arena arena;
   private final MemorySegment frameSegment;
   private final FrameScope scope;
-  private final VulkanOwnedTextureFrame frame;
+  private final MetalOwnedTextureFrame frame;
   private boolean closed;
 
-  VulkanOwnedTextureFrameLease(
+  MetalOwnedTextureFrameHandle(
       RenderSessionHandle session,
       Arena arena,
       MemorySegment frameSegment,
       FrameScope scope,
-      VulkanOwnedTextureFrame frame) {
+      MetalOwnedTextureFrame frame) {
     this.session = Objects.requireNonNull(session, "session");
     this.arena = Objects.requireNonNull(arena, "arena");
     this.frameSegment = Objects.requireNonNull(frameSegment, "frameSegment");
@@ -34,7 +34,7 @@ public final class VulkanOwnedTextureFrameLease implements AutoCloseable {
     this.frame = Objects.requireNonNull(frame, "frame");
   }
 
-  public VulkanOwnedTextureFrame frame() {
+  public MetalOwnedTextureFrame frame() {
     ensureOpen();
     return frame;
   }
@@ -51,7 +51,7 @@ public final class VulkanOwnedTextureFrameLease implements AutoCloseable {
     RuntimeException releaseFailure = null;
     Error releaseError = null;
     try {
-      session.releaseVulkanFrame(frameSegment, null);
+      session.releaseMetalFrame(frameSegment, null);
     } catch (RuntimeException error) {
       releaseFailure = error;
       throw error;
@@ -88,7 +88,7 @@ public final class VulkanOwnedTextureFrameLease implements AutoCloseable {
 
   private void ensureOpen() {
     if (closed) {
-      throw new IllegalStateException("Vulkan owned texture frame lease is closed");
+      throw new IllegalStateException("Metal owned texture frame handle is closed");
     }
   }
 }

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.java
@@ -48,41 +48,12 @@ public final class MetalOwnedTextureFrameHandle implements AutoCloseable {
     if (closed) {
       return;
     }
-    RuntimeException releaseFailure = null;
-    Error releaseError = null;
+    session.releaseMetalFrame(frameSegment, null);
+    closed = true;
     try {
-      session.releaseMetalFrame(frameSegment, null);
-    } catch (RuntimeException error) {
-      releaseFailure = error;
-      throw error;
-    } catch (Error error) {
-      releaseError = error;
-      throw error;
+      scope.close();
     } finally {
-      closed = true;
-      try {
-        scope.close();
-      } catch (RuntimeException cleanupError) {
-        if (releaseFailure != null) {
-          releaseFailure.addSuppressed(cleanupError);
-        } else if (releaseError != null) {
-          releaseError.addSuppressed(cleanupError);
-        } else {
-          throw cleanupError;
-        }
-      } finally {
-        try {
-          arena.close();
-        } catch (RuntimeException cleanupError) {
-          if (releaseFailure != null) {
-            releaseFailure.addSuppressed(cleanupError);
-          } else if (releaseError != null) {
-            releaseError.addSuppressed(cleanupError);
-          } else {
-            throw cleanupError;
-          }
-        }
-      }
+      arena.close();
     }
   }
 

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/MetalOwnedTextureFrameLease.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/MetalOwnedTextureFrameLease.java
@@ -1,0 +1,94 @@
+package org.maplibre.nativeffi.render;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.Objects;
+
+/**
+ * Explicit lease for a Metal session-owned texture frame.
+ *
+ * <p>This is an advanced API for render integrations that must submit GPU work and release the
+ * MapLibre-owned texture only after that work no longer samples it. The frame and its native
+ * pointers stay valid until {@link #close()}. Callers must synchronize GPU use before closing the
+ * lease, close it on the render session owner thread, and close it before resizing, rendering
+ * another update, detaching, or closing the render session.
+ */
+public final class MetalOwnedTextureFrameLease implements AutoCloseable {
+  private final RenderSessionHandle session;
+  private final Arena arena;
+  private final MemorySegment frameSegment;
+  private final FrameScope scope;
+  private final MetalOwnedTextureFrame frame;
+  private boolean closed;
+
+  MetalOwnedTextureFrameLease(
+      RenderSessionHandle session,
+      Arena arena,
+      MemorySegment frameSegment,
+      FrameScope scope,
+      MetalOwnedTextureFrame frame) {
+    this.session = Objects.requireNonNull(session, "session");
+    this.arena = Objects.requireNonNull(arena, "arena");
+    this.frameSegment = Objects.requireNonNull(frameSegment, "frameSegment");
+    this.scope = Objects.requireNonNull(scope, "scope");
+    this.frame = Objects.requireNonNull(frame, "frame");
+  }
+
+  public MetalOwnedTextureFrame frame() {
+    ensureOpen();
+    return frame;
+  }
+
+  public boolean isClosed() {
+    return closed;
+  }
+
+  @Override
+  public void close() {
+    if (closed) {
+      return;
+    }
+    RuntimeException releaseFailure = null;
+    Error releaseError = null;
+    try {
+      session.releaseMetalFrame(frameSegment, null);
+    } catch (RuntimeException error) {
+      releaseFailure = error;
+      throw error;
+    } catch (Error error) {
+      releaseError = error;
+      throw error;
+    } finally {
+      closed = true;
+      try {
+        scope.close();
+      } catch (RuntimeException cleanupError) {
+        if (releaseFailure != null) {
+          releaseFailure.addSuppressed(cleanupError);
+        } else if (releaseError != null) {
+          releaseError.addSuppressed(cleanupError);
+        } else {
+          throw cleanupError;
+        }
+      } finally {
+        try {
+          arena.close();
+        } catch (RuntimeException cleanupError) {
+          if (releaseFailure != null) {
+            releaseFailure.addSuppressed(cleanupError);
+          } else if (releaseError != null) {
+            releaseError.addSuppressed(cleanupError);
+          } else {
+            throw cleanupError;
+          }
+        }
+      }
+    }
+  }
+
+  private void ensureOpen() {
+    if (closed) {
+      throw new IllegalStateException("Metal owned texture frame lease is closed");
+    }
+  }
+}

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/RenderSessionHandle.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/RenderSessionHandle.java
@@ -5,8 +5,6 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import org.maplibre.nativeffi.error.InvalidArgumentException;
 import org.maplibre.nativeffi.error.MaplibreStatus;
 import org.maplibre.nativeffi.geo.Feature;
@@ -318,23 +316,6 @@ public final class RenderSessionHandle implements AutoCloseable {
     }
   }
 
-  public void withMetalOwnedTextureFrame(Consumer<MetalOwnedTextureFrame> callback) {
-    Objects.requireNonNull(callback, "callback");
-    withMetalOwnedTextureFrame(
-        frame -> {
-          callback.accept(frame);
-          return null;
-        });
-  }
-
-  public <T> T withMetalOwnedTextureFrame(Function<MetalOwnedTextureFrame, T> callback) {
-    NativeAccess.ensureLoaded();
-    Objects.requireNonNull(callback, "callback");
-    try (var lease = acquireMetalOwnedTextureFrame()) {
-      return callback.apply(lease.frame());
-    }
-  }
-
   /**
    * Acquires an explicit Metal session-owned texture frame lease.
    *
@@ -357,23 +338,6 @@ public final class RenderSessionHandle implements AutoCloseable {
     } catch (Throwable throwable) {
       arena.close();
       throw throwable;
-    }
-  }
-
-  public void withVulkanOwnedTextureFrame(Consumer<VulkanOwnedTextureFrame> callback) {
-    Objects.requireNonNull(callback, "callback");
-    withVulkanOwnedTextureFrame(
-        frame -> {
-          callback.accept(frame);
-          return null;
-        });
-  }
-
-  public <T> T withVulkanOwnedTextureFrame(Function<VulkanOwnedTextureFrame, T> callback) {
-    NativeAccess.ensureLoaded();
-    Objects.requireNonNull(callback, "callback");
-    try (var lease = acquireVulkanOwnedTextureFrame()) {
-      return callback.apply(lease.frame());
     }
   }
 

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/RenderSessionHandle.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/RenderSessionHandle.java
@@ -330,24 +330,33 @@ public final class RenderSessionHandle implements AutoCloseable {
   public <T> T withMetalOwnedTextureFrame(Function<MetalOwnedTextureFrame, T> callback) {
     NativeAccess.ensureLoaded();
     Objects.requireNonNull(callback, "callback");
-    try (var arena = Arena.ofConfined()) {
-      var frameSegment = RenderStructs.metalOwnedTextureFrame(arena);
+    try (var lease = acquireMetalOwnedTextureFrame()) {
+      return callback.apply(lease.frame());
+    }
+  }
+
+  /**
+   * Acquires an explicit Metal session-owned texture frame lease.
+   *
+   * <p>This advanced API is intended for integrations that submit GPU work using the returned
+   * texture and need to release it after that work completes. The returned lease must be closed on
+   * the render session owner thread after GPU work using {@link MetalOwnedTextureFrame#texture()}
+   * has completed. While the lease is open, the native session rejects resize, render, detach,
+   * destroy, and second-acquire operations.
+   */
+  public MetalOwnedTextureFrameLease acquireMetalOwnedTextureFrame() {
+    NativeAccess.ensureLoaded();
+    var arena = Arena.ofConfined();
+    var frameSegment = RenderStructs.metalOwnedTextureFrame(arena);
+    try {
       Status.check(
           MapLibreNativeC.mln_metal_owned_texture_acquire_frame(state.requireLive(), frameSegment));
       var scope = new FrameScope();
-      Throwable callbackFailure = null;
-      try {
-        return callback.apply(metalOwnedTextureFrame(frameSegment, scope));
-      } catch (Throwable throwable) {
-        callbackFailure = throwable;
-        throw throwable;
-      } finally {
-        try {
-          releaseMetalFrame(frameSegment, callbackFailure);
-        } finally {
-          scope.close();
-        }
-      }
+      return new MetalOwnedTextureFrameLease(
+          this, arena, frameSegment, scope, metalOwnedTextureFrame(frameSegment, scope));
+    } catch (Throwable throwable) {
+      arena.close();
+      throw throwable;
     }
   }
 
@@ -487,7 +496,7 @@ public final class RenderSessionHandle implements AutoCloseable {
         : NativePointer.scoped(segment.address(), scope);
   }
 
-  private void releaseMetalFrame(MemorySegment frameSegment, Throwable callbackFailure) {
+  void releaseMetalFrame(MemorySegment frameSegment, Throwable callbackFailure) {
     try {
       Status.check(
           MapLibreNativeC.mln_metal_owned_texture_release_frame(state.requireLive(), frameSegment));

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/RenderSessionHandle.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/RenderSessionHandle.java
@@ -363,25 +363,34 @@ public final class RenderSessionHandle implements AutoCloseable {
   public <T> T withVulkanOwnedTextureFrame(Function<VulkanOwnedTextureFrame, T> callback) {
     NativeAccess.ensureLoaded();
     Objects.requireNonNull(callback, "callback");
-    try (var arena = Arena.ofConfined()) {
-      var frameSegment = RenderStructs.vulkanOwnedTextureFrame(arena);
+    try (var lease = acquireVulkanOwnedTextureFrame()) {
+      return callback.apply(lease.frame());
+    }
+  }
+
+  /**
+   * Acquires an explicit Vulkan session-owned texture frame lease.
+   *
+   * <p>This advanced API is intended for integrations that submit GPU work using the returned image
+   * and need to release it after an external fence signals. The returned lease must be closed on
+   * the render session owner thread after GPU work using {@link VulkanOwnedTextureFrame#image()} or
+   * {@link VulkanOwnedTextureFrame#imageView()} has completed. While the lease is open, the native
+   * session rejects resize, render, detach, destroy, and second-acquire operations.
+   */
+  public VulkanOwnedTextureFrameLease acquireVulkanOwnedTextureFrame() {
+    NativeAccess.ensureLoaded();
+    var arena = Arena.ofConfined();
+    var frameSegment = RenderStructs.vulkanOwnedTextureFrame(arena);
+    try {
       Status.check(
           MapLibreNativeC.mln_vulkan_owned_texture_acquire_frame(
               state.requireLive(), frameSegment));
       var scope = new FrameScope();
-      Throwable callbackFailure = null;
-      try {
-        return callback.apply(vulkanOwnedTextureFrame(frameSegment, scope));
-      } catch (Throwable throwable) {
-        callbackFailure = throwable;
-        throw throwable;
-      } finally {
-        try {
-          releaseVulkanFrame(frameSegment, callbackFailure);
-        } finally {
-          scope.close();
-        }
-      }
+      return new VulkanOwnedTextureFrameLease(
+          this, arena, frameSegment, scope, vulkanOwnedTextureFrame(frameSegment, scope));
+    } catch (Throwable throwable) {
+      arena.close();
+      throw throwable;
     }
   }
 
@@ -491,7 +500,7 @@ public final class RenderSessionHandle implements AutoCloseable {
     }
   }
 
-  private void releaseVulkanFrame(MemorySegment frameSegment, Throwable callbackFailure) {
+  void releaseVulkanFrame(MemorySegment frameSegment, Throwable callbackFailure) {
     try {
       Status.check(
           MapLibreNativeC.mln_vulkan_owned_texture_release_frame(

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/RenderSessionHandle.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/RenderSessionHandle.java
@@ -317,15 +317,15 @@ public final class RenderSessionHandle implements AutoCloseable {
   }
 
   /**
-   * Acquires an explicit Metal session-owned texture frame lease.
+   * Acquires an explicit Metal session-owned texture frame handle.
    *
    * <p>This advanced API is intended for integrations that submit GPU work using the returned
-   * texture and need to release it after that work completes. The returned lease must be closed on
+   * texture and need to release it after that work completes. The returned handle must be closed on
    * the render session owner thread after GPU work using {@link MetalOwnedTextureFrame#texture()}
-   * has completed. While the lease is open, the native session rejects resize, render, detach,
+   * has completed. While the handle is open, the native session rejects resize, render, detach,
    * destroy, and second-acquire operations.
    */
-  public MetalOwnedTextureFrameLease acquireMetalOwnedTextureFrame() {
+  public MetalOwnedTextureFrameHandle acquireMetalOwnedTextureFrame() {
     NativeAccess.ensureLoaded();
     var arena = Arena.ofConfined();
     var frameSegment = RenderStructs.metalOwnedTextureFrame(arena);
@@ -333,7 +333,7 @@ public final class RenderSessionHandle implements AutoCloseable {
       Status.check(
           MapLibreNativeC.mln_metal_owned_texture_acquire_frame(state.requireLive(), frameSegment));
       var scope = new FrameScope();
-      return new MetalOwnedTextureFrameLease(
+      return new MetalOwnedTextureFrameHandle(
           this, arena, frameSegment, scope, metalOwnedTextureFrame(frameSegment, scope));
     } catch (Throwable throwable) {
       arena.close();
@@ -342,15 +342,15 @@ public final class RenderSessionHandle implements AutoCloseable {
   }
 
   /**
-   * Acquires an explicit Vulkan session-owned texture frame lease.
+   * Acquires an explicit Vulkan session-owned texture frame handle.
    *
    * <p>This advanced API is intended for integrations that submit GPU work using the returned image
-   * and need to release it after an external fence signals. The returned lease must be closed on
+   * and need to release it after an external fence signals. The returned handle must be closed on
    * the render session owner thread after GPU work using {@link VulkanOwnedTextureFrame#image()} or
-   * {@link VulkanOwnedTextureFrame#imageView()} has completed. While the lease is open, the native
+   * {@link VulkanOwnedTextureFrame#imageView()} has completed. While the handle is open, the native
    * session rejects resize, render, detach, destroy, and second-acquire operations.
    */
-  public VulkanOwnedTextureFrameLease acquireVulkanOwnedTextureFrame() {
+  public VulkanOwnedTextureFrameHandle acquireVulkanOwnedTextureFrame() {
     NativeAccess.ensureLoaded();
     var arena = Arena.ofConfined();
     var frameSegment = RenderStructs.vulkanOwnedTextureFrame(arena);
@@ -359,7 +359,7 @@ public final class RenderSessionHandle implements AutoCloseable {
           MapLibreNativeC.mln_vulkan_owned_texture_acquire_frame(
               state.requireLive(), frameSegment));
       var scope = new FrameScope();
-      return new VulkanOwnedTextureFrameLease(
+      return new VulkanOwnedTextureFrameHandle(
           this, arena, frameSegment, scope, vulkanOwnedTextureFrame(frameSegment, scope));
     } catch (Throwable throwable) {
       arena.close();

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/VulkanOwnedTextureFrame.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/VulkanOwnedTextureFrame.java
@@ -1,6 +1,6 @@
 package org.maplibre.nativeffi.render;
 
-/** Borrowed Vulkan texture frame valid only during the frame callback. */
+/** Borrowed Vulkan texture frame valid only while its frame handle is open. */
 public final class VulkanOwnedTextureFrame {
   private final FrameScope scope;
   private final long generation;

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.java
@@ -5,28 +5,28 @@ import java.lang.foreign.MemorySegment;
 import java.util.Objects;
 
 /**
- * Explicit lease for a Metal session-owned texture frame.
+ * Explicit handle for a Vulkan session-owned texture frame.
  *
  * <p>This is an advanced API for render integrations that must submit GPU work and release the
- * MapLibre-owned texture only after that work no longer samples it. The frame and its native
- * pointers stay valid until {@link #close()}. Callers must synchronize GPU use before closing the
- * lease, close it on the render session owner thread, and close it before resizing, rendering
- * another update, detaching, or closing the render session.
+ * MapLibre-owned image only after that work no longer samples it. The frame and its native pointers
+ * stay valid until {@link #close()}. Callers must synchronize GPU use before closing the handle,
+ * close it on the render session owner thread, and close it before resizing, rendering another
+ * update, detaching, or closing the render session.
  */
-public final class MetalOwnedTextureFrameLease implements AutoCloseable {
+public final class VulkanOwnedTextureFrameHandle implements AutoCloseable {
   private final RenderSessionHandle session;
   private final Arena arena;
   private final MemorySegment frameSegment;
   private final FrameScope scope;
-  private final MetalOwnedTextureFrame frame;
+  private final VulkanOwnedTextureFrame frame;
   private boolean closed;
 
-  MetalOwnedTextureFrameLease(
+  VulkanOwnedTextureFrameHandle(
       RenderSessionHandle session,
       Arena arena,
       MemorySegment frameSegment,
       FrameScope scope,
-      MetalOwnedTextureFrame frame) {
+      VulkanOwnedTextureFrame frame) {
     this.session = Objects.requireNonNull(session, "session");
     this.arena = Objects.requireNonNull(arena, "arena");
     this.frameSegment = Objects.requireNonNull(frameSegment, "frameSegment");
@@ -34,7 +34,7 @@ public final class MetalOwnedTextureFrameLease implements AutoCloseable {
     this.frame = Objects.requireNonNull(frame, "frame");
   }
 
-  public MetalOwnedTextureFrame frame() {
+  public VulkanOwnedTextureFrame frame() {
     ensureOpen();
     return frame;
   }
@@ -51,7 +51,7 @@ public final class MetalOwnedTextureFrameLease implements AutoCloseable {
     RuntimeException releaseFailure = null;
     Error releaseError = null;
     try {
-      session.releaseMetalFrame(frameSegment, null);
+      session.releaseVulkanFrame(frameSegment, null);
     } catch (RuntimeException error) {
       releaseFailure = error;
       throw error;
@@ -88,7 +88,7 @@ public final class MetalOwnedTextureFrameLease implements AutoCloseable {
 
   private void ensureOpen() {
     if (closed) {
-      throw new IllegalStateException("Metal owned texture frame lease is closed");
+      throw new IllegalStateException("Vulkan owned texture frame handle is closed");
     }
   }
 }

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.java
@@ -48,41 +48,12 @@ public final class VulkanOwnedTextureFrameHandle implements AutoCloseable {
     if (closed) {
       return;
     }
-    RuntimeException releaseFailure = null;
-    Error releaseError = null;
+    session.releaseVulkanFrame(frameSegment, null);
+    closed = true;
     try {
-      session.releaseVulkanFrame(frameSegment, null);
-    } catch (RuntimeException error) {
-      releaseFailure = error;
-      throw error;
-    } catch (Error error) {
-      releaseError = error;
-      throw error;
+      scope.close();
     } finally {
-      closed = true;
-      try {
-        scope.close();
-      } catch (RuntimeException cleanupError) {
-        if (releaseFailure != null) {
-          releaseFailure.addSuppressed(cleanupError);
-        } else if (releaseError != null) {
-          releaseError.addSuppressed(cleanupError);
-        } else {
-          throw cleanupError;
-        }
-      } finally {
-        try {
-          arena.close();
-        } catch (RuntimeException cleanupError) {
-          if (releaseFailure != null) {
-            releaseFailure.addSuppressed(cleanupError);
-          } else if (releaseError != null) {
-            releaseError.addSuppressed(cleanupError);
-          } else {
-            throw cleanupError;
-          }
-        }
-      }
+      arena.close();
     }
   }
 

--- a/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameLease.java
+++ b/bindings/java-ffm/src/main/java/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameLease.java
@@ -1,0 +1,94 @@
+package org.maplibre.nativeffi.render;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.Objects;
+
+/**
+ * Explicit lease for a Vulkan session-owned texture frame.
+ *
+ * <p>This is an advanced API for render integrations that must submit GPU work and release the
+ * MapLibre-owned image only after that work no longer samples it. The frame and its native pointers
+ * stay valid until {@link #close()}. Callers must synchronize GPU use before closing the lease,
+ * close it on the render session owner thread, and close it before resizing, rendering another
+ * update, detaching, or closing the render session.
+ */
+public final class VulkanOwnedTextureFrameLease implements AutoCloseable {
+  private final RenderSessionHandle session;
+  private final Arena arena;
+  private final MemorySegment frameSegment;
+  private final FrameScope scope;
+  private final VulkanOwnedTextureFrame frame;
+  private boolean closed;
+
+  VulkanOwnedTextureFrameLease(
+      RenderSessionHandle session,
+      Arena arena,
+      MemorySegment frameSegment,
+      FrameScope scope,
+      VulkanOwnedTextureFrame frame) {
+    this.session = Objects.requireNonNull(session, "session");
+    this.arena = Objects.requireNonNull(arena, "arena");
+    this.frameSegment = Objects.requireNonNull(frameSegment, "frameSegment");
+    this.scope = Objects.requireNonNull(scope, "scope");
+    this.frame = Objects.requireNonNull(frame, "frame");
+  }
+
+  public VulkanOwnedTextureFrame frame() {
+    ensureOpen();
+    return frame;
+  }
+
+  public boolean isClosed() {
+    return closed;
+  }
+
+  @Override
+  public void close() {
+    if (closed) {
+      return;
+    }
+    RuntimeException releaseFailure = null;
+    Error releaseError = null;
+    try {
+      session.releaseVulkanFrame(frameSegment, null);
+    } catch (RuntimeException error) {
+      releaseFailure = error;
+      throw error;
+    } catch (Error error) {
+      releaseError = error;
+      throw error;
+    } finally {
+      closed = true;
+      try {
+        scope.close();
+      } catch (RuntimeException cleanupError) {
+        if (releaseFailure != null) {
+          releaseFailure.addSuppressed(cleanupError);
+        } else if (releaseError != null) {
+          releaseError.addSuppressed(cleanupError);
+        } else {
+          throw cleanupError;
+        }
+      } finally {
+        try {
+          arena.close();
+        } catch (RuntimeException cleanupError) {
+          if (releaseFailure != null) {
+            releaseFailure.addSuppressed(cleanupError);
+          } else if (releaseError != null) {
+            releaseError.addSuppressed(cleanupError);
+          } else {
+            throw cleanupError;
+          }
+        }
+      }
+    }
+  }
+
+  private void ensureOpen() {
+    if (closed) {
+      throw new IllegalStateException("Vulkan owned texture frame lease is closed");
+    }
+  }
+}

--- a/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionHandleTest.java
+++ b/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionHandleTest.java
@@ -186,6 +186,39 @@ final class RenderSessionHandleTest {
   }
 
   @Test
+  void vulkanOwnedTextureFrameLeaseStaysActiveUntilClosed() throws Exception {
+    Maplibre.setLogCallback(record -> true);
+    Maplibre.setAsyncLogSeverities(EnumSet.noneOf(LogSeverity.class));
+
+    var runtime = RuntimeHandle.create();
+    var map = MapHandle.create(runtime, new MapOptions().size(64, 64));
+    RenderSessionHandle session = null;
+    try {
+      session = assumeVulkanOwnedTextureSession(map);
+      var activeSession = session;
+      map.setStyleJson(STYLE_JSON);
+      waitForMapEvent(runtime, map, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE);
+      activeSession.renderUpdate();
+
+      VulkanOwnedTextureFrame frame;
+      try (var lease = activeSession.acquireVulkanOwnedTextureFrame()) {
+        frame = lease.frame();
+        assertEquals(32, frame.width());
+        assertFalse(lease.isClosed());
+        assertThrows(InvalidStateException.class, activeSession::renderUpdate);
+      }
+      assertThrows(IllegalStateException.class, frame::width);
+      activeSession.renderUpdate();
+    } finally {
+      if (session != null) {
+        session.close();
+      }
+      map.close();
+      runtime.close();
+    }
+  }
+
+  @Test
   void renderTargetDescriptorsTrackOptionalFields() {
     var vulkanBorrowed = new VulkanBorrowedTextureDescriptor();
     assertFalse(vulkanBorrowed.hasFinalLayout());

--- a/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionHandleTest.java
+++ b/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionHandleTest.java
@@ -109,7 +109,7 @@ final class RenderSessionHandleTest {
   }
 
   @Test
-  void metalOwnedTextureFrameLeaseStaysActiveUntilClosed() throws Exception {
+  void metalOwnedTextureFrameHandleStaysActiveUntilClosed() throws Exception {
     Maplibre.setLogCallback(record -> true);
     Maplibre.setAsyncLogSeverities(EnumSet.noneOf(LogSeverity.class));
 
@@ -124,10 +124,10 @@ final class RenderSessionHandleTest {
       activeSession.renderUpdate();
 
       MetalOwnedTextureFrame frame;
-      try (var lease = activeSession.acquireMetalOwnedTextureFrame()) {
-        frame = lease.frame();
+      try (var frameHandle = activeSession.acquireMetalOwnedTextureFrame()) {
+        frame = frameHandle.frame();
         assertEquals(32, frame.width());
-        assertFalse(lease.isClosed());
+        assertFalse(frameHandle.isClosed());
         assertThrows(InvalidStateException.class, activeSession::renderUpdate);
       }
       assertThrows(IllegalStateException.class, frame::width);
@@ -142,7 +142,7 @@ final class RenderSessionHandleTest {
   }
 
   @Test
-  void vulkanOwnedTextureFrameLeaseStaysActiveUntilClosed() throws Exception {
+  void vulkanOwnedTextureFrameHandleStaysActiveUntilClosed() throws Exception {
     Maplibre.setLogCallback(record -> true);
     Maplibre.setAsyncLogSeverities(EnumSet.noneOf(LogSeverity.class));
 
@@ -157,10 +157,10 @@ final class RenderSessionHandleTest {
       activeSession.renderUpdate();
 
       VulkanOwnedTextureFrame frame;
-      try (var lease = activeSession.acquireVulkanOwnedTextureFrame()) {
-        frame = lease.frame();
+      try (var frameHandle = activeSession.acquireVulkanOwnedTextureFrame()) {
+        frame = frameHandle.frame();
         assertEquals(32, frame.width());
-        assertFalse(lease.isClosed());
+        assertFalse(frameHandle.isClosed());
         assertThrows(InvalidStateException.class, activeSession::renderUpdate);
       }
       assertThrows(IllegalStateException.class, frame::width);

--- a/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionHandleTest.java
+++ b/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionHandleTest.java
@@ -186,6 +186,39 @@ final class RenderSessionHandleTest {
   }
 
   @Test
+  void metalOwnedTextureFrameLeaseStaysActiveUntilClosed() throws Exception {
+    Maplibre.setLogCallback(record -> true);
+    Maplibre.setAsyncLogSeverities(EnumSet.noneOf(LogSeverity.class));
+
+    var runtime = RuntimeHandle.create();
+    var map = MapHandle.create(runtime, new MapOptions().size(64, 64));
+    RenderSessionHandle session = null;
+    try {
+      session = assumeMetalOwnedTextureSession(map);
+      var activeSession = session;
+      map.setStyleJson(STYLE_JSON);
+      waitForMapEvent(runtime, map, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE);
+      activeSession.renderUpdate();
+
+      MetalOwnedTextureFrame frame;
+      try (var lease = activeSession.acquireMetalOwnedTextureFrame()) {
+        frame = lease.frame();
+        assertEquals(32, frame.width());
+        assertFalse(lease.isClosed());
+        assertThrows(InvalidStateException.class, activeSession::renderUpdate);
+      }
+      assertThrows(IllegalStateException.class, frame::width);
+      activeSession.renderUpdate();
+    } finally {
+      if (session != null) {
+        session.close();
+      }
+      map.close();
+      runtime.close();
+    }
+  }
+
+  @Test
   void vulkanOwnedTextureFrameLeaseStaysActiveUntilClosed() throws Exception {
     Maplibre.setLogCallback(record -> true);
     Maplibre.setAsyncLogSeverities(EnumSet.noneOf(LogSeverity.class));

--- a/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionHandleTest.java
+++ b/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionHandleTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -100,82 +99,6 @@ final class RenderSessionHandleTest {
       activeSession.close();
       assertTrue(activeSession.isClosed());
       session = null;
-    } finally {
-      if (session != null) {
-        session.close();
-      }
-      map.close();
-      runtime.close();
-    }
-  }
-
-  @Test
-  void metalOwnedTextureFrameReleasesAfterCallbackFailure() throws Exception {
-    Maplibre.setLogCallback(record -> true);
-    Maplibre.setAsyncLogSeverities(EnumSet.noneOf(LogSeverity.class));
-
-    var runtime = RuntimeHandle.create();
-    var map = MapHandle.create(runtime, new MapOptions().size(64, 64));
-    RenderSessionHandle session = null;
-    try {
-      session = assumeMetalOwnedTextureSession(map);
-      var activeSession = session;
-      map.setStyleJson(STYLE_JSON);
-      waitForMapEvent(runtime, map, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE);
-      activeSession.renderUpdate();
-
-      var escaped = new AtomicReference<MetalOwnedTextureFrame>();
-      var failure =
-          assertThrows(
-              IllegalStateException.class,
-              () ->
-                  activeSession.withMetalOwnedTextureFrame(
-                      (Consumer<MetalOwnedTextureFrame>)
-                          frame -> {
-                            escaped.set(frame);
-                            throw new IllegalStateException("boom");
-                          }));
-      assertEquals("boom", failure.getMessage());
-      assertThrows(IllegalStateException.class, () -> escaped.get().width());
-      activeSession.renderUpdate();
-    } finally {
-      if (session != null) {
-        session.close();
-      }
-      map.close();
-      runtime.close();
-    }
-  }
-
-  @Test
-  void vulkanOwnedTextureFrameReleasesAfterCallbackFailure() throws Exception {
-    Maplibre.setLogCallback(record -> true);
-    Maplibre.setAsyncLogSeverities(EnumSet.noneOf(LogSeverity.class));
-
-    var runtime = RuntimeHandle.create();
-    var map = MapHandle.create(runtime, new MapOptions().size(64, 64));
-    RenderSessionHandle session = null;
-    try {
-      session = assumeVulkanOwnedTextureSession(map);
-      var activeSession = session;
-      map.setStyleJson(STYLE_JSON);
-      waitForMapEvent(runtime, map, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE);
-      activeSession.renderUpdate();
-
-      var escaped = new AtomicReference<VulkanOwnedTextureFrame>();
-      var failure =
-          assertThrows(
-              IllegalStateException.class,
-              () ->
-                  activeSession.withVulkanOwnedTextureFrame(
-                      (Consumer<VulkanOwnedTextureFrame>)
-                          frame -> {
-                            escaped.set(frame);
-                            throw new IllegalStateException("boom");
-                          }));
-      assertEquals("boom", failure.getMessage());
-      assertThrows(IllegalStateException.class, () -> escaped.get().width());
-      activeSession.renderUpdate();
     } finally {
       if (session != null) {
         session.close();

--- a/docs/src/content/docs/development/bindings-java-ffm.md
+++ b/docs/src/content/docs/development/bindings-java-ffm.md
@@ -155,12 +155,10 @@ alive. Closing the map while a session is live reports native invalid state.
 Texture readback supports reusable off-heap storage through `NativeBuffer` and a
 convenience path that returns a copied `PremultipliedRgba8Image`.
 
-Owned texture frame access uses closure-scoped helpers for most callers. The
-helper acquires the native frame, exposes copied metadata and scoped
-`NativePointer` values, releases the frame in `finally`, and invalidates the
-frame scope after the callback returns or fails. Scoped frame values and
-pointers reject access after the callback. Integrations that must keep a
-MapLibre-owned texture alive until GPU work finishes can use the explicit
-`AutoCloseable` lease APIs instead: callers synchronize GPU use, close the lease
-on the render session owner thread, and close it before resize, another render
-update, detach, or session destruction.
+Owned texture frame access uses explicit `AutoCloseable` lease APIs. The lease
+acquires the native frame, exposes copied metadata and scoped `NativePointer`
+values, and keeps the MapLibre-owned texture alive until callers close it.
+Callers synchronize GPU use, close the lease on the render session owner thread,
+and close it before resize, another render update, detach, or session
+destruction. Scoped frame values and pointers reject access after the lease
+closes.

--- a/docs/src/content/docs/development/bindings-java-ffm.md
+++ b/docs/src/content/docs/development/bindings-java-ffm.md
@@ -159,11 +159,8 @@ Owned texture frame access uses closure-scoped helpers for most callers. The
 helper acquires the native frame, exposes copied metadata and scoped
 `NativePointer` values, releases the frame in `finally`, and invalidates the
 frame scope after the callback returns or fails. Scoped frame values and
-pointers reject access after the callback.
-
-Vulkan integrations that must keep a MapLibre-owned image alive until GPU work
-finishes can use `RenderSessionHandle.acquireVulkanOwnedTextureFrame()`. The
-returned `VulkanOwnedTextureFrameLease` is an explicit `AutoCloseable` lease.
-Callers synchronize GPU use, close the lease on the render session owner thread,
-and close it before resize, another render update, detach, or session
-destruction.
+pointers reject access after the callback. Integrations that must keep a
+MapLibre-owned texture alive until GPU work finishes can use the explicit
+`AutoCloseable` lease APIs instead: callers synchronize GPU use, close the lease
+on the render session owner thread, and close it before resize, another render
+update, detach, or session destruction.

--- a/docs/src/content/docs/development/bindings-java-ffm.md
+++ b/docs/src/content/docs/development/bindings-java-ffm.md
@@ -155,8 +155,15 @@ alive. Closing the map while a session is live reports native invalid state.
 Texture readback supports reusable off-heap storage through `NativeBuffer` and a
 convenience path that returns a copied `PremultipliedRgba8Image`.
 
-Owned texture frame access uses closure-scoped helpers. The helper acquires the
-native frame, exposes copied metadata and scoped `NativePointer` values,
-releases the frame in `finally`, and invalidates the frame scope after the
-callback returns or fails. Scoped frame values and pointers reject access after
-the callback.
+Owned texture frame access uses closure-scoped helpers for most callers. The
+helper acquires the native frame, exposes copied metadata and scoped
+`NativePointer` values, releases the frame in `finally`, and invalidates the
+frame scope after the callback returns or fails. Scoped frame values and
+pointers reject access after the callback.
+
+Vulkan integrations that must keep a MapLibre-owned image alive until GPU work
+finishes can use `RenderSessionHandle.acquireVulkanOwnedTextureFrame()`. The
+returned `VulkanOwnedTextureFrameLease` is an explicit `AutoCloseable` lease.
+Callers synchronize GPU use, close the lease on the render session owner thread,
+and close it before resize, another render update, detach, or session
+destruction.

--- a/docs/src/content/docs/development/bindings-java-ffm.md
+++ b/docs/src/content/docs/development/bindings-java-ffm.md
@@ -155,10 +155,10 @@ alive. Closing the map while a session is live reports native invalid state.
 Texture readback supports reusable off-heap storage through `NativeBuffer` and a
 convenience path that returns a copied `PremultipliedRgba8Image`.
 
-Owned texture frame access uses explicit `AutoCloseable` lease APIs. The lease
-acquires the native frame, exposes copied metadata and scoped `NativePointer`
-values, and keeps the MapLibre-owned texture alive until callers close it.
-Callers synchronize GPU use, close the lease on the render session owner thread,
-and close it before resize, another render update, detach, or session
-destruction. Scoped frame values and pointers reject access after the lease
-closes.
+Owned texture frame access uses explicit `AutoCloseable` frame handle APIs. The
+handle acquires the native frame, exposes copied metadata and scoped
+`NativePointer` values, and keeps the MapLibre-owned texture alive until callers
+close it. Callers synchronize GPU use, close the handle on the render session
+owner thread, and close it before resize, another render update, detach, or
+session destruction. Scoped frame values and pointers reject access after the
+handle closes.

--- a/docs/src/content/docs/development/bindings-rust.md
+++ b/docs/src/content/docs/development/bindings-rust.md
@@ -182,13 +182,12 @@ Texture readback supports two shapes:
   caller-owned reusable storage.
 - A convenience method returning a copied `PremultipliedRgba8Image`.
 
-Session-owned texture frames use closure-scoped accessors (`with_metal_frame`,
-`with_vulkan_frame`). The helper acquires the native frame, passes a frame view
-tied to a mutable borrow of the session, and releases the frame on return or
-unwind. Frame views expose copied metadata through safe accessors. Backend
-handles use scoped `NativePointer` accessors marked `unsafe`—callers honor
-backend synchronization and lifetime rules.
+Session-owned texture frames use explicit frame handles. The handle acquires the
+native frame and releases it on close or drop. Frame views expose copied
+metadata through safe accessors. Backend handles use scoped `NativePointer`
+accessors marked `unsafe`—callers honor backend synchronization and lifetime
+rules.
 
-Safe Rust borrowing prevents reentrant session calls through the same handle
-while a frame is acquired. Backend `NativePointer` values are tied to the frame
-lifetime and cannot escape the closure.
+Safe Rust borrowing prevents reentrant session calls through the same session
+while a frame handle is live. Backend `NativePointer` values are tied to the
+frame lifetime and cannot outlive the frame handle.

--- a/docs/src/content/docs/development/bindings.md
+++ b/docs/src/content/docs/development/bindings.md
@@ -223,13 +223,12 @@ native handles after copying, even when copying fails. A lazy view tied to a
 native snapshot handle owns and releases that handle and never exposes
 free-floating borrowed views.
 
-A callback-scoped borrow exposes native data only during a language callback.
-The binding acquires the borrow before invoking the callback and releases it
-after the callback returns or fails. Texture frames use callback-scoped access:
-the frame view is valid only during the callback, unsafe accessors check that
-the frame is active, and the frame type has no public close method. The native
-session rejects nested acquisition, render updates, resize, detach, and destroy
-while a frame is acquired.
+A scoped borrow exposes native data only during a binding-controlled lifetime.
+The binding acquires the borrow, exposes a scoped view, and releases it when the
+scope ends. Session-owned texture frames use explicit frame handles: the frame
+view is valid only while the handle is live, unsafe accessors check that active
+state, and the native session rejects nested acquisition, render updates,
+resize, detach, and destroy while a frame is acquired.
 
 Runtime event polling returns copied language values. Public event objects are
 independent of the next native poll. A runtime wrapper may keep a registry of
@@ -296,10 +295,9 @@ caller-owned texture descriptors contain backend-native handles. The binding
 treats those handles as borrowed—the caller keeps backend objects valid and
 synchronized for the lifetime documented by the C API.
 
-Session-owned texture targets expose rendered backend objects through
-callback-scoped frame access. CPU readback APIs copy into language arrays, byte
-buffers, or explicit native buffers and return copied `TextureImageInfo`
-metadata.
+Session-owned texture targets expose rendered backend objects through explicit
+frame handles. CPU readback APIs copy into language arrays, byte buffers, or
+explicit native buffers and return copied `TextureImageInfo` metadata.
 
 Backend interop requires raw native handles in specific render-target APIs.
 Unsafe accessors are limited to those APIs, marked with the target language's
@@ -319,6 +317,6 @@ corresponding language function propagates the native status, diagnostic, or
 copied output correctly.
 
 Add regression tests when the binding owns a lifetime or threading invariant
-that raw C declarations cannot express, such as releasing a texture frame after
-a failing callback, preserving parent validity while child handles are live, or
-releasing callback references exactly once.
+that raw C declarations cannot express, such as invalidating a texture frame
+after its scope closes, preserving parent validity while child handles are live,
+or releasing callback references exactly once.

--- a/examples/lwjgl-map/build.gradle.kts
+++ b/examples/lwjgl-map/build.gradle.kts
@@ -1,0 +1,69 @@
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
+
+plugins { application }
+
+repositories { mavenCentral() }
+
+val lwjglVersion = "3.4.1"
+
+fun lwjglNativeClassifier(): String {
+  val os = System.getProperty("os.name").lowercase()
+  val arch = System.getProperty("os.arch").lowercase()
+  return when {
+    os.contains("mac") && (arch == "aarch64" || arch == "arm64") -> "natives-macos-arm64"
+    os.contains("mac") -> "natives-macos"
+    os.contains("linux") && (arch == "aarch64" || arch == "arm64") -> "natives-linux-arm64"
+    os.contains("linux") -> "natives-linux"
+    os.contains("windows") -> "natives-windows"
+    else -> throw GradleException("Unsupported LWJGL native platform: $os/$arch")
+  }
+}
+
+val lwjglNative = lwjglNativeClassifier()
+val hostIsMac = System.getProperty("os.name").lowercase().contains("mac")
+val lwjglMapJvmArgs = buildList {
+  add("--enable-native-access=ALL-UNNAMED")
+  if (hostIsMac) {
+    add("-XstartOnFirstThread")
+  }
+}
+
+application {
+  mainClass = "org.maplibre.nativeffi.examples.lwjglmap.Main"
+  applicationDefaultJvmArgs = lwjglMapJvmArgs
+}
+
+dependencies {
+  implementation(project(":bindings:java-ffm"))
+  implementation(platform("org.lwjgl:lwjgl-bom:$lwjglVersion"))
+  implementation("org.lwjgl:lwjgl")
+  implementation("org.lwjgl:lwjgl-glfw")
+  implementation("org.lwjgl:lwjgl-vulkan")
+  implementation("org.lwjgl:lwjgl-shaderc")
+  runtimeOnly("org.lwjgl:lwjgl::$lwjglNative")
+  runtimeOnly("org.lwjgl:lwjgl-glfw::$lwjglNative")
+  runtimeOnly("org.lwjgl:lwjgl-shaderc::$lwjglNative")
+
+  testImplementation(platform("org.junit:junit-bom:6.0.3"))
+  testImplementation("org.junit.jupiter:junit-jupiter")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<JavaCompile>().configureEach { options.release = 25 }
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }
+
+val nativeLibraryPathProperty = "org.maplibre.nativeffi.library.path"
+val nativeBuildDir =
+  providers
+    .environmentVariable("MLN_FFI_BUILD_DIR")
+    .orElse(rootProject.layout.buildDirectory.dir("host").map { it.asFile.absolutePath })
+val nativeLibraryPath = nativeBuildDir.map { "$it/${System.mapLibraryName("maplibre-native-c")}" }
+
+tasks.withType<JavaExec>().configureEach {
+  jvmArgs(lwjglMapJvmArgs)
+  systemProperty(nativeLibraryPathProperty, nativeLibraryPath.get())
+  inputs.file(nativeLibraryPath).withPropertyName("maplibreNativeCLibrary").optional()
+}

--- a/examples/lwjgl-map/build.gradle.kts
+++ b/examples/lwjgl-map/build.gradle.kts
@@ -22,11 +22,24 @@ fun lwjglNativeClassifier(): String {
 }
 
 val lwjglNative = lwjglNativeClassifier()
-val hostIsMac = System.getProperty("os.name").lowercase().contains("mac")
+val hostOs = System.getProperty("os.name").lowercase()
+val hostIsMac = hostOs.contains("mac")
+val hostIsLinux = hostOs.contains("linux")
+val pixiVulkanLoader =
+  rootProject.layout.projectDirectory.file(
+    when {
+      hostIsMac -> ".pixi/envs/default/lib/libvulkan.1.dylib"
+      hostIsLinux -> ".pixi/envs/default/lib/libvulkan.so.1"
+      else -> ""
+    }
+  )
 val lwjglMapJvmArgs = buildList {
   add("--enable-native-access=ALL-UNNAMED")
   if (hostIsMac) {
     add("-XstartOnFirstThread")
+  }
+  if ((hostIsMac || hostIsLinux) && pixiVulkanLoader.asFile.exists()) {
+    add("-Dorg.lwjgl.vulkan.libname=${pixiVulkanLoader.asFile.absolutePath}")
   }
 }
 

--- a/examples/lwjgl-map/mise.toml
+++ b/examples/lwjgl-map/mise.toml
@@ -1,0 +1,15 @@
+[tasks.build]
+depends = ["//:ensure-native-library"]
+run = "../../gradlew :examples:lwjgl-map:build"
+
+[tasks.run]
+depends = ["//:ensure-native-library"]
+run = "../../gradlew :examples:lwjgl-map:run --args='--render-target=owned-texture'"
+
+[tasks."run:owned-texture"]
+depends = ["//:ensure-native-library"]
+run = "../../gradlew :examples:lwjgl-map:run --args='--render-target=owned-texture'"
+
+[tasks."run:native-surface"]
+depends = ["//:ensure-native-library"]
+run = "../../gradlew :examples:lwjgl-map:run --args='--render-target=native-surface'"

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/InputController.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/InputController.java
@@ -107,9 +107,9 @@ final class InputController implements AutoCloseable {
   }
 
   private void onScroll(double yOffset) {
-    // GLFW reports OS-adjusted scroll deltas; keep Wayland/natural-scroll behavior intact.
-    var delta = -yOffset;
-    var scale = Math.pow(2.0, delta * 0.25);
+    // GLFW reports OS-adjusted scroll deltas; use them directly so trackpads with natural
+    // scrolling behave like the host platform expects.
+    var scale = Math.pow(2.0, yOffset * 0.25);
     map.scaleBy(scale, new ScreenPoint(cursorX, cursorY));
   }
 

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/InputController.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/InputController.java
@@ -1,0 +1,175 @@
+package org.maplibre.nativeffi.examples.lwjglmap;
+
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_0;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_A;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_D;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_DOWN;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_E;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_EQUAL;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_LEFT;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_LEFT_BRACKET;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_MINUS;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_PAGE_DOWN;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_PAGE_UP;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_Q;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_RIGHT;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_RIGHT_BRACKET;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_S;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_UP;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_W;
+import static org.lwjgl.glfw.GLFW.GLFW_MOD_CONTROL;
+import static org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_LEFT;
+import static org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_RIGHT;
+import static org.lwjgl.glfw.GLFW.GLFW_PRESS;
+import static org.lwjgl.glfw.GLFW.GLFW_RELEASE;
+import static org.lwjgl.glfw.GLFW.GLFW_REPEAT;
+import static org.lwjgl.glfw.GLFW.glfwSetCursorPosCallback;
+import static org.lwjgl.glfw.GLFW.glfwSetKeyCallback;
+import static org.lwjgl.glfw.GLFW.glfwSetMouseButtonCallback;
+import static org.lwjgl.glfw.GLFW.glfwSetScrollCallback;
+
+import org.maplibre.nativeffi.camera.AnimationOptions;
+import org.maplibre.nativeffi.camera.CameraOptions;
+import org.maplibre.nativeffi.geo.ScreenPoint;
+import org.maplibre.nativeffi.map.MapHandle;
+
+final class InputController implements AutoCloseable {
+  private static final double DRAG_ROTATE_FACTOR = 0.5;
+  private static final double DRAG_PITCH_FACTOR = 0.5;
+  private static final double KEYBOARD_PAN = 120.0;
+  private static final double KEYBOARD_ZOOM = 1.25;
+  private static final double KEYBOARD_BEARING = 10.0;
+  private static final double KEYBOARD_PITCH = 5.0;
+  private static final AnimationOptions KEYBOARD_ANIMATION = new AnimationOptions().durationMs(160);
+  private static final AnimationOptions RESET_ANIMATION = new AnimationOptions().durationMs(220);
+
+  private final long window;
+  private final MapHandle map;
+  private boolean leftDown;
+  private boolean rightDown;
+  private boolean ctrlDown;
+  private double lastX;
+  private double lastY;
+  private double cursorX;
+  private double cursorY;
+
+  InputController(long window, MapHandle map) {
+    this.window = window;
+    this.map = map;
+    installCallbacks();
+  }
+
+  static void printControls() {
+    System.out.println("Controls:");
+    System.out.println("  left drag: pan");
+    System.out.println("  right drag or Ctrl+left drag: rotate with X, pitch with Y");
+    System.out.println("  scroll: zoom at cursor");
+    System.out.println("  arrows or WASD: pan");
+    System.out.println("  + / -: zoom at center");
+    System.out.println("  Q / E: rotate");
+    System.out.println("  PageUp / PageDown or [ / ]: pitch");
+    System.out.println("  0: reset pitch and bearing");
+  }
+
+  private void installCallbacks() {
+    glfwSetCursorPosCallback(window, (ignored, x, y) -> onCursor(x, y));
+    glfwSetMouseButtonCallback(
+        window, (ignored, button, action, mods) -> onMouse(button, action, mods));
+    glfwSetScrollCallback(window, (ignored, xOffset, yOffset) -> onScroll(yOffset));
+    glfwSetKeyCallback(window, (ignored, key, scancode, action, mods) -> onKey(key, action, mods));
+  }
+
+  private void onCursor(double x, double y) {
+    cursorX = x;
+    cursorY = y;
+    var dx = x - lastX;
+    var dy = y - lastY;
+    lastX = x;
+    lastY = y;
+    if (rightDown || (leftDown && ctrlDown)) {
+      setBearing(currentBearing() + dx * DRAG_ROTATE_FACTOR, false);
+      setPitch(currentPitch() - dy * DRAG_PITCH_FACTOR, false);
+    } else if (leftDown) {
+      map.moveBy(dx, dy);
+    }
+  }
+
+  private void onMouse(int button, int action, int mods) {
+    ctrlDown = (mods & GLFW_MOD_CONTROL) != 0;
+    if (button == GLFW_MOUSE_BUTTON_LEFT) {
+      leftDown = action == GLFW_PRESS ? true : action == GLFW_RELEASE ? false : leftDown;
+    } else if (button == GLFW_MOUSE_BUTTON_RIGHT) {
+      rightDown = action == GLFW_PRESS ? true : action == GLFW_RELEASE ? false : rightDown;
+    }
+    if (action == GLFW_PRESS) {
+      map.cancelTransitions();
+    }
+  }
+
+  private void onScroll(double yOffset) {
+    // GLFW reports OS-adjusted scroll deltas; keep Wayland/natural-scroll behavior intact.
+    var delta = -yOffset;
+    var scale = Math.pow(2.0, delta * 0.25);
+    map.scaleBy(scale, new ScreenPoint(cursorX, cursorY));
+  }
+
+  private void onKey(int key, int action, int mods) {
+    ctrlDown = (mods & GLFW_MOD_CONTROL) != 0;
+    if (action != GLFW_PRESS && action != GLFW_REPEAT) {
+      return;
+    }
+    switch (key) {
+      case GLFW_KEY_LEFT, GLFW_KEY_A -> map.moveByAnimated(KEYBOARD_PAN, 0.0, KEYBOARD_ANIMATION);
+      case GLFW_KEY_RIGHT, GLFW_KEY_D -> map.moveByAnimated(-KEYBOARD_PAN, 0.0, KEYBOARD_ANIMATION);
+      case GLFW_KEY_UP, GLFW_KEY_W -> map.moveByAnimated(0.0, KEYBOARD_PAN, KEYBOARD_ANIMATION);
+      case GLFW_KEY_DOWN, GLFW_KEY_S -> map.moveByAnimated(0.0, -KEYBOARD_PAN, KEYBOARD_ANIMATION);
+      case GLFW_KEY_EQUAL -> map.scaleByAnimated(KEYBOARD_ZOOM, KEYBOARD_ANIMATION);
+      case GLFW_KEY_MINUS -> map.scaleByAnimated(1.0 / KEYBOARD_ZOOM, KEYBOARD_ANIMATION);
+      case GLFW_KEY_Q -> setBearing(currentBearing() - KEYBOARD_BEARING, true);
+      case GLFW_KEY_E -> setBearing(currentBearing() + KEYBOARD_BEARING, true);
+      case GLFW_KEY_PAGE_UP, GLFW_KEY_RIGHT_BRACKET ->
+          setPitch(currentPitch() + KEYBOARD_PITCH, true);
+      case GLFW_KEY_PAGE_DOWN, GLFW_KEY_LEFT_BRACKET ->
+          setPitch(currentPitch() - KEYBOARD_PITCH, true);
+      case GLFW_KEY_0 -> map.easeTo(new CameraOptions().bearing(0.0).pitch(0.0), RESET_ANIMATION);
+      default -> {}
+    }
+  }
+
+  private double currentBearing() {
+    var camera = map.camera();
+    return camera.hasBearing() ? camera.bearing() : 0.0;
+  }
+
+  private double currentPitch() {
+    var camera = map.camera();
+    return camera.hasPitch() ? camera.pitch() : 0.0;
+  }
+
+  private void setBearing(double bearing, boolean animated) {
+    var camera = new CameraOptions().bearing(bearing);
+    if (animated) {
+      map.easeTo(camera, KEYBOARD_ANIMATION);
+    } else {
+      map.jumpTo(camera);
+    }
+  }
+
+  private void setPitch(double pitch, boolean animated) {
+    var clamped = Math.max(0.0, Math.min(60.0, pitch));
+    var camera = new CameraOptions().pitch(clamped);
+    if (animated) {
+      map.easeTo(camera, KEYBOARD_ANIMATION);
+    } else {
+      map.jumpTo(camera);
+    }
+  }
+
+  @Override
+  public void close() {
+    glfwSetCursorPosCallback(window, null);
+    glfwSetMouseButtonCallback(window, null);
+    glfwSetScrollCallback(window, null);
+    glfwSetKeyCallback(window, null);
+  }
+}

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Main.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Main.java
@@ -1,0 +1,102 @@
+package org.maplibre.nativeffi.examples.lwjglmap;
+
+import static org.lwjgl.glfw.GLFW.glfwPollEvents;
+import static org.lwjgl.glfw.GLFW.glfwSetFramebufferSizeCallback;
+import static org.lwjgl.glfw.GLFW.glfwSetWindowContentScaleCallback;
+import static org.lwjgl.glfw.GLFW.glfwSetWindowSizeCallback;
+import static org.lwjgl.glfw.GLFW.glfwWindowShouldClose;
+
+import org.maplibre.nativeffi.Maplibre;
+import org.maplibre.nativeffi.render.RenderBackend;
+
+public final class Main {
+  private Main() {}
+
+  public static void main(String[] args) throws Exception {
+    var mode = parseArgs(args);
+    if (!Maplibre.supportedRenderBackends().contains(RenderBackend.VULKAN)) {
+      throw new IllegalStateException("The loaded MapLibre native library does not support Vulkan");
+    }
+    System.out.println("lwjgl-map render target: " + mode.cliName());
+    System.out.println("render target status: " + mode.status());
+    var propertyPath = System.getProperty("org.maplibre.nativeffi.library.path");
+    if (propertyPath != null) {
+      System.out.println("MapLibre native library: " + propertyPath);
+    }
+
+    try (var vulkan = VulkanContext.create("MapLibre LWJGL Map", 1280, 720)) {
+      var viewport = new ViewportHolder(Viewport.read(vulkan.window()));
+      try (var mapState = MapState.create(vulkan, viewport.value, mode);
+          var input = new InputController(vulkan.window(), mapState.map())) {
+        InputController.printControls();
+        installResizeCallbacks(vulkan.window(), viewport);
+        while (!glfwWindowShouldClose(vulkan.window())) {
+          glfwPollEvents();
+          if (viewport.consumeChanged()) {
+            mapState.resize(viewport.value);
+          }
+          var rendered = mapState.step();
+          if (!rendered) {
+            Thread.sleep(4);
+          }
+        }
+      }
+    }
+  }
+
+  private static RenderTargetMode parseArgs(String[] args) {
+    var mode = RenderTargetMode.OWNED_TEXTURE;
+    for (var arg : args) {
+      if (arg.equals("--help") || arg.equals("-h")) {
+        usageAndExit();
+      } else if (arg.startsWith("--render-target=")) {
+        mode = RenderTargetMode.parse(arg.substring("--render-target=".length()));
+      } else if (!arg.startsWith("-")) {
+        mode = RenderTargetMode.parse(arg);
+      } else {
+        throw new IllegalArgumentException("unknown argument: " + arg);
+      }
+    }
+    return mode;
+  }
+
+  private static void usageAndExit() {
+    System.out.println("Usage: lwjgl-map [--render-target=owned-texture|native-surface]");
+    System.out.println("       lwjgl-map [owned-texture|native-surface]");
+    System.out.println();
+    System.out.println("Render targets:");
+    for (var mode : RenderTargetMode.values()) {
+      System.out.println("  " + mode.cliName() + " - " + mode.status());
+    }
+    System.exit(0);
+  }
+
+  private static void installResizeCallbacks(long window, ViewportHolder viewport) {
+    glfwSetWindowSizeCallback(window, (ignored, width, height) -> viewport.update(window));
+    glfwSetFramebufferSizeCallback(window, (ignored, width, height) -> viewport.update(window));
+    glfwSetWindowContentScaleCallback(window, (ignored, xScale, yScale) -> viewport.update(window));
+  }
+
+  private static final class ViewportHolder {
+    private Viewport value;
+    private boolean changed;
+
+    ViewportHolder(Viewport value) {
+      this.value = value;
+    }
+
+    void update(long window) {
+      var next = Viewport.read(window);
+      if (!next.equals(value)) {
+        value = next;
+        changed = true;
+      }
+    }
+
+    boolean consumeChanged() {
+      var result = changed;
+      changed = false;
+      return result;
+    }
+  }
+}

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Main.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Main.java
@@ -47,9 +47,7 @@ public final class Main {
   private static RenderTargetMode parseArgs(String[] args) {
     var mode = RenderTargetMode.OWNED_TEXTURE;
     for (var arg : args) {
-      if (arg.equals("--help") || arg.equals("-h")) {
-        usageAndExit();
-      } else if (arg.startsWith("--render-target=")) {
+      if (arg.startsWith("--render-target=")) {
         mode = RenderTargetMode.parse(arg.substring("--render-target=".length()));
       } else if (!arg.startsWith("-")) {
         mode = RenderTargetMode.parse(arg);
@@ -58,17 +56,6 @@ public final class Main {
       }
     }
     return mode;
-  }
-
-  private static void usageAndExit() {
-    System.out.println("Usage: lwjgl-map [--render-target=owned-texture|native-surface]");
-    System.out.println("       lwjgl-map [owned-texture|native-surface]");
-    System.out.println();
-    System.out.println("Render targets:");
-    for (var mode : RenderTargetMode.values()) {
-      System.out.println("  " + mode.cliName() + " - " + mode.status());
-    }
-    System.exit(0);
   }
 
   private static void installResizeCallbacks(long window, ViewportHolder viewport) {

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/MapState.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/MapState.java
@@ -1,0 +1,221 @@
+package org.maplibre.nativeffi.examples.lwjglmap;
+
+import org.maplibre.nativeffi.camera.CameraOptions;
+import org.maplibre.nativeffi.map.MapHandle;
+import org.maplibre.nativeffi.map.MapMode;
+import org.maplibre.nativeffi.map.MapOptions;
+import org.maplibre.nativeffi.render.RenderSessionHandle;
+import org.maplibre.nativeffi.render.VulkanOwnedTextureDescriptor;
+import org.maplibre.nativeffi.render.VulkanSurfaceDescriptor;
+import org.maplibre.nativeffi.runtime.RuntimeEventType;
+import org.maplibre.nativeffi.runtime.RuntimeHandle;
+import org.maplibre.nativeffi.runtime.RuntimeOptions;
+
+final class MapState implements AutoCloseable {
+  private static final String STYLE_URL = "https://tiles.openfreemap.org/styles/bright";
+
+  private final RuntimeHandle runtime;
+  private final MapHandle map;
+  private final RenderTarget renderTarget;
+  private boolean renderPending = true;
+
+  private MapState(RuntimeHandle runtime, MapHandle map, RenderTarget renderTarget) {
+    this.runtime = runtime;
+    this.map = map;
+    this.renderTarget = renderTarget;
+  }
+
+  static MapState create(VulkanContext vulkan, Viewport viewport, RenderTargetMode mode) {
+    var runtime = RuntimeHandle.create(new RuntimeOptions().cachePath(":memory:"));
+    var map =
+        MapHandle.create(
+            runtime,
+            new MapOptions()
+                .size(viewport.width(), viewport.height())
+                .scaleFactor(viewport.scaleFactor())
+                .mapMode(MapMode.CONTINUOUS));
+    RenderTarget target = null;
+    try {
+      target = attachRenderTarget(vulkan, map, viewport, mode);
+      map.setStyleUrl(STYLE_URL);
+      map.jumpTo(
+          new CameraOptions().center(37.7749, -122.4194).zoom(13.0).bearing(12.0).pitch(30.0));
+      return new MapState(runtime, map, target);
+    } catch (RuntimeException error) {
+      if (target != null) {
+        target.close();
+      }
+      map.close();
+      runtime.close();
+      throw error;
+    }
+  }
+
+  MapHandle map() {
+    return map;
+  }
+
+  void resize(Viewport viewport) {
+    renderTarget.resize(viewport);
+    renderPending = true;
+  }
+
+  boolean step() {
+    runtime.runOnce();
+    drainEvents();
+    if (!renderPending) {
+      return false;
+    }
+    renderPending = false;
+    renderTarget.renderUpdate();
+    return true;
+  }
+
+  private void drainEvents() {
+    while (true) {
+      var event = runtime.pollEvent();
+      if (event.isEmpty()) {
+        return;
+      }
+      var value = event.get();
+      if (value.type() == RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE
+          && value.mapSource().filter(source -> source == map).isPresent()) {
+        renderPending = true;
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      renderTarget.close();
+    } finally {
+      try {
+        map.close();
+      } finally {
+        runtime.close();
+      }
+    }
+  }
+
+  private static RenderTarget attachRenderTarget(
+      VulkanContext vulkan, MapHandle map, Viewport viewport, RenderTargetMode mode) {
+    return switch (mode) {
+      case NATIVE_SURFACE -> {
+        var descriptor =
+            new VulkanSurfaceDescriptor()
+                .size(viewport.width(), viewport.height())
+                .scaleFactor(viewport.scaleFactor())
+                .instance(vulkan.instancePointer())
+                .physicalDevice(vulkan.physicalDevicePointer())
+                .device(vulkan.devicePointer())
+                .graphicsQueue(vulkan.graphicsQueuePointer())
+                .graphicsQueueFamilyIndex(vulkan.graphicsQueueFamilyIndex())
+                .surface(vulkan.surfacePointer());
+        yield new SurfaceRenderTarget(RenderSessionHandle.attachVulkanSurface(map, descriptor));
+      }
+      case OWNED_TEXTURE -> attachOwnedTextureRenderTarget(vulkan, map, viewport);
+    };
+  }
+
+  private static RenderTarget attachOwnedTextureRenderTarget(
+      VulkanContext vulkan, MapHandle map, Viewport viewport) {
+    var descriptor =
+        new VulkanOwnedTextureDescriptor()
+            .size(viewport.width(), viewport.height())
+            .scaleFactor(viewport.scaleFactor())
+            .instance(vulkan.instancePointer())
+            .physicalDevice(vulkan.physicalDevicePointer())
+            .device(vulkan.devicePointer())
+            .graphicsQueue(vulkan.graphicsQueuePointer())
+            .graphicsQueueFamilyIndex(vulkan.graphicsQueueFamilyIndex());
+    RenderSessionHandle session = null;
+    VulkanTextureCompositor compositor = null;
+    try {
+      session = RenderSessionHandle.attachVulkanOwnedTexture(map, descriptor);
+      compositor = new VulkanTextureCompositor(vulkan, viewport);
+      return new OwnedTextureRenderTarget(session, compositor);
+    } catch (RuntimeException error) {
+      if (compositor != null) {
+        try {
+          compositor.close();
+        } catch (RuntimeException cleanupError) {
+          error.addSuppressed(cleanupError);
+        }
+      }
+      if (session != null) {
+        try {
+          session.close();
+        } catch (RuntimeException cleanupError) {
+          error.addSuppressed(cleanupError);
+        }
+      }
+      throw error;
+    }
+  }
+
+  private interface RenderTarget extends AutoCloseable {
+    void resize(Viewport viewport);
+
+    void renderUpdate();
+
+    @Override
+    void close();
+  }
+
+  private static final class SurfaceRenderTarget implements RenderTarget {
+    private final RenderSessionHandle session;
+
+    SurfaceRenderTarget(RenderSessionHandle session) {
+      this.session = session;
+    }
+
+    @Override
+    public void resize(Viewport viewport) {
+      session.resize(viewport.width(), viewport.height(), viewport.scaleFactor());
+    }
+
+    @Override
+    public void renderUpdate() {
+      session.renderUpdate();
+    }
+
+    @Override
+    public void close() {
+      session.close();
+    }
+  }
+
+  private static final class OwnedTextureRenderTarget implements RenderTarget {
+    private final RenderSessionHandle session;
+    private final VulkanTextureCompositor compositor;
+
+    OwnedTextureRenderTarget(RenderSessionHandle session, VulkanTextureCompositor compositor) {
+      this.session = session;
+      this.compositor = compositor;
+    }
+
+    @Override
+    public void resize(Viewport viewport) {
+      compositor.resize(viewport);
+      session.resize(viewport.width(), viewport.height(), viewport.scaleFactor());
+    }
+
+    @Override
+    public void renderUpdate() {
+      session.renderUpdate();
+      try (var lease = session.acquireVulkanOwnedTextureFrame()) {
+        compositor.draw(lease);
+      }
+    }
+
+    @Override
+    public void close() {
+      try {
+        compositor.close();
+      } finally {
+        session.close();
+      }
+    }
+  }
+}

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/MapState.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/MapState.java
@@ -204,8 +204,8 @@ final class MapState implements AutoCloseable {
     @Override
     public void renderUpdate() {
       session.renderUpdate();
-      try (var lease = session.acquireVulkanOwnedTextureFrame()) {
-        compositor.draw(lease);
+      try (var frameHandle = session.acquireVulkanOwnedTextureFrame()) {
+        compositor.draw(frameHandle);
       }
     }
 

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/RenderTargetMode.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/RenderTargetMode.java
@@ -1,0 +1,32 @@
+package org.maplibre.nativeffi.examples.lwjglmap;
+
+enum RenderTargetMode {
+  OWNED_TEXTURE("owned-texture"),
+  NATIVE_SURFACE("native-surface");
+
+  private final String cliName;
+
+  RenderTargetMode(String cliName) {
+    this.cliName = cliName;
+  }
+
+  String cliName() {
+    return cliName;
+  }
+
+  String status() {
+    return switch (this) {
+      case OWNED_TEXTURE -> "samples MapLibre-owned Vulkan frames into the GLFW swapchain";
+      case NATIVE_SURFACE -> "renders directly to the GLFW Vulkan surface";
+    };
+  }
+
+  static RenderTargetMode parse(String value) {
+    for (var mode : values()) {
+      if (mode.cliName.equals(value)) {
+        return mode;
+      }
+    }
+    throw new IllegalArgumentException("unknown render target '" + value + "'");
+  }
+}

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Viewport.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Viewport.java
@@ -1,0 +1,36 @@
+package org.maplibre.nativeffi.examples.lwjglmap;
+
+import static org.lwjgl.glfw.GLFW.glfwGetFramebufferSize;
+import static org.lwjgl.glfw.GLFW.glfwGetWindowContentScale;
+import static org.lwjgl.glfw.GLFW.glfwGetWindowSize;
+
+import org.lwjgl.system.MemoryStack;
+
+record Viewport(
+    int width, int height, double scaleFactor, int framebufferWidth, int framebufferHeight) {
+  static Viewport read(long window) {
+    try (var stack = MemoryStack.stackPush()) {
+      var windowWidth = stack.mallocInt(1);
+      var windowHeight = stack.mallocInt(1);
+      var framebufferWidth = stack.mallocInt(1);
+      var framebufferHeight = stack.mallocInt(1);
+      var xScale = stack.mallocFloat(1);
+      var yScale = stack.mallocFloat(1);
+      glfwGetWindowSize(window, windowWidth, windowHeight);
+      glfwGetFramebufferSize(window, framebufferWidth, framebufferHeight);
+      glfwGetWindowContentScale(window, xScale, yScale);
+
+      var logicalWidth = Math.max(1, windowWidth.get(0));
+      var logicalHeight = Math.max(1, windowHeight.get(0));
+      var physicalWidth = Math.max(1, framebufferWidth.get(0));
+      var physicalHeight = Math.max(1, framebufferHeight.get(0));
+      double scale = Math.max(xScale.get(0), yScale.get(0));
+      if (!(scale > 0.0)) {
+        scale =
+            Math.max(
+                (double) physicalWidth / logicalWidth, (double) physicalHeight / logicalHeight);
+      }
+      return new Viewport(logicalWidth, logicalHeight, scale, physicalWidth, physicalHeight);
+    }
+  }
+}

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/VulkanContext.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/VulkanContext.java
@@ -1,0 +1,382 @@
+package org.maplibre.nativeffi.examples.lwjglmap;
+
+import static org.lwjgl.glfw.GLFW.GLFW_CLIENT_API;
+import static org.lwjgl.glfw.GLFW.GLFW_NO_API;
+import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM;
+import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_WAYLAND;
+import static org.lwjgl.glfw.GLFW.GLFW_RESIZABLE;
+import static org.lwjgl.glfw.GLFW.GLFW_TRUE;
+import static org.lwjgl.glfw.GLFW.glfwCreateWindow;
+import static org.lwjgl.glfw.GLFW.glfwDefaultWindowHints;
+import static org.lwjgl.glfw.GLFW.glfwDestroyWindow;
+import static org.lwjgl.glfw.GLFW.glfwGetPlatform;
+import static org.lwjgl.glfw.GLFW.glfwGetVersionString;
+import static org.lwjgl.glfw.GLFW.glfwInit;
+import static org.lwjgl.glfw.GLFW.glfwInitHint;
+import static org.lwjgl.glfw.GLFW.glfwTerminate;
+import static org.lwjgl.glfw.GLFW.glfwWindowHint;
+import static org.lwjgl.glfw.GLFWVulkan.glfwCreateWindowSurface;
+import static org.lwjgl.glfw.GLFWVulkan.glfwGetRequiredInstanceExtensions;
+import static org.lwjgl.glfw.GLFWVulkan.glfwVulkanSupported;
+import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.vulkan.EXTDebugUtils.VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
+import static org.lwjgl.vulkan.KHRPortabilityEnumeration.VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+import static org.lwjgl.vulkan.KHRPortabilityEnumeration.VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+import static org.lwjgl.vulkan.KHRPortabilitySubset.VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
+import static org.lwjgl.vulkan.KHRSurface.vkDestroySurfaceKHR;
+import static org.lwjgl.vulkan.KHRSurface.vkGetPhysicalDeviceSurfaceSupportKHR;
+import static org.lwjgl.vulkan.KHRSwapchain.VK_KHR_SWAPCHAIN_EXTENSION_NAME;
+import static org.lwjgl.vulkan.VK10.VK_API_VERSION_1_0;
+import static org.lwjgl.vulkan.VK10.VK_QUEUE_GRAPHICS_BIT;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_APPLICATION_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_SUCCESS;
+import static org.lwjgl.vulkan.VK10.vkCreateDevice;
+import static org.lwjgl.vulkan.VK10.vkCreateInstance;
+import static org.lwjgl.vulkan.VK10.vkDestroyDevice;
+import static org.lwjgl.vulkan.VK10.vkDestroyInstance;
+import static org.lwjgl.vulkan.VK10.vkDeviceWaitIdle;
+import static org.lwjgl.vulkan.VK10.vkEnumerateDeviceExtensionProperties;
+import static org.lwjgl.vulkan.VK10.vkEnumerateInstanceExtensionProperties;
+import static org.lwjgl.vulkan.VK10.vkEnumeratePhysicalDevices;
+import static org.lwjgl.vulkan.VK10.vkGetDeviceQueue;
+import static org.lwjgl.vulkan.VK10.vkGetPhysicalDeviceQueueFamilyProperties;
+
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VkApplicationInfo;
+import org.lwjgl.vulkan.VkDevice;
+import org.lwjgl.vulkan.VkDeviceCreateInfo;
+import org.lwjgl.vulkan.VkDeviceQueueCreateInfo;
+import org.lwjgl.vulkan.VkExtensionProperties;
+import org.lwjgl.vulkan.VkInstance;
+import org.lwjgl.vulkan.VkInstanceCreateInfo;
+import org.lwjgl.vulkan.VkPhysicalDevice;
+import org.lwjgl.vulkan.VkQueue;
+import org.lwjgl.vulkan.VkQueueFamilyProperties;
+import org.maplibre.nativeffi.render.NativePointer;
+
+final class VulkanContext implements AutoCloseable {
+  private final long window;
+  private VkInstance instance;
+  private long surface;
+  private VkPhysicalDevice physicalDevice;
+  private VkDevice device;
+  private VkQueue graphicsQueue;
+  private int graphicsQueueFamilyIndex;
+
+  private VulkanContext(long window) {
+    this.window = window;
+  }
+
+  static VulkanContext create(String title, int width, int height) {
+    selectWaylandOnLinux();
+    if (!glfwInit()) {
+      throw new IllegalStateException("GLFW initialization failed");
+    }
+    if (!glfwVulkanSupported()) {
+      throw new IllegalStateException("GLFW reports Vulkan is not supported");
+    }
+    validateWaylandOnLinux();
+    glfwDefaultWindowHints();
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+    glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
+    var window = glfwCreateWindow(width, height, title, NULL, NULL);
+    if (window == NULL) {
+      glfwTerminate();
+      throw new IllegalStateException("GLFW window creation failed");
+    }
+    var context = new VulkanContext(window);
+    try {
+      context.createInstance();
+      context.createSurface();
+      context.pickPhysicalDeviceAndQueue();
+      context.createDevice();
+      System.out.printf(
+          "GLFW %s, Vulkan queue family %d, platform %d%n",
+          glfwGetVersionString(), context.graphicsQueueFamilyIndex, glfwGetPlatform());
+      return context;
+    } catch (RuntimeException error) {
+      context.close();
+      throw error;
+    }
+  }
+
+  long window() {
+    return window;
+  }
+
+  NativePointer instancePointer() {
+    return NativePointer.ofAddress(instance.address());
+  }
+
+  NativePointer physicalDevicePointer() {
+    return NativePointer.ofAddress(physicalDevice.address());
+  }
+
+  NativePointer devicePointer() {
+    return NativePointer.ofAddress(device.address());
+  }
+
+  NativePointer graphicsQueuePointer() {
+    return NativePointer.ofAddress(graphicsQueue.address());
+  }
+
+  int graphicsQueueFamilyIndex() {
+    return graphicsQueueFamilyIndex;
+  }
+
+  NativePointer surfacePointer() {
+    return NativePointer.ofAddress(surface);
+  }
+
+  VkInstance instance() {
+    return instance;
+  }
+
+  long surface() {
+    return surface;
+  }
+
+  VkPhysicalDevice physicalDevice() {
+    return physicalDevice;
+  }
+
+  VkDevice device() {
+    return device;
+  }
+
+  VkQueue graphicsQueue() {
+    return graphicsQueue;
+  }
+
+  void waitIdle() {
+    if (device != null) {
+      check(vkDeviceWaitIdle(device), "vkDeviceWaitIdle");
+    }
+  }
+
+  private void createInstance() {
+    try (var stack = MemoryStack.stackPush()) {
+      var required = glfwGetRequiredInstanceExtensions();
+      if (required == null) {
+        throw new IllegalStateException("GLFW did not return Vulkan instance extensions");
+      }
+      var available = instanceExtensions(stack);
+      var extensions = new LinkedHashSet<String>();
+      for (int i = 0; i < required.remaining(); i++) {
+        extensions.add(required.getStringUTF8(i));
+      }
+      var enablePortability = available.contains(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+      if (enablePortability) {
+        extensions.add(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+      }
+      if (available.contains(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
+        // Enable the extension when present so validation layers can attach during local runs.
+        extensions.add(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+      }
+      var extensionBuffer = stringBuffer(stack, extensions);
+      var app =
+          VkApplicationInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_APPLICATION_INFO)
+              .pApplicationName(stack.UTF8("lwjgl-map"))
+              .pEngineName(stack.UTF8("maplibre-native-ffi"))
+              .apiVersion(VK_API_VERSION_1_0);
+      var createInfo =
+          VkInstanceCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
+              .pApplicationInfo(app)
+              .ppEnabledExtensionNames(extensionBuffer);
+      if (enablePortability) {
+        createInfo.flags(VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR);
+      }
+      var out = stack.mallocPointer(1);
+      check(vkCreateInstance(createInfo, null, out), "vkCreateInstance");
+      instance = new VkInstance(out.get(0), createInfo);
+      System.out.println("Enabled Vulkan instance extensions: " + extensions);
+    }
+  }
+
+  private void createSurface() {
+    try (var stack = MemoryStack.stackPush()) {
+      var out = stack.mallocLong(1);
+      check(glfwCreateWindowSurface(instance, window, null, out), "glfwCreateWindowSurface");
+      surface = out.get(0);
+    }
+  }
+
+  private void pickPhysicalDeviceAndQueue() {
+    try (var stack = MemoryStack.stackPush()) {
+      var count = stack.mallocInt(1);
+      check(vkEnumeratePhysicalDevices(instance, count, null), "vkEnumeratePhysicalDevices(count)");
+      if (count.get(0) == 0) {
+        throw new IllegalStateException("No Vulkan physical devices found");
+      }
+      var devices = stack.mallocPointer(count.get(0));
+      check(vkEnumeratePhysicalDevices(instance, count, devices), "vkEnumeratePhysicalDevices");
+      for (int i = 0; i < devices.capacity(); i++) {
+        var candidate = new VkPhysicalDevice(devices.get(i), instance);
+        var queueFamily = findGraphicsPresentQueueFamily(stack, candidate);
+        if (queueFamily >= 0) {
+          physicalDevice = candidate;
+          graphicsQueueFamilyIndex = queueFamily;
+          return;
+        }
+      }
+      throw new IllegalStateException("No Vulkan device has a graphics queue that can present");
+    }
+  }
+
+  private int findGraphicsPresentQueueFamily(MemoryStack stack, VkPhysicalDevice candidate) {
+    var count = stack.mallocInt(1);
+    vkGetPhysicalDeviceQueueFamilyProperties(candidate, count, null);
+    var families = VkQueueFamilyProperties.calloc(count.get(0), stack);
+    vkGetPhysicalDeviceQueueFamilyProperties(candidate, count, families);
+    var present = stack.mallocInt(1);
+    for (int i = 0; i < families.capacity(); i++) {
+      var family = families.get(i);
+      if ((family.queueFlags() & VK_QUEUE_GRAPHICS_BIT) == 0) {
+        continue;
+      }
+      check(
+          vkGetPhysicalDeviceSurfaceSupportKHR(candidate, i, surface, present),
+          "vkGetPhysicalDeviceSurfaceSupportKHR");
+      if (present.get(0) != 0) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private void createDevice() {
+    try (var stack = MemoryStack.stackPush()) {
+      var extensions = new LinkedHashSet<String>();
+      extensions.add(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+      var deviceExtensions = deviceExtensions(stack, physicalDevice);
+      if (!deviceExtensions.contains(VK_KHR_SWAPCHAIN_EXTENSION_NAME)) {
+        throw new IllegalStateException("Selected Vulkan device does not support VK_KHR_swapchain");
+      }
+      if (deviceExtensions.contains(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        extensions.add(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+      }
+      var priorities = stack.floats(1.0f);
+      var queueInfo =
+          VkDeviceQueueCreateInfo.calloc(1, stack)
+              .sType(VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO)
+              .queueFamilyIndex(graphicsQueueFamilyIndex)
+              .pQueuePriorities(priorities);
+      var createInfo =
+          VkDeviceCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
+              .pQueueCreateInfos(queueInfo)
+              .ppEnabledExtensionNames(stringBuffer(stack, extensions));
+      var out = stack.mallocPointer(1);
+      check(vkCreateDevice(physicalDevice, createInfo, null, out), "vkCreateDevice");
+      device = new VkDevice(out.get(0), physicalDevice, createInfo);
+      var queueOut = stack.mallocPointer(1);
+      vkGetDeviceQueue(device, graphicsQueueFamilyIndex, 0, queueOut);
+      graphicsQueue = new VkQueue(queueOut.get(0), device);
+      System.out.println("Enabled Vulkan device extensions: " + extensions);
+    }
+  }
+
+  private static Set<String> instanceExtensions(MemoryStack stack) {
+    var count = stack.mallocInt(1);
+    check(
+        vkEnumerateInstanceExtensionProperties((String) null, count, null),
+        "vkEnumerateInstanceExtensionProperties(count)");
+    var props = VkExtensionProperties.calloc(count.get(0), stack);
+    check(
+        vkEnumerateInstanceExtensionProperties((String) null, count, props),
+        "vkEnumerateInstanceExtensionProperties");
+    var names = new LinkedHashSet<String>();
+    for (var prop : props) {
+      names.add(prop.extensionNameString());
+    }
+    return names;
+  }
+
+  private static Set<String> deviceExtensions(MemoryStack stack, VkPhysicalDevice device) {
+    var count = stack.mallocInt(1);
+    check(
+        vkEnumerateDeviceExtensionProperties(device, (String) null, count, null),
+        "vkEnumerateDeviceExtensionProperties(count)");
+    var props = VkExtensionProperties.calloc(count.get(0), stack);
+    check(
+        vkEnumerateDeviceExtensionProperties(device, (String) null, count, props),
+        "vkEnumerateDeviceExtensionProperties");
+    var names = new LinkedHashSet<String>();
+    for (var prop : props) {
+      names.add(prop.extensionNameString());
+    }
+    return names;
+  }
+
+  private static PointerBuffer stringBuffer(MemoryStack stack, Set<String> values) {
+    var buffer = stack.mallocPointer(values.size());
+    for (var value : values) {
+      buffer.put(stack.UTF8(value));
+    }
+    return buffer.flip();
+  }
+
+  private static void selectWaylandOnLinux() {
+    if (!isLinux()) {
+      return;
+    }
+    if (System.getenv("WAYLAND_DISPLAY") != null && !System.getenv("WAYLAND_DISPLAY").isBlank()) {
+      glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_WAYLAND);
+    }
+  }
+
+  private static void validateWaylandOnLinux() {
+    if (!isLinux()) {
+      return;
+    }
+    if (System.getenv("WAYLAND_DISPLAY") == null || System.getenv("WAYLAND_DISPLAY").isBlank()) {
+      System.err.println(
+          "WAYLAND_DISPLAY is not set; Linux runtime support for this example targets Wayland.");
+      return;
+    }
+    if (glfwGetPlatform() != GLFW_PLATFORM_WAYLAND) {
+      throw new IllegalStateException(
+          "GLFW did not select Wayland; selected platform=" + glfwGetPlatform());
+    }
+  }
+
+  private static boolean isLinux() {
+    return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("linux");
+  }
+
+  private static void check(int status, String operation) {
+    if (status != VK_SUCCESS) {
+      throw new IllegalStateException(operation + " failed with Vulkan status " + status);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (device != null) {
+      vkDeviceWaitIdle(device);
+      vkDestroyDevice(device, null);
+      device = null;
+    }
+    if (surface != NULL) {
+      vkDestroySurfaceKHR(instance, surface, null);
+      surface = NULL;
+    }
+    if (instance != null) {
+      vkDestroyInstance(instance, null);
+      instance = null;
+    }
+    if (window != NULL) {
+      glfwDestroyWindow(window);
+    }
+    glfwTerminate();
+  }
+}

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.java
@@ -315,8 +315,8 @@ final class VulkanTextureCompositor implements AutoCloseable {
         }
       }
       swapchainFormat = chosen.format();
-      extentWidth = chooseExtentDimension(capabilities, viewport.width(), true);
-      extentHeight = chooseExtentDimension(capabilities, viewport.height(), false);
+      extentWidth = chooseExtentDimension(capabilities, viewport.framebufferWidth(), true);
+      extentHeight = chooseExtentDimension(capabilities, viewport.framebufferHeight(), false);
       var imageCount = capabilities.minImageCount() + 1;
       if (capabilities.maxImageCount() > 0 && imageCount > capabilities.maxImageCount()) {
         imageCount = capabilities.maxImageCount();

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.java
@@ -1,0 +1,853 @@
+package org.maplibre.nativeffi.examples.lwjglmap;
+
+import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_compilation_status_success;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_compile_into_spv;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_compile_options_initialize;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_compile_options_release;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_compiler_initialize;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_compiler_release;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_fragment_shader;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_result_get_bytes;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_result_get_compilation_status;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_result_get_error_message;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_result_release;
+import static org.lwjgl.util.shaderc.Shaderc.shaderc_vertex_shader;
+import static org.lwjgl.vulkan.KHRSurface.VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+import static org.lwjgl.vulkan.KHRSurface.VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+import static org.lwjgl.vulkan.KHRSurface.VK_PRESENT_MODE_FIFO_KHR;
+import static org.lwjgl.vulkan.KHRSurface.vkGetPhysicalDeviceSurfaceCapabilitiesKHR;
+import static org.lwjgl.vulkan.KHRSurface.vkGetPhysicalDeviceSurfaceFormatsKHR;
+import static org.lwjgl.vulkan.KHRSwapchain.VK_ERROR_OUT_OF_DATE_KHR;
+import static org.lwjgl.vulkan.KHRSwapchain.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+import static org.lwjgl.vulkan.KHRSwapchain.VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+import static org.lwjgl.vulkan.KHRSwapchain.VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+import static org.lwjgl.vulkan.KHRSwapchain.VK_SUBOPTIMAL_KHR;
+import static org.lwjgl.vulkan.KHRSwapchain.vkAcquireNextImageKHR;
+import static org.lwjgl.vulkan.KHRSwapchain.vkCreateSwapchainKHR;
+import static org.lwjgl.vulkan.KHRSwapchain.vkDestroySwapchainKHR;
+import static org.lwjgl.vulkan.KHRSwapchain.vkGetSwapchainImagesKHR;
+import static org.lwjgl.vulkan.KHRSwapchain.vkQueuePresentKHR;
+import static org.lwjgl.vulkan.VK10.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+import static org.lwjgl.vulkan.VK10.VK_ATTACHMENT_LOAD_OP_CLEAR;
+import static org.lwjgl.vulkan.VK10.VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+import static org.lwjgl.vulkan.VK10.VK_ATTACHMENT_STORE_OP_DONT_CARE;
+import static org.lwjgl.vulkan.VK10.VK_ATTACHMENT_STORE_OP_STORE;
+import static org.lwjgl.vulkan.VK10.VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+import static org.lwjgl.vulkan.VK10.VK_COLOR_COMPONENT_A_BIT;
+import static org.lwjgl.vulkan.VK10.VK_COLOR_COMPONENT_B_BIT;
+import static org.lwjgl.vulkan.VK10.VK_COLOR_COMPONENT_G_BIT;
+import static org.lwjgl.vulkan.VK10.VK_COLOR_COMPONENT_R_BIT;
+import static org.lwjgl.vulkan.VK10.VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+import static org.lwjgl.vulkan.VK10.VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+import static org.lwjgl.vulkan.VK10.VK_COMPARE_OP_ALWAYS;
+import static org.lwjgl.vulkan.VK10.VK_CULL_MODE_NONE;
+import static org.lwjgl.vulkan.VK10.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+import static org.lwjgl.vulkan.VK10.VK_DYNAMIC_STATE_SCISSOR;
+import static org.lwjgl.vulkan.VK10.VK_DYNAMIC_STATE_VIEWPORT;
+import static org.lwjgl.vulkan.VK10.VK_FILTER_LINEAR;
+import static org.lwjgl.vulkan.VK10.VK_FORMAT_B8G8R8A8_UNORM;
+import static org.lwjgl.vulkan.VK10.VK_FORMAT_R8G8B8A8_UNORM;
+import static org.lwjgl.vulkan.VK10.VK_FRONT_FACE_COUNTER_CLOCKWISE;
+import static org.lwjgl.vulkan.VK10.VK_IMAGE_ASPECT_COLOR_BIT;
+import static org.lwjgl.vulkan.VK10.VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+import static org.lwjgl.vulkan.VK10.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+import static org.lwjgl.vulkan.VK10.VK_IMAGE_LAYOUT_UNDEFINED;
+import static org.lwjgl.vulkan.VK10.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+import static org.lwjgl.vulkan.VK10.VK_LOGIC_OP_COPY;
+import static org.lwjgl.vulkan.VK10.VK_PIPELINE_BIND_POINT_GRAPHICS;
+import static org.lwjgl.vulkan.VK10.VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+import static org.lwjgl.vulkan.VK10.VK_POLYGON_MODE_FILL;
+import static org.lwjgl.vulkan.VK10.VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+import static org.lwjgl.vulkan.VK10.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+import static org.lwjgl.vulkan.VK10.VK_SAMPLER_MIPMAP_MODE_LINEAR;
+import static org.lwjgl.vulkan.VK10.VK_SAMPLE_COUNT_1_BIT;
+import static org.lwjgl.vulkan.VK10.VK_SHADER_STAGE_FRAGMENT_BIT;
+import static org.lwjgl.vulkan.VK10.VK_SHADER_STAGE_VERTEX_BIT;
+import static org.lwjgl.vulkan.VK10.VK_SHARING_MODE_EXCLUSIVE;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_SUBMIT_INFO;
+import static org.lwjgl.vulkan.VK10.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+import static org.lwjgl.vulkan.VK10.VK_SUBPASS_CONTENTS_INLINE;
+import static org.lwjgl.vulkan.VK10.VK_SUBPASS_EXTERNAL;
+import static org.lwjgl.vulkan.VK10.VK_SUCCESS;
+import static org.lwjgl.vulkan.VK10.vkAllocateCommandBuffers;
+import static org.lwjgl.vulkan.VK10.vkAllocateDescriptorSets;
+import static org.lwjgl.vulkan.VK10.vkBeginCommandBuffer;
+import static org.lwjgl.vulkan.VK10.vkCmdBeginRenderPass;
+import static org.lwjgl.vulkan.VK10.vkCmdBindDescriptorSets;
+import static org.lwjgl.vulkan.VK10.vkCmdBindPipeline;
+import static org.lwjgl.vulkan.VK10.vkCmdDraw;
+import static org.lwjgl.vulkan.VK10.vkCmdEndRenderPass;
+import static org.lwjgl.vulkan.VK10.vkCmdSetScissor;
+import static org.lwjgl.vulkan.VK10.vkCmdSetViewport;
+import static org.lwjgl.vulkan.VK10.vkCreateCommandPool;
+import static org.lwjgl.vulkan.VK10.vkCreateDescriptorPool;
+import static org.lwjgl.vulkan.VK10.vkCreateDescriptorSetLayout;
+import static org.lwjgl.vulkan.VK10.vkCreateFence;
+import static org.lwjgl.vulkan.VK10.vkCreateFramebuffer;
+import static org.lwjgl.vulkan.VK10.vkCreateGraphicsPipelines;
+import static org.lwjgl.vulkan.VK10.vkCreateImageView;
+import static org.lwjgl.vulkan.VK10.vkCreatePipelineLayout;
+import static org.lwjgl.vulkan.VK10.vkCreateRenderPass;
+import static org.lwjgl.vulkan.VK10.vkCreateSampler;
+import static org.lwjgl.vulkan.VK10.vkCreateSemaphore;
+import static org.lwjgl.vulkan.VK10.vkCreateShaderModule;
+import static org.lwjgl.vulkan.VK10.vkDestroyCommandPool;
+import static org.lwjgl.vulkan.VK10.vkDestroyDescriptorPool;
+import static org.lwjgl.vulkan.VK10.vkDestroyDescriptorSetLayout;
+import static org.lwjgl.vulkan.VK10.vkDestroyFence;
+import static org.lwjgl.vulkan.VK10.vkDestroyFramebuffer;
+import static org.lwjgl.vulkan.VK10.vkDestroyImageView;
+import static org.lwjgl.vulkan.VK10.vkDestroyPipeline;
+import static org.lwjgl.vulkan.VK10.vkDestroyPipelineLayout;
+import static org.lwjgl.vulkan.VK10.vkDestroyRenderPass;
+import static org.lwjgl.vulkan.VK10.vkDestroySampler;
+import static org.lwjgl.vulkan.VK10.vkDestroySemaphore;
+import static org.lwjgl.vulkan.VK10.vkDestroyShaderModule;
+import static org.lwjgl.vulkan.VK10.vkEndCommandBuffer;
+import static org.lwjgl.vulkan.VK10.vkQueueSubmit;
+import static org.lwjgl.vulkan.VK10.vkQueueWaitIdle;
+import static org.lwjgl.vulkan.VK10.vkResetCommandBuffer;
+import static org.lwjgl.vulkan.VK10.vkResetFences;
+import static org.lwjgl.vulkan.VK10.vkUpdateDescriptorSets;
+import static org.lwjgl.vulkan.VK10.vkWaitForFences;
+
+import java.nio.ByteBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VkAttachmentDescription;
+import org.lwjgl.vulkan.VkAttachmentReference;
+import org.lwjgl.vulkan.VkClearValue;
+import org.lwjgl.vulkan.VkCommandBuffer;
+import org.lwjgl.vulkan.VkCommandBufferAllocateInfo;
+import org.lwjgl.vulkan.VkCommandBufferBeginInfo;
+import org.lwjgl.vulkan.VkCommandPoolCreateInfo;
+import org.lwjgl.vulkan.VkDescriptorImageInfo;
+import org.lwjgl.vulkan.VkDescriptorPoolCreateInfo;
+import org.lwjgl.vulkan.VkDescriptorPoolSize;
+import org.lwjgl.vulkan.VkDescriptorSetAllocateInfo;
+import org.lwjgl.vulkan.VkDescriptorSetLayoutBinding;
+import org.lwjgl.vulkan.VkDescriptorSetLayoutCreateInfo;
+import org.lwjgl.vulkan.VkExtent2D;
+import org.lwjgl.vulkan.VkFenceCreateInfo;
+import org.lwjgl.vulkan.VkFramebufferCreateInfo;
+import org.lwjgl.vulkan.VkGraphicsPipelineCreateInfo;
+import org.lwjgl.vulkan.VkImageSubresourceRange;
+import org.lwjgl.vulkan.VkImageViewCreateInfo;
+import org.lwjgl.vulkan.VkOffset2D;
+import org.lwjgl.vulkan.VkPipelineColorBlendAttachmentState;
+import org.lwjgl.vulkan.VkPipelineColorBlendStateCreateInfo;
+import org.lwjgl.vulkan.VkPipelineDynamicStateCreateInfo;
+import org.lwjgl.vulkan.VkPipelineInputAssemblyStateCreateInfo;
+import org.lwjgl.vulkan.VkPipelineLayoutCreateInfo;
+import org.lwjgl.vulkan.VkPipelineMultisampleStateCreateInfo;
+import org.lwjgl.vulkan.VkPipelineRasterizationStateCreateInfo;
+import org.lwjgl.vulkan.VkPipelineShaderStageCreateInfo;
+import org.lwjgl.vulkan.VkPipelineVertexInputStateCreateInfo;
+import org.lwjgl.vulkan.VkPipelineViewportStateCreateInfo;
+import org.lwjgl.vulkan.VkPresentInfoKHR;
+import org.lwjgl.vulkan.VkRect2D;
+import org.lwjgl.vulkan.VkRenderPassBeginInfo;
+import org.lwjgl.vulkan.VkRenderPassCreateInfo;
+import org.lwjgl.vulkan.VkSamplerCreateInfo;
+import org.lwjgl.vulkan.VkSemaphoreCreateInfo;
+import org.lwjgl.vulkan.VkShaderModuleCreateInfo;
+import org.lwjgl.vulkan.VkSubmitInfo;
+import org.lwjgl.vulkan.VkSubpassDependency;
+import org.lwjgl.vulkan.VkSubpassDescription;
+import org.lwjgl.vulkan.VkSurfaceCapabilitiesKHR;
+import org.lwjgl.vulkan.VkSurfaceFormatKHR;
+import org.lwjgl.vulkan.VkSwapchainCreateInfoKHR;
+import org.lwjgl.vulkan.VkViewport;
+import org.lwjgl.vulkan.VkWriteDescriptorSet;
+import org.maplibre.nativeffi.render.VulkanOwnedTextureFrameLease;
+
+final class VulkanTextureCompositor implements AutoCloseable {
+  private static final String VERTEX_SHADER =
+      """
+      #version 450
+      layout(location = 0) out vec2 out_uv;
+      vec2 positions[3] = vec2[](vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
+      vec2 uvs[3] = vec2[](vec2(0.0, 0.0), vec2(2.0, 0.0), vec2(0.0, 2.0));
+      void main() {
+        gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+        out_uv = uvs[gl_VertexIndex];
+      }
+      """;
+  private static final String FRAGMENT_SHADER =
+      """
+      #version 450
+      layout(set = 0, binding = 0) uniform sampler2D map_texture;
+      layout(location = 0) in vec2 in_uv;
+      layout(location = 0) out vec4 out_color;
+      void main() {
+        out_color = texture(map_texture, in_uv);
+      }
+      """;
+
+  private final VulkanContext context;
+  private long swapchain;
+  private int swapchainFormat;
+  private int extentWidth;
+  private int extentHeight;
+  private long[] imageViews = new long[0];
+  private long[] framebuffers = new long[0];
+  private long renderPass;
+  private long descriptorSetLayout;
+  private long pipelineLayout;
+  private long pipeline;
+  private long sampler;
+  private long descriptorPool;
+  private long descriptorSet;
+  private long commandPool;
+  private VkCommandBuffer commandBuffer;
+  private long imageAvailable;
+  private long renderFinished;
+  private long inFlight;
+
+  VulkanTextureCompositor(VulkanContext context, Viewport viewport) {
+    this.context = context;
+    try {
+      createSwapchain(viewport);
+      createRenderPass();
+      createDescriptorState();
+      createPipeline();
+      createFramebuffers();
+      createCommands();
+    } catch (RuntimeException error) {
+      try {
+        close();
+      } catch (RuntimeException cleanupError) {
+        error.addSuppressed(cleanupError);
+      }
+      throw error;
+    }
+  }
+
+  void resize(Viewport viewport) {
+    context.waitIdle();
+    destroySwapchainDependents();
+    createSwapchain(viewport);
+    createFramebuffers();
+  }
+
+  void draw(VulkanOwnedTextureFrameLease lease) {
+    var frame = lease.frame();
+    if (frame.width() <= 0 || frame.height() <= 0) {
+      throw new IllegalStateException("MapLibre returned an empty Vulkan owned texture frame");
+    }
+    if (frame.layout() != VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+      throw new IllegalStateException(
+          "MapLibre owned texture frame is not shader-readable: layout=" + frame.layout());
+    }
+
+    try (var stack = MemoryStack.stackPush()) {
+      check(vkWaitForFences(context.device(), inFlight, true, Long.MAX_VALUE), "vkWaitForFences");
+      var imageIndex = stack.mallocInt(1);
+      var acquire =
+          vkAcquireNextImageKHR(
+              context.device(), swapchain, Long.MAX_VALUE, imageAvailable, NULL, imageIndex);
+      if (acquire == VK_ERROR_OUT_OF_DATE_KHR) {
+        return;
+      }
+      if (acquire != VK_SUCCESS && acquire != VK_SUBOPTIMAL_KHR) {
+        throw new IllegalStateException(
+            "vkAcquireNextImageKHR failed with Vulkan status " + acquire);
+      }
+      check(vkResetFences(context.device(), inFlight), "vkResetFences");
+
+      updateDescriptor(frame.imageView().address());
+      record(imageIndex.get(0));
+      submit(stack);
+      check(vkWaitForFences(context.device(), inFlight, true, Long.MAX_VALUE), "vkWaitForFences");
+      present(stack, imageIndex.get(0));
+    }
+  }
+
+  private void createSwapchain(Viewport viewport) {
+    try (var stack = MemoryStack.stackPush()) {
+      var capabilities = VkSurfaceCapabilitiesKHR.calloc(stack);
+      check(
+          vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+              context.physicalDevice(), context.surface(), capabilities),
+          "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
+      var formatCount = stack.mallocInt(1);
+      check(
+          vkGetPhysicalDeviceSurfaceFormatsKHR(
+              context.physicalDevice(), context.surface(), formatCount, null),
+          "vkGetPhysicalDeviceSurfaceFormatsKHR(count)");
+      var formats = VkSurfaceFormatKHR.calloc(formatCount.get(0), stack);
+      check(
+          vkGetPhysicalDeviceSurfaceFormatsKHR(
+              context.physicalDevice(), context.surface(), formatCount, formats),
+          "vkGetPhysicalDeviceSurfaceFormatsKHR");
+      var chosen = formats.get(0);
+      for (int i = 0; i < formats.capacity(); i++) {
+        var candidate = formats.get(i);
+        if ((candidate.format() == VK_FORMAT_B8G8R8A8_UNORM
+                || candidate.format() == VK_FORMAT_R8G8B8A8_UNORM)
+            && candidate.colorSpace() == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+          chosen = candidate;
+          break;
+        }
+      }
+      swapchainFormat = chosen.format();
+      extentWidth = chooseExtentDimension(capabilities, viewport.width(), true);
+      extentHeight = chooseExtentDimension(capabilities, viewport.height(), false);
+      var imageCount = capabilities.minImageCount() + 1;
+      if (capabilities.maxImageCount() > 0 && imageCount > capabilities.maxImageCount()) {
+        imageCount = capabilities.maxImageCount();
+      }
+      var createInfo =
+          VkSwapchainCreateInfoKHR.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR)
+              .surface(context.surface())
+              .minImageCount(imageCount)
+              .imageFormat(swapchainFormat)
+              .imageColorSpace(chosen.colorSpace())
+              .imageExtent(e -> e.width(extentWidth).height(extentHeight))
+              .imageArrayLayers(1)
+              .imageUsage(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+              .imageSharingMode(VK_SHARING_MODE_EXCLUSIVE)
+              .preTransform(capabilities.currentTransform())
+              .compositeAlpha(VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)
+              .presentMode(VK_PRESENT_MODE_FIFO_KHR)
+              .clipped(true)
+              .oldSwapchain(NULL);
+      var out = stack.mallocLong(1);
+      check(vkCreateSwapchainKHR(context.device(), createInfo, null, out), "vkCreateSwapchainKHR");
+      swapchain = out.get(0);
+
+      var actualCount = stack.mallocInt(1);
+      check(
+          vkGetSwapchainImagesKHR(context.device(), swapchain, actualCount, null),
+          "vkGetSwapchainImagesKHR(count)");
+      var images = stack.mallocLong(actualCount.get(0));
+      check(
+          vkGetSwapchainImagesKHR(context.device(), swapchain, actualCount, images),
+          "vkGetSwapchainImagesKHR");
+      imageViews = new long[actualCount.get(0)];
+      for (int i = 0; i < imageViews.length; i++) {
+        imageViews[i] = createImageView(images.get(i), swapchainFormat);
+      }
+    }
+  }
+
+  private int chooseExtentDimension(
+      VkSurfaceCapabilitiesKHR capabilities, int viewportValue, boolean width) {
+    var current =
+        width ? capabilities.currentExtent().width() : capabilities.currentExtent().height();
+    if (current != 0xFFFFFFFF) {
+      return current;
+    }
+    var min =
+        width ? capabilities.minImageExtent().width() : capabilities.minImageExtent().height();
+    var max =
+        width ? capabilities.maxImageExtent().width() : capabilities.maxImageExtent().height();
+    return Math.max(min, Math.min(max, viewportValue));
+  }
+
+  private long createImageView(long image, int format) {
+    try (var stack = MemoryStack.stackPush()) {
+      var createInfo =
+          VkImageViewCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
+              .image(image)
+              .viewType(org.lwjgl.vulkan.VK10.VK_IMAGE_VIEW_TYPE_2D)
+              .format(format)
+              .subresourceRange(
+                  VkImageSubresourceRange.calloc(stack)
+                      .aspectMask(VK_IMAGE_ASPECT_COLOR_BIT)
+                      .baseMipLevel(0)
+                      .levelCount(1)
+                      .baseArrayLayer(0)
+                      .layerCount(1));
+      var out = stack.mallocLong(1);
+      check(vkCreateImageView(context.device(), createInfo, null, out), "vkCreateImageView");
+      return out.get(0);
+    }
+  }
+
+  private void createRenderPass() {
+    try (var stack = MemoryStack.stackPush()) {
+      var attachment =
+          VkAttachmentDescription.calloc(1, stack)
+              .format(swapchainFormat)
+              .samples(VK_SAMPLE_COUNT_1_BIT)
+              .loadOp(VK_ATTACHMENT_LOAD_OP_CLEAR)
+              .storeOp(VK_ATTACHMENT_STORE_OP_STORE)
+              .stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE)
+              .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
+              .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED)
+              .finalLayout(VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+      var colorRef =
+          VkAttachmentReference.calloc(1, stack)
+              .attachment(0)
+              .layout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+      var subpass =
+          VkSubpassDescription.calloc(1, stack)
+              .pipelineBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS)
+              .colorAttachmentCount(1)
+              .pColorAttachments(colorRef);
+      var dependency =
+          VkSubpassDependency.calloc(1, stack)
+              .srcSubpass(VK_SUBPASS_EXTERNAL)
+              .dstSubpass(0)
+              .srcStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
+              .dstStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
+              .srcAccessMask(0)
+              .dstAccessMask(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+      var createInfo =
+          VkRenderPassCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO)
+              .pAttachments(attachment)
+              .pSubpasses(subpass)
+              .pDependencies(dependency);
+      var out = stack.mallocLong(1);
+      check(vkCreateRenderPass(context.device(), createInfo, null, out), "vkCreateRenderPass");
+      renderPass = out.get(0);
+    }
+  }
+
+  private void createDescriptorState() {
+    try (var stack = MemoryStack.stackPush()) {
+      var binding =
+          VkDescriptorSetLayoutBinding.calloc(1, stack)
+              .binding(0)
+              .descriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+              .descriptorCount(1)
+              .stageFlags(VK_SHADER_STAGE_FRAGMENT_BIT);
+      var layoutInfo =
+          VkDescriptorSetLayoutCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO)
+              .pBindings(binding);
+      var out = stack.mallocLong(1);
+      check(
+          vkCreateDescriptorSetLayout(context.device(), layoutInfo, null, out),
+          "vkCreateDescriptorSetLayout");
+      descriptorSetLayout = out.get(0);
+
+      var samplerInfo =
+          VkSamplerCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO)
+              .magFilter(VK_FILTER_LINEAR)
+              .minFilter(VK_FILTER_LINEAR)
+              .mipmapMode(VK_SAMPLER_MIPMAP_MODE_LINEAR)
+              .addressModeU(VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+              .addressModeV(VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+              .addressModeW(VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+              .anisotropyEnable(false)
+              .maxAnisotropy(1.0f)
+              .compareEnable(false)
+              .compareOp(VK_COMPARE_OP_ALWAYS)
+              .minLod(0.0f)
+              .maxLod(0.0f)
+              .borderColor(VK_BORDER_COLOR_INT_OPAQUE_BLACK);
+      check(vkCreateSampler(context.device(), samplerInfo, null, out), "vkCreateSampler");
+      sampler = out.get(0);
+
+      var poolSize =
+          VkDescriptorPoolSize.calloc(1, stack)
+              .type(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+              .descriptorCount(1);
+      var poolInfo =
+          VkDescriptorPoolCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO)
+              .maxSets(1)
+              .pPoolSizes(poolSize);
+      check(
+          vkCreateDescriptorPool(context.device(), poolInfo, null, out), "vkCreateDescriptorPool");
+      descriptorPool = out.get(0);
+
+      var layouts = stack.longs(descriptorSetLayout);
+      var allocInfo =
+          VkDescriptorSetAllocateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO)
+              .descriptorPool(descriptorPool)
+              .pSetLayouts(layouts);
+      check(vkAllocateDescriptorSets(context.device(), allocInfo, out), "vkAllocateDescriptorSets");
+      descriptorSet = out.get(0);
+    }
+  }
+
+  private void createPipeline() {
+    var vert =
+        createShaderModule(compileShader(VERTEX_SHADER, shaderc_vertex_shader, "fullscreen.vert"));
+    var frag =
+        createShaderModule(compileShader(FRAGMENT_SHADER, shaderc_fragment_shader, "sample.frag"));
+    try (var stack = MemoryStack.stackPush()) {
+      var stages = VkPipelineShaderStageCreateInfo.calloc(2, stack);
+      stages
+          .get(0)
+          .sType(VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO)
+          .stage(VK_SHADER_STAGE_VERTEX_BIT)
+          .module(vert)
+          .pName(stack.UTF8("main"));
+      stages
+          .get(1)
+          .sType(VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO)
+          .stage(VK_SHADER_STAGE_FRAGMENT_BIT)
+          .module(frag)
+          .pName(stack.UTF8("main"));
+      var vertexInput =
+          VkPipelineVertexInputStateCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO);
+      var inputAssembly =
+          VkPipelineInputAssemblyStateCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO)
+              .topology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
+      var viewportState =
+          VkPipelineViewportStateCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO)
+              .viewportCount(1)
+              .scissorCount(1);
+      var rasterizer =
+          VkPipelineRasterizationStateCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO)
+              .polygonMode(VK_POLYGON_MODE_FILL)
+              .cullMode(VK_CULL_MODE_NONE)
+              .frontFace(VK_FRONT_FACE_COUNTER_CLOCKWISE)
+              .lineWidth(1.0f);
+      var multisample =
+          VkPipelineMultisampleStateCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO)
+              .rasterizationSamples(VK_SAMPLE_COUNT_1_BIT);
+      var blendAttachment =
+          VkPipelineColorBlendAttachmentState.calloc(1, stack)
+              .colorWriteMask(
+                  VK_COLOR_COMPONENT_R_BIT
+                      | VK_COLOR_COMPONENT_G_BIT
+                      | VK_COLOR_COMPONENT_B_BIT
+                      | VK_COLOR_COMPONENT_A_BIT);
+      var colorBlend =
+          VkPipelineColorBlendStateCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO)
+              .logicOpEnable(false)
+              .logicOp(VK_LOGIC_OP_COPY)
+              .pAttachments(blendAttachment);
+      var dynamicStates = stack.ints(VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR);
+      var dynamicState =
+          VkPipelineDynamicStateCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO)
+              .pDynamicStates(dynamicStates);
+      var layoutInfo =
+          VkPipelineLayoutCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO)
+              .pSetLayouts(stack.longs(descriptorSetLayout));
+      var out = stack.mallocLong(1);
+      check(
+          vkCreatePipelineLayout(context.device(), layoutInfo, null, out),
+          "vkCreatePipelineLayout");
+      pipelineLayout = out.get(0);
+      var pipelineInfo =
+          VkGraphicsPipelineCreateInfo.calloc(1, stack)
+              .sType(VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO)
+              .pStages(stages)
+              .pVertexInputState(vertexInput)
+              .pInputAssemblyState(inputAssembly)
+              .pViewportState(viewportState)
+              .pRasterizationState(rasterizer)
+              .pMultisampleState(multisample)
+              .pColorBlendState(colorBlend)
+              .pDynamicState(dynamicState)
+              .layout(pipelineLayout)
+              .renderPass(renderPass)
+              .subpass(0);
+      check(
+          vkCreateGraphicsPipelines(context.device(), NULL, pipelineInfo, null, out),
+          "vkCreateGraphicsPipelines");
+      pipeline = out.get(0);
+    } finally {
+      vkDestroyShaderModule(context.device(), frag, null);
+      vkDestroyShaderModule(context.device(), vert, null);
+    }
+  }
+
+  private ByteBuffer compileShader(String source, int kind, String name) {
+    var compiler = shaderc_compiler_initialize();
+    var options = shaderc_compile_options_initialize();
+    try {
+      var result = shaderc_compile_into_spv(compiler, source, kind, name, "main", options);
+      if (result == NULL) {
+        throw new IllegalStateException("shaderc returned null compiling " + name);
+      }
+      try {
+        if (shaderc_result_get_compilation_status(result) != shaderc_compilation_status_success) {
+          throw new IllegalStateException(
+              "shaderc failed for " + name + ": " + shaderc_result_get_error_message(result));
+        }
+        var compiled = shaderc_result_get_bytes(result);
+        var copy = ByteBuffer.allocateDirect(compiled.remaining());
+        copy.put(compiled);
+        return copy.flip();
+      } finally {
+        shaderc_result_release(result);
+      }
+    } finally {
+      shaderc_compile_options_release(options);
+      shaderc_compiler_release(compiler);
+    }
+  }
+
+  private long createShaderModule(ByteBuffer code) {
+    try (var stack = MemoryStack.stackPush()) {
+      var createInfo =
+          VkShaderModuleCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
+              .pCode(code);
+      var out = stack.mallocLong(1);
+      check(vkCreateShaderModule(context.device(), createInfo, null, out), "vkCreateShaderModule");
+      return out.get(0);
+    }
+  }
+
+  private void createFramebuffers() {
+    framebuffers = new long[imageViews.length];
+    try (var stack = MemoryStack.stackPush()) {
+      var attachments = stack.mallocLong(1);
+      for (int i = 0; i < imageViews.length; i++) {
+        attachments.put(0, imageViews[i]);
+        var createInfo =
+            VkFramebufferCreateInfo.calloc(stack)
+                .sType(VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO)
+                .renderPass(renderPass)
+                .pAttachments(attachments)
+                .width(extentWidth)
+                .height(extentHeight)
+                .layers(1);
+        var out = stack.mallocLong(1);
+        check(vkCreateFramebuffer(context.device(), createInfo, null, out), "vkCreateFramebuffer");
+        framebuffers[i] = out.get(0);
+      }
+    }
+  }
+
+  private void createCommands() {
+    try (var stack = MemoryStack.stackPush()) {
+      var poolInfo =
+          VkCommandPoolCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO)
+              .flags(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)
+              .queueFamilyIndex(context.graphicsQueueFamilyIndex());
+      var out = stack.mallocLong(1);
+      check(vkCreateCommandPool(context.device(), poolInfo, null, out), "vkCreateCommandPool");
+      commandPool = out.get(0);
+      var allocInfo =
+          VkCommandBufferAllocateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO)
+              .commandPool(commandPool)
+              .level(VK_COMMAND_BUFFER_LEVEL_PRIMARY)
+              .commandBufferCount(1);
+      var commandOut = stack.mallocPointer(1);
+      check(
+          vkAllocateCommandBuffers(context.device(), allocInfo, commandOut),
+          "vkAllocateCommandBuffers");
+      commandBuffer = new VkCommandBuffer(commandOut.get(0), context.device());
+      var semaphoreInfo =
+          VkSemaphoreCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO);
+      check(
+          vkCreateSemaphore(context.device(), semaphoreInfo, null, out),
+          "vkCreateSemaphore(imageAvailable)");
+      imageAvailable = out.get(0);
+      check(
+          vkCreateSemaphore(context.device(), semaphoreInfo, null, out),
+          "vkCreateSemaphore(renderFinished)");
+      renderFinished = out.get(0);
+      var fenceInfo =
+          VkFenceCreateInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_FENCE_CREATE_INFO)
+              .flags(org.lwjgl.vulkan.VK10.VK_FENCE_CREATE_SIGNALED_BIT);
+      check(vkCreateFence(context.device(), fenceInfo, null, out), "vkCreateFence");
+      inFlight = out.get(0);
+    }
+  }
+
+  private void updateDescriptor(long imageView) {
+    try (var stack = MemoryStack.stackPush()) {
+      var imageInfo =
+          VkDescriptorImageInfo.calloc(1, stack)
+              .sampler(sampler)
+              .imageView(imageView)
+              .imageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+      var write =
+          VkWriteDescriptorSet.calloc(1, stack)
+              .sType(VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET)
+              .dstSet(descriptorSet)
+              .dstBinding(0)
+              .descriptorCount(1)
+              .descriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+              .pImageInfo(imageInfo);
+      vkUpdateDescriptorSets(context.device(), write, null);
+    }
+  }
+
+  private void record(int imageIndex) {
+    try (var stack = MemoryStack.stackPush()) {
+      check(vkResetCommandBuffer(commandBuffer, 0), "vkResetCommandBuffer");
+      var beginInfo =
+          VkCommandBufferBeginInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO);
+      check(vkBeginCommandBuffer(commandBuffer, beginInfo), "vkBeginCommandBuffer");
+      var clear = VkClearValue.calloc(1, stack);
+      clear.color().float32(0, 0.08f).float32(1, 0.09f).float32(2, 0.11f).float32(3, 1.0f);
+      var renderArea =
+          VkRect2D.calloc(stack)
+              .offset(VkOffset2D.calloc(stack).set(0, 0))
+              .extent(VkExtent2D.calloc(stack).set(extentWidth, extentHeight));
+      var passInfo =
+          VkRenderPassBeginInfo.calloc(stack)
+              .sType(VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO)
+              .renderPass(renderPass)
+              .framebuffer(framebuffers[imageIndex])
+              .renderArea(renderArea)
+              .pClearValues(clear);
+      vkCmdBeginRenderPass(commandBuffer, passInfo, VK_SUBPASS_CONTENTS_INLINE);
+      vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+      var viewport =
+          VkViewport.calloc(1, stack)
+              .x(0)
+              .y(0)
+              .width(extentWidth)
+              .height(extentHeight)
+              .minDepth(0)
+              .maxDepth(1);
+      var scissor =
+          VkRect2D.calloc(1, stack)
+              .offset(VkOffset2D.calloc(stack).set(0, 0))
+              .extent(VkExtent2D.calloc(stack).set(extentWidth, extentHeight));
+      vkCmdSetViewport(commandBuffer, 0, viewport);
+      vkCmdSetScissor(commandBuffer, 0, scissor);
+      vkCmdBindDescriptorSets(
+          commandBuffer,
+          VK_PIPELINE_BIND_POINT_GRAPHICS,
+          pipelineLayout,
+          0,
+          stack.longs(descriptorSet),
+          null);
+      vkCmdDraw(commandBuffer, 3, 1, 0, 0);
+      vkCmdEndRenderPass(commandBuffer);
+      check(vkEndCommandBuffer(commandBuffer), "vkEndCommandBuffer");
+    }
+  }
+
+  private void submit(MemoryStack stack) {
+    var waitStages = stack.ints(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    var submitInfo =
+        VkSubmitInfo.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_SUBMIT_INFO)
+            .pWaitSemaphores(stack.longs(imageAvailable))
+            .pWaitDstStageMask(waitStages)
+            .pCommandBuffers(stack.pointers(commandBuffer))
+            .pSignalSemaphores(stack.longs(renderFinished));
+    check(vkQueueSubmit(context.graphicsQueue(), submitInfo, inFlight), "vkQueueSubmit");
+  }
+
+  private void present(MemoryStack stack, int imageIndex) {
+    var indices = stack.ints(imageIndex);
+    var presentInfo =
+        VkPresentInfoKHR.calloc(stack)
+            .sType(VK_STRUCTURE_TYPE_PRESENT_INFO_KHR)
+            .pWaitSemaphores(stack.longs(renderFinished))
+            .swapchainCount(1)
+            .pSwapchains(stack.longs(swapchain))
+            .pImageIndices(indices);
+    var status = vkQueuePresentKHR(context.graphicsQueue(), presentInfo);
+    if (status != VK_SUCCESS && status != VK_SUBOPTIMAL_KHR && status != VK_ERROR_OUT_OF_DATE_KHR) {
+      throw new IllegalStateException("vkQueuePresentKHR failed with Vulkan status " + status);
+    }
+    check(vkQueueWaitIdle(context.graphicsQueue()), "vkQueueWaitIdle");
+  }
+
+  private void destroySwapchainDependents() {
+    for (var framebuffer : framebuffers) {
+      if (framebuffer != NULL) {
+        vkDestroyFramebuffer(context.device(), framebuffer, null);
+      }
+    }
+    framebuffers = new long[0];
+    for (var imageView : imageViews) {
+      if (imageView != NULL) {
+        vkDestroyImageView(context.device(), imageView, null);
+      }
+    }
+    imageViews = new long[0];
+    if (swapchain != NULL) {
+      vkDestroySwapchainKHR(context.device(), swapchain, null);
+      swapchain = NULL;
+    }
+  }
+
+  @Override
+  public void close() {
+    context.waitIdle();
+    if (inFlight != NULL) {
+      vkDestroyFence(context.device(), inFlight, null);
+      inFlight = NULL;
+    }
+    if (renderFinished != NULL) {
+      vkDestroySemaphore(context.device(), renderFinished, null);
+      renderFinished = NULL;
+    }
+    if (imageAvailable != NULL) {
+      vkDestroySemaphore(context.device(), imageAvailable, null);
+      imageAvailable = NULL;
+    }
+    if (commandPool != NULL) {
+      vkDestroyCommandPool(context.device(), commandPool, null);
+      commandPool = NULL;
+    }
+    destroySwapchainDependents();
+    if (pipeline != NULL) {
+      vkDestroyPipeline(context.device(), pipeline, null);
+      pipeline = NULL;
+    }
+    if (pipelineLayout != NULL) {
+      vkDestroyPipelineLayout(context.device(), pipelineLayout, null);
+      pipelineLayout = NULL;
+    }
+    if (descriptorPool != NULL) {
+      vkDestroyDescriptorPool(context.device(), descriptorPool, null);
+      descriptorPool = NULL;
+    }
+    if (sampler != NULL) {
+      vkDestroySampler(context.device(), sampler, null);
+      sampler = NULL;
+    }
+    if (descriptorSetLayout != NULL) {
+      vkDestroyDescriptorSetLayout(context.device(), descriptorSetLayout, null);
+      descriptorSetLayout = NULL;
+    }
+    if (renderPass != NULL) {
+      vkDestroyRenderPass(context.device(), renderPass, null);
+      renderPass = NULL;
+    }
+  }
+
+  private static void check(int status, String operation) {
+    if (status != VK_SUCCESS) {
+      throw new IllegalStateException(operation + " failed with Vulkan status " + status);
+    }
+  }
+}

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/VulkanTextureCompositor.java
@@ -183,7 +183,7 @@ import org.lwjgl.vulkan.VkSurfaceFormatKHR;
 import org.lwjgl.vulkan.VkSwapchainCreateInfoKHR;
 import org.lwjgl.vulkan.VkViewport;
 import org.lwjgl.vulkan.VkWriteDescriptorSet;
-import org.maplibre.nativeffi.render.VulkanOwnedTextureFrameLease;
+import org.maplibre.nativeffi.render.VulkanOwnedTextureFrameHandle;
 
 final class VulkanTextureCompositor implements AutoCloseable {
   private static final String VERTEX_SHADER =
@@ -254,8 +254,8 @@ final class VulkanTextureCompositor implements AutoCloseable {
     createFramebuffers();
   }
 
-  void draw(VulkanOwnedTextureFrameLease lease) {
-    var frame = lease.frame();
+  void draw(VulkanOwnedTextureFrameHandle frameHandle) {
+    var frame = frameHandle.frame();
     if (frame.width() <= 0 || frame.height() <= 0) {
       throw new IllegalStateException("MapLibre returned an empty Vulkan owned texture frame");
     }

--- a/examples/lwjgl-map/src/test/java/org/maplibre/nativeffi/examples/lwjglmap/RenderTargetModeTest.java
+++ b/examples/lwjgl-map/src/test/java/org/maplibre/nativeffi/examples/lwjglmap/RenderTargetModeTest.java
@@ -1,0 +1,30 @@
+package org.maplibre.nativeffi.examples.lwjglmap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+final class RenderTargetModeTest {
+  @Test
+  void parsesSupportedCliNames() {
+    assertEquals(RenderTargetMode.OWNED_TEXTURE, RenderTargetMode.parse("owned-texture"));
+    assertEquals(RenderTargetMode.NATIVE_SURFACE, RenderTargetMode.parse("native-surface"));
+  }
+
+  @Test
+  void rejectsUnknownCliNames() {
+    var error = assertThrows(IllegalArgumentException.class, () -> RenderTargetMode.parse("metal"));
+
+    assertEquals("unknown render target 'metal'", error.getMessage());
+  }
+
+  @Test
+  void describesRenderTargets() {
+    assertEquals(
+        "samples MapLibre-owned Vulkan frames into the GLFW swapchain",
+        RenderTargetMode.OWNED_TEXTURE.status());
+    assertEquals(
+        "renders directly to the GLFW Vulkan surface", RenderTargetMode.NATIVE_SURFACE.status());
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
 rootProject.name = "maplibre-native-ffi"
 
 include(":bindings:java-ffm")
+
+include(":examples:lwjgl-map")


### PR DESCRIPTION
## Summary

Added an `lwjgl-map` example mirroring `zig-map`. It supports Vulkan only on macOS and Linux, with owned-texture and native-surface render modes. I've validated only macOS so far.

To support the example, I added a Java FFM texture frame lease API for compositor integrations. The callback based API was too restrictive for asynchronous gpu operations, so I removed it in favor of this lower level API.

## Notes

- We omit LWJGL's Vulkan native artifact on macOS so LWJGL and MapLibre use the same Vulkan loader path.
- Follow-up issue for host-controlled Vulkan loading: #136