### PR TITLE
Point maplibre-native submodule at upstream main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,5 @@
 [submodule "third_party/maplibre-native"]
 	path = third_party/maplibre-native
-	url = https://github.com/sargunv/maplibre-native.git
-	branch = codex/windows-vulkan-wedge-fixes
+	url = https://github.com/maplibre/maplibre-native.git
 	shallow = true
 	ignore = dirty


### PR DESCRIPTION
The fork branch was only needed for a Vulkan teardown fix that turned out to be unnecessary. Restore the upstream submodule URL and advance to current maplibre/maplibre-native main.