### PR TITLE
fix formatters on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-*              text=auto
-/gradlew        text eol=lf
-*.bat           text eol=crlf
-*.jar           binary
+*           text=auto eol=lf
+*.bat       text eol=crlf
+*.jar       binary

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "editor.defaultFormatter": "dprint.dprint",
   "git.ignoreSubmodules": true,
   "git.detectSubmodules": false,
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv"
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
+  "json.schemaDownload.trustedDomains": { "https://dprint.dev": true }
 }

--- a/hk.pkl
+++ b/hk.pkl
@@ -6,7 +6,10 @@ amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
 
 local lintSteps = new Mapping<String, Step> {
-  ["dprint"] = Builtins.dprint
+  ["dprint"] = (Builtins.dprint) {
+    // the default batch=false hits the cmd length limit on windows
+    batch = true
+  }
   ["actionlint"] {
     glob = List(".github/workflows/*.yml", ".github/workflows/*.yaml")
     check = "actionlint {{files}}"

--- a/mise.toml
+++ b/mise.toml
@@ -144,12 +144,14 @@ run = "pnpm dlx actions-up"
 description = "Called by dprint.jsonc"
 hide = true
 run = 'java -jar {{ tools["aqua:facebook/ktfmt"].path }}/ktfmt'
+# ktfmt on windows doesn't work in git bash for some reason
+shell = '{% if os() == "windows" %}cmd /c{% else %}sh -c -o errexit{% endif %}'
 
 [tasks."ci:lint"]
 run = [
   "hk fix --all",
   "git update-index -q --refresh",
-  # New mise versions often change the lockfile.
+  # Lockfile drift is common across different mise builds
   "git diff --exit-code -- . ':(exclude)mise.lock'",
   "git diff --cached --exit-code -- . ':(exclude)mise.lock'",
 ]


### PR DESCRIPTION
`mise run fix` was broken on windows:

- `dprint fmt` all files at once surpassed the cmd limit of 8192 chars
- ktfmt didn't like running in git bash
- git and formatters disagreed about line endings