### PR TITLE
fix some flaky tests

### DIFF
--- a/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionQueryTest.java
+++ b/bindings/java-ffm/src/test/java/org/maplibre/nativeffi/render/RenderSessionQueryTest.java
@@ -170,18 +170,26 @@ final class RenderSessionQueryTest {
                   JsonValue.array(List.of(JsonValue.of("get"), JsonValue.of("kind"))),
                   JsonValue.of("capital")));
       var rendered =
-          session.queryRenderedFeatures(
+          waitForRenderedFeature(
+              runtime,
+              map,
+              session,
               geometry,
-              new RenderedFeatureQueryOptions().layerIds(List.of("point-circle")).filter(filter));
-      assertEquals(1, rendered.size());
-      assertEquals("point", rendered.getFirst().sourceId().orElseThrow());
-      assertEquals(JsonValue.of("capital"), member(rendered.getFirst().feature(), "kind"));
+              new RenderedFeatureQueryOptions().layerIds(List.of("point-circle")).filter(filter),
+              "rendered point feature");
+      assertEquals("point", rendered.sourceId().orElseThrow());
+      assertEquals(JsonValue.of("capital"), member(rendered.feature(), "kind"));
 
       var source =
-          session.querySourceFeatures("point", new SourceFeatureQueryOptions().filter(filter));
-      assertEquals(1, source.size());
-      assertEquals("point", source.getFirst().sourceId().orElseThrow());
-      assertEquals(JsonValue.of("capital"), member(source.getFirst().feature(), "kind"));
+          waitForSourceFeature(
+              runtime,
+              map,
+              session,
+              "point",
+              new SourceFeatureQueryOptions().filter(filter),
+              "source point feature");
+      assertEquals("point", source.sourceId().orElseThrow());
+      assertEquals(JsonValue.of("capital"), member(source.feature(), "kind"));
     } finally {
       session.close();
       map.close();
@@ -206,12 +214,13 @@ final class RenderSessionQueryTest {
                   new ScreenPoint(queryPoint.x() - 30.0, queryPoint.y() - 30.0),
                   new ScreenPoint(queryPoint.x() + 30.0, queryPoint.y() + 30.0)));
       var cluster =
-          waitForRenderedCluster(
+          waitForRenderedFeature(
               runtime,
               map,
               session,
               geometry,
-              new RenderedFeatureQueryOptions().layerIds(List.of("cluster-circle")));
+              new RenderedFeatureQueryOptions().layerIds(List.of("cluster-circle")),
+              "rendered cluster");
 
       var children =
           assertInstanceOf(
@@ -274,22 +283,43 @@ final class RenderSessionQueryTest {
     }
   }
 
