### PR TITLE
Sync submodule URLs during postinstall

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -73,8 +73,6 @@ MLN_FFI_TEST_TIMEOUT = "{{env.MLN_FFI_TEST_TIMEOUT | default(value=\"30s\")}}"
 
 [hooks]
 postinstall = [
-  # Sync before update so reruns pick up URL changes from .gitmodules. Update
-  # the root submodule first so nested sync reads MapLibre's pinned .gitmodules.
   "git submodule sync third_party/maplibre-native",
   "git submodule update --init --depth 1 third_party/maplibre-native",
   "git -C third_party/maplibre-native submodule sync --recursive",

--- a/mise.toml
+++ b/mise.toml
@@ -73,7 +73,12 @@ MLN_FFI_TEST_TIMEOUT = "{{env.MLN_FFI_TEST_TIMEOUT | default(value=\"30s\")}}"
 
 [hooks]
 postinstall = [
-  "git submodule update --init --recursive --depth 1 third_party/maplibre-native",
+  # Sync before update so reruns pick up URL changes from .gitmodules. Update
+  # the root submodule first so nested sync reads MapLibre's pinned .gitmodules.
+  "git submodule sync third_party/maplibre-native",
+  "git submodule update --init --depth 1 third_party/maplibre-native",
+  "git -C third_party/maplibre-native submodule sync --recursive",
+  "git -C third_party/maplibre-native submodule update --init --recursive --depth 1",
   "hk install --mise --quiet",
   "pixi install --locked --quiet",
   "uv sync --locked --quiet",

--- a/mise.toml
+++ b/mise.toml
@@ -73,10 +73,8 @@ MLN_FFI_TEST_TIMEOUT = "{{env.MLN_FFI_TEST_TIMEOUT | default(value=\"30s\")}}"
 
 [hooks]
 postinstall = [
-  "git submodule sync third_party/maplibre-native",
-  "git submodule update --init --depth 1 third_party/maplibre-native",
-  "git -C third_party/maplibre-native submodule sync --recursive",
-  "git -C third_party/maplibre-native submodule update --init --recursive --depth 1",
+  "git submodule sync --recursive third_party/maplibre-native",
+  "git submodule update --init --recursive --depth 1 third_party/maplibre-native",
   "hk install --mise --quiet",
   "pixi install --locked --quiet",
   "uv sync --locked --quiet",


### PR DESCRIPTION
Sync submodule URLs recursively before postinstall updates the MapLibre Native submodule. The submodule update call already present wasn't sufficient to actually update the submodule urls in .git/