### PR TITLE
Fix Windows Vulkan loader library name

### DIFF
--- a/src/render/vulkan/vulkan_surface_session.cpp
+++ b/src/render/vulkan/vulkan_surface_session.cpp
@@ -26,6 +26,8 @@ namespace {
 auto vulkan_loader_library_name() noexcept -> const char* {
 #ifdef __APPLE__
   return "libvulkan.dylib";
+#elif defined(_WIN32)
+  return "vulkan-1.dll";
 #else
   return "libvulkan.so.1";
 #endif

--- a/src/render/vulkan/vulkan_texture_backend.cpp
+++ b/src/render/vulkan/vulkan_texture_backend.cpp
@@ -33,6 +33,8 @@ namespace {
 auto vulkan_loader_library_name() noexcept -> const char* {
 #ifdef __APPLE__
   return "libvulkan.dylib";
+#elif defined(_WIN32)
+  return "vulkan-1.dll";
 #else
   return "libvulkan.so.1";
 #endif


### PR DESCRIPTION
## Summary
- load vulkan-1.dll from custom Vulkan texture and surface backends on Windows
- keep existing macOS and Linux loader names

## Test
- mise run build