### PR TITLE
Fix macOS CI Rust component cache repair

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -25,11 +25,10 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
-          ~/.cargo/bin/
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-cargo-registry-v1-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache Gradle
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -48,11 +47,22 @@ runs:
         cache_key_prefix: mise-v2
         install: true
 
-    # The mise action may restore a Rust toolchain without optional components.
-    # See https://github.com/jdx/mise-action/issues/184.
+    # The mise action may restore Rust metadata without all rustup-managed
+    # component files. Repair the toolchain only when rustup cannot add the
+    # configured components or the component binaries still cannot run.
     - name: Ensure Rust components
-      run: mise exec -- rustup component add rustfmt clippy
       shell: bash
+      run: |
+        ensure_rust_components() {
+          mise exec -- rustup component add rustfmt clippy &&
+            mise exec -- cargo fmt --version &&
+            mise exec -- cargo clippy --version
+        }
+
+        if ! ensure_rust_components; then
+          mise install --force rust
+          ensure_rust_components
+        fi
 
     - name: Trim Windows PATH before Pixi activation
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
## Summary
- stop caching ~/.cargo/bin with Cargo package caches
- bust the old Cargo cache key so broken rustup shims are not restored
- repair Rust components by verifying rustup can add them and cargo fmt/clippy can run, then force-reinstalling Rust only if needed

## Testing
- mise run fix
- local isolated simulation of missing rustup component binaries while metadata still reports rustfmt/clippy installed