### PR TITLE
decouple ci variants

### DIFF
--- a/.github/workflows/ci-variant.yml
+++ b/.github/workflows/ci-variant.yml
@@ -1,0 +1,116 @@
+name: CI variant
+
+on:
+  workflow_call:
+    inputs:
+      variant:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-matrices:
+    name: prepare matrices / ${{ inputs.variant }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      bindings: ${{ steps.matrix.outputs.bindings }}
+      bindings_count: ${{ steps.matrix.outputs.bindings_count }}
+      examples: ${{ steps.matrix.outputs.examples }}
+      examples_count: ${{ steps.matrix.outputs.examples_count }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-ci-deps
+      - id: matrix
+        env:
+          VARIANT: ${{ inputs.variant }}
+        run: |
+          bindings="$(mise run -q ci:matrix bindings --variant "$VARIANT")"
+          examples="$(mise run -q ci:matrix examples --variant "$VARIANT")"
+          bindings_count="$(MATRIX_JSON="$bindings" python -c 'import json, os; print(len(json.loads(os.environ["MATRIX_JSON"])["include"]))')"
+          examples_count="$(MATRIX_JSON="$examples" python -c 'import json, os; print(len(json.loads(os.environ["MATRIX_JSON"])["include"]))')"
+          {
+            echo "bindings=$bindings"
+            echo "bindings_count=$bindings_count"
+            echo "examples=$examples"
+            echo "examples_count=$examples_count"
+          } >> "$GITHUB_OUTPUT"
+
+  native:
+    name: native / ${{ inputs.variant }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    env:
+      MISE_ENV: ${{ inputs.variant }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Cache MapLibre Native source
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            third_party/maplibre-native
+            .git/modules/third_party/maplibre-native
+          key: mln-src-v2-${{ hashFiles('.gitmodules', 'cmake/mln_version.cmake') }}
+      - uses: ./.github/actions/setup-ci-deps
+      - run: mise run configure
+      # Windows builds successfully, but native tests/examples are runtime-broken for now.
+      - if: ${{ inputs.variant == 'windows-x64-vulkan' }}
+        run: mise run build
+      - if: ${{ inputs.variant != 'windows-x64-vulkan' }}
+        run: mise run test
+      - run: mise run ci:prepare-native-artifact
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-${{ inputs.variant }}
+          path: ci-artifact
+          if-no-files-found: error
+          retention-days: 14
+
+  bindings:
+    name: bindings / ${{ matrix.binding }} / ${{ inputs.variant }}
+    if: ${{ needs.prepare-matrices.outputs.bindings_count != '0' }}
+    runs-on: ${{ inputs.runner }}
+    needs:
+      - prepare-matrices
+      - native
+    timeout-minutes: 60
+    env:
+      MISE_ENV: ${{ inputs.variant }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrices.outputs.bindings) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-ci-deps
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: native-${{ inputs.variant }}
+          path: .
+      - run: mise run "${{ matrix.task }}"
+
+  examples:
+    name: examples / ${{ matrix.example }} / ${{ inputs.variant }}
+    if: ${{ needs.prepare-matrices.outputs.examples_count != '0' }}
+    runs-on: ${{ inputs.runner }}
+    needs:
+      - prepare-matrices
+      - native
+    timeout-minutes: 60
+    env:
+      MISE_ENV: ${{ inputs.variant }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrices.outputs.examples) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-ci-deps
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: native-${{ inputs.variant }}
+          path: .
+      - run: mise run "${{ matrix.task }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,94 +38,22 @@ jobs:
     timeout-minutes: 10
     outputs:
       native: ${{ steps.matrix.outputs.native }}
-      examples: ${{ steps.matrix.outputs.examples }}
-      bindings: ${{ steps.matrix.outputs.bindings }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ci-deps
       - id: matrix
-        run: |
-          {
-            echo "native=$(mise run -q ci:matrix native)"
-            echo "examples=$(mise run -q ci:matrix examples)"
-            echo "bindings=$(mise run -q ci:matrix bindings)"
-          } >> "$GITHUB_OUTPUT"
+        run: echo "native=$(mise run -q ci:matrix native)" >> "$GITHUB_OUTPUT"
 
-  native:
-    name: native / ${{ matrix.variant }}
-    runs-on: ${{ matrix.runner }}
+  variants:
+    name: variant / ${{ matrix.variant }}
     needs: prepare-matrices
-    timeout-minutes: 60
-    env:
-      MISE_ENV: ${{ matrix.variant }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-matrices.outputs.native) }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Cache MapLibre Native source
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            third_party/maplibre-native
-            .git/modules/third_party/maplibre-native
-          key: mln-src-v2-${{ hashFiles('.gitmodules', 'cmake/mln_version.cmake') }}
-      - uses: ./.github/actions/setup-ci-deps
-      - run: mise run configure
-      # Windows builds successfully, but native tests/examples are runtime-broken for now.
-      - if: ${{ matrix.variant == 'windows-x64-vulkan' }}
-        run: mise run build
-      - if: ${{ matrix.variant != 'windows-x64-vulkan' }}
-        run: mise run test
-      - run: mise run ci:prepare-native-artifact
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: native-${{ matrix.variant }}
-          path: ci-artifact
-          if-no-files-found: error
-          retention-days: 14
-
-  bindings:
-    name: bindings / ${{ matrix.binding }} / ${{ matrix.variant }}
-    runs-on: ${{ matrix.runner }}
-    needs:
-      - native
-      - prepare-matrices
-    timeout-minutes: 60
-    env:
-      MISE_ENV: ${{ matrix.variant }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-matrices.outputs.bindings) }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-ci-deps
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: native-${{ matrix.variant }}
-          path: .
-      - run: mise run "${{ matrix.task }}"
-
-  examples:
-    name: examples / ${{ matrix.example }} / ${{ matrix.variant }}
-    runs-on: ${{ matrix.runner }}
-    needs:
-      - native
-      - prepare-matrices
-    timeout-minutes: 60
-    env:
-      MISE_ENV: ${{ matrix.variant }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-matrices.outputs.examples) }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-ci-deps
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: native-${{ matrix.variant }}
-          path: .
-      - run: mise run "${{ matrix.task }}"
+    uses: ./.github/workflows/ci-variant.yml
+    with:
+      variant: ${{ matrix.variant }}
+      runner: ${{ matrix.runner }}
 
   required:
     name: ci-required
@@ -136,9 +64,7 @@ jobs:
       - hygiene
       - docs
       - prepare-matrices
-      - native
-      - bindings
-      - examples
+      - variants
     steps:
       - name: Fail if required jobs failed
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}

--- a/.mise/tasks/ci/matrix.py
+++ b/.mise/tasks/ci/matrix.py
@@ -4,6 +4,7 @@
 # [USAGE]   choices "native" "examples" "bindings"
 # [USAGE] }
 # [USAGE] flag "--schema <schema>" help="Path to the GitHub matrix config"
+# [USAGE] flag "--variant <variant>" help="Limit the matrix to one native variant"
 # [USAGE] flag "--pretty" help="Print indented JSON for local inspection"
 
 import json
@@ -116,6 +117,21 @@ def load_variants(repo_root: Path, schema: TomlTable) -> dict[str, TomlTable]:
     return dict(sorted(variants.items()))
 
 
+def select_variant(
+    variants: dict[str, TomlTable],
+    variant_name: str | None,
+) -> dict[str, TomlTable]:
+    """Return all variants, or one named variant when requested."""
+    if variant_name is None:
+        return variants
+
+    if variant_name in variants:
+        return {variant_name: variants[variant_name]}
+
+    message = f"unknown variant: {variant_name}"
+    raise ValueError(message)
+
+
 def native_matrix(variants: dict[str, TomlTable]) -> Matrix:
     """Generate the native build matrix."""
     return {
@@ -173,7 +189,10 @@ def main() -> int:
     pretty = os.environ.get("usage_pretty") == "true"
 
     schema = load_toml(schema_path)
-    variants = load_variants(Path.cwd(), schema)
+    variants = select_variant(
+        load_variants(Path.cwd(), schema),
+        os.environ.get("usage_variant"),
+    )
     if matrix_name == "native":
         matrix = native_matrix(variants)
     elif matrix_name == "examples":


### PR DESCRIPTION
before: all natives must build before any examples/bindings begin

after: examples/bindings only depend on their own variant's native buid (hopefully, testing in this PR)