### PR TITLE
chore: update actions tooling

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -10,7 +10,7 @@ runs:
       run: git config --global core.longpaths true
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
     - name: Wire sccache into CMake
       shell: bash

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = third_party/maplibre-native
 	url = https://github.com/maplibre/maplibre-native.git
 	shallow = true
+	ignore = dirty

--- a/mise.toml
+++ b/mise.toml
@@ -144,6 +144,10 @@ run = "hk check --all"
 [tasks.fix]
 run = "hk fix --all"
 
+[tasks.actions-up]
+description = "Update and pin GitHub Actions steps."
+run = "pnpm dlx actions-up"
+
 [tasks._ktfmt]
 description = "Called by dprint.jsonc"
 hide = true


### PR DESCRIPTION
## Summary
- Update the pinned `mozilla-actions/sccache-action` revision.
- Add an `actions-up` mise task for updating/pinning GitHub Actions steps.
- Mark the MapLibre Native submodule as ignored when dirty to speed up git status 

## Testing
- `mise run fix`