-  private static QueriedFeature waitForRenderedCluster(
+  private static QueriedFeature waitForRenderedFeature(
       RuntimeHandle runtime,
       MapHandle map,
       RenderSessionHandle session,
       RenderedQueryGeometry geometry,
-      RenderedFeatureQueryOptions options)
+      RenderedFeatureQueryOptions options,
+      String description)
       throws InterruptedException {
     for (var attempt = 0; attempt < 1000; attempt++) {
-      var clusters = session.queryRenderedFeatures(geometry, options);
-      if (clusters.size() == 1) {
-        return clusters.getFirst();
+      var features = session.queryRenderedFeatures(geometry, options);
+      if (features.size() == 1) {
+        return features.getFirst();
       }
       renderPendingUpdates(runtime, map, session);
       Thread.sleep(1);
     }
-    fail("Timed out waiting for rendered cluster");
+    fail("Timed out waiting for " + description);
+    return null;
+  }
+
+  private static QueriedFeature waitForSourceFeature(
+      RuntimeHandle runtime,
+      MapHandle map,
+      RenderSessionHandle session,
+      String sourceId,
+      SourceFeatureQueryOptions options,
+      String description)
+      throws InterruptedException {
+    for (var attempt = 0; attempt < 1000; attempt++) {
+      var features = session.querySourceFeatures(sourceId, options);
+      if (features.size() == 1) {
+        return features.getFirst();
+      }
+      renderPendingUpdates(runtime, map, session);
+      Thread.sleep(1);
+    }
+    fail("Timed out waiting for " + description);
     return null;
   }
 
@@ -307,7 +337,7 @@ final class RenderSessionQueryTest {
   private static void renderPendingUpdates(
       RuntimeHandle runtime, MapHandle map, RenderSessionHandle session) {
     runtime.runOnce();
-    while (true) {
+    for (var eventCount = 0; eventCount < 100; eventCount++) {
       var event = runtime.pollEvent();
       if (event.isEmpty()) {
         return;

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -75,6 +75,58 @@ fn render_available_updates(runtime: &RuntimeHandle, session: &RenderSessionHand
     }
 }
 
+fn render_pending_updates(runtime: &RuntimeHandle, session: &RenderSessionHandle) {
+    let _ = runtime.run_once();
+    for _ in 0..100 {
+        let Ok(Some(event)) = runtime.poll_event() else {
+            return;
+        };
+        if event.event_type == RuntimeEventType::MapRenderUpdateAvailable {
+            let _ = session.render_update();
+        }
+    }
+}
+
+fn wait_for_rendered_feature(
+    runtime: &RuntimeHandle,
+    session: &RenderSessionHandle,
+    geometry: &RenderedQueryGeometry,
+    options: &RenderedFeatureQueryOptions,
+    description: &str,
+) -> QueriedFeature {
+    for _ in 0..1000 {
+        let features = session
+            .query_rendered_features(geometry, Some(options))
+            .unwrap();
+        if features.len() == 1 {
+            return features.into_iter().next().unwrap();
+        }
+        render_pending_updates(runtime, session);
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    panic!("timed out waiting for {description}");
+}
+
+fn wait_for_source_feature(
+    runtime: &RuntimeHandle,
+    session: &RenderSessionHandle,
+    source_id: &str,
+    options: &SourceFeatureQueryOptions,
+    description: &str,
+) -> QueriedFeature {
+    for _ in 0..1000 {
+        let features = session
+            .query_source_features(source_id, Some(options))
+            .unwrap();
+        if features.len() == 1 {
+            return features.into_iter().next().unwrap();
+        }
+        render_pending_updates(runtime, session);
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    panic!("timed out waiting for {description}");
+}
+
 fn feature_member<'a>(feature: &'a Feature, key: &str) -> Option<&'a JsonValue> {
     feature
         .properties
@@ -432,24 +484,30 @@ fn rendered_and_source_queries_copy_results() {
     let rendered_options = RenderedFeatureQueryOptions::new()
         .with_layer_ids(vec!["point-circle".into()])
         .with_filter(filter.clone());
-    let rendered = session
-        .query_rendered_features(&geometry, Some(&rendered_options))
-        .unwrap();
-    assert_eq!(rendered.len(), 1);
-    assert_eq!(rendered[0].source_id.as_deref(), Some("point"));
+    let rendered = wait_for_rendered_feature(
+        &runtime,
+        &session,
+        &geometry,
+        &rendered_options,
+        "rendered point feature",
+    );
+    assert_eq!(rendered.source_id.as_deref(), Some("point"));
     assert_eq!(
-        feature_member(&rendered[0].feature, "kind"),
+        feature_member(&rendered.feature, "kind"),
         Some(&JsonValue::String("capital".into()))
     );
 
     let source_options = SourceFeatureQueryOptions::new().with_filter(filter);
-    let source = session
-        .query_source_features("point", Some(&source_options))
-        .unwrap();
-    assert_eq!(source.len(), 1);
-    assert_eq!(source[0].source_id.as_deref(), Some("point"));
+    let source = wait_for_source_feature(
+        &runtime,
+        &session,
+        "point",
+        &source_options,
+        "source point feature",
+    );
+    assert_eq!(source.source_id.as_deref(), Some("point"));
     assert_eq!(
-        feature_member(&source[0].feature, "kind"),
+        feature_member(&source.feature, "kind"),
         Some(&JsonValue::String("capital".into()))
     );
 
@@ -473,20 +531,8 @@ fn feature_extension_queries_copy_value_and_feature_collection_results() {
         ScreenPoint::new(query_point.x + 30.0, query_point.y + 30.0),
     ));
     let options = RenderedFeatureQueryOptions::new().with_layer_ids(vec!["cluster-circle".into()]);
-    let cluster = (0..100)
-        .find_map(|_| {
-            let clusters = session
-                .query_rendered_features(&geometry, Some(&options))
-                .ok()?;
-            if clusters.len() == 1 {
-                clusters.into_iter().next()
-            } else {
-                render_available_updates(&runtime, &session, 1);
-                std::thread::sleep(Duration::from_millis(1));
-                None
-            }
-        })
-        .expect("timed out waiting for rendered cluster");
+    let cluster =
+        wait_for_rendered_feature(&runtime, &session, &geometry, &options, "rendered cluster");
 
     let children = session
         .query_feature_extension(

--- a/tests/c/query.zig
+++ b/tests/c/query.zig
@@ -3,6 +3,8 @@ const testing = std.testing;
 const support = @import("support.zig");
 const c = support.c;
 
+extern fn usleep(useconds: c_uint) c_int;
+
 const query_style_json =
     \\{
     \\  "version": 8,
@@ -139,7 +141,26 @@ fn loadClusterStyleAndRender(runtime: *c.mln_runtime, map: *c.mln_map, session: 
     }
 }
 
-fn waitForRenderedCluster(runtime: *c.mln_runtime, map: *c.mln_map, session: *c.mln_render_session, geometry: *const c.mln_rendered_query_geometry, options: *const c.mln_rendered_feature_query_options) !*c.mln_feature_query_result {
+fn renderPendingUpdates(runtime: *c.mln_runtime, map: *c.mln_map, session: *c.mln_render_session) !void {
+    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_run_once(runtime));
+    for (0..100) |_| {
+        var event = support.emptyEvent();
+        var has_event = false;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_runtime_poll_event(runtime, &event, &has_event));
+        if (!has_event) return;
+        if (event.type == c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE and
+            event.source_type == c.MLN_RUNTIME_EVENT_SOURCE_MAP and
+            event.source == @as(?*anyopaque, @ptrCast(map)))
+        {
+            const status = c.mln_render_session_render_update(session);
+            if (status != c.MLN_STATUS_INVALID_STATE) {
+                try testing.expectEqual(c.MLN_STATUS_OK, status);
+            }
+        }
+    }
+}
+
+fn waitForRenderedFeature(runtime: *c.mln_runtime, map: *c.mln_map, session: *c.mln_render_session, geometry: *const c.mln_rendered_query_geometry, options: *const c.mln_rendered_feature_query_options) !*c.mln_feature_query_result {
     for (0..1000) |_| {
         var result: ?*c.mln_feature_query_result = null;
         try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_rendered_features(session, geometry, options, &result));
@@ -149,11 +170,26 @@ fn waitForRenderedCluster(runtime: *c.mln_runtime, map: *c.mln_map, session: *c.
         if (count == 1) return result.?;
 
         c.mln_feature_query_result_destroy(result.?);
-        if (try support.waitForEvent(runtime, map, c.MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE)) {
-            try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_render_update(session));
-        }
+        try renderPendingUpdates(runtime, map, session);
+        _ = usleep(1000);
     }
-    return error.ClusterNotQueryable;
+    return error.RenderedFeatureNotQueryable;
+}
+
+fn waitForSourceFeature(runtime: *c.mln_runtime, map: *c.mln_map, session: *c.mln_render_session, source_id: c.mln_string_view, options: *const c.mln_source_feature_query_options) !*c.mln_feature_query_result {
+    for (0..1000) |_| {
+        var result: ?*c.mln_feature_query_result = null;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_source_features(session, source_id, options, &result));
+
+        var count: usize = 0;
+        try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_count(result.?, &count));
+        if (count == 1) return result.?;
+
+        c.mln_feature_query_result_destroy(result.?);
+        try renderPendingUpdates(runtime, map, session);
+        _ = usleep(1000);
+    }
+    return error.SourceFeatureNotQueryable;
 }
 
 fn expectFeatureKind(feature: *const c.mln_queried_feature, expected: []const u8) !void {
@@ -218,12 +254,8 @@ test "render session queries rendered and source features" {
     const rendered_filter = jsonArray(&rendered_filter_values);
     rendered_options.filter = &rendered_filter;
 
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_rendered_features(session, &rendered_geometry, &rendered_options, &rendered_result));
+    rendered_result = try waitForRenderedFeature(runtime, map, session, &rendered_geometry, &rendered_options);
     defer c.mln_feature_query_result_destroy(rendered_result.?);
-
-    var count: usize = 0;
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_count(rendered_result.?, &count));
-    try testing.expectEqual(@as(usize, 1), count);
 
     var rendered_feature: c.mln_queried_feature = .{ .size = @sizeOf(c.mln_queried_feature), .fields = 0, .feature = undefined, .source_id = .{ .data = null, .size = 0 }, .source_layer_id = .{ .data = null, .size = 0 }, .state = null };
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_get(rendered_result.?, 0, &rendered_feature));
@@ -238,13 +270,8 @@ test "render session queries rendered and source features" {
     const source_filter = jsonArray(&source_filter_values);
     source_options.filter = &source_filter;
 
-    var source_result: ?*c.mln_feature_query_result = null;
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_render_session_query_source_features(session, stringView("point"), &source_options, &source_result));
+    const source_result: ?*c.mln_feature_query_result = try waitForSourceFeature(runtime, map, session, stringView("point"), &source_options);
     defer c.mln_feature_query_result_destroy(source_result.?);
-
-    count = 0;
-    try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_count(source_result.?, &count));
-    try testing.expectEqual(@as(usize, 1), count);
 
     var source_feature: c.mln_queried_feature = .{ .size = @sizeOf(c.mln_queried_feature), .fields = 0, .feature = undefined, .source_id = .{ .data = null, .size = 0 }, .source_layer_id = .{ .data = null, .size = 0 }, .state = null };
     try testing.expectEqual(c.MLN_STATUS_OK, c.mln_feature_query_result_get(source_result.?, 0, &source_feature));
@@ -278,7 +305,7 @@ test "render session queries feature extensions" {
     options.layer_ids = &layer_ids;
     options.layer_id_count = layer_ids.len;
 
-    const cluster_result = try waitForRenderedCluster(runtime, map, session, &geometry, &options);
+    const cluster_result = try waitForRenderedFeature(runtime, map, session, &geometry, &options);
     defer c.mln_feature_query_result_destroy(cluster_result);
 
     var cluster: c.mln_queried_feature = .{ .size = @sizeOf(c.mln_queried_feature), .fields = 0, .feature = undefined, .source_id = .{ .data = null, .size = 0 }, .source_layer_id = .{ .data = null, .size = 0 }, .state = null };


### PR DESCRIPTION
## Summary
- wait for rendered/source query results in Java FFM tests instead of asserting immediately after a fixed render count
- apply the same bounded readiness pattern to equivalent Rust binding and C ABI query tests
- avoid nested long waits in the C cluster query helper by pumping pending render updates directly

## Validation
- `mise run test`
- `mise run //bindings/java-ffm:build`
- `mise run //bindings/rust:test`
- `mise run fix`