### PR TITLE
Update overview status tables for platforms and bindings

### DIFF
--- a/docs/src/content/docs/development/bindings.md
+++ b/docs/src/content/docs/development/bindings.md
@@ -10,7 +10,9 @@ core model while adapting ownership, memory, error, and threading to the target
 language's conventions.
 
 See the language-specific binding conventions in this section for implementation
-choices in each target language.
+choices in each target language. For binding maturity across languages, see the
+[project status](/maplibre-native-ffi/#language-bindings) table on the overview
+page.
 
 ## Naming
 

--- a/docs/src/content/docs/development/overview.md
+++ b/docs/src/content/docs/development/overview.md
@@ -91,6 +91,7 @@ Preview the generated matrices locally:
 ```bash
 mise run ci:matrix native --pretty
 mise run ci:matrix examples --pretty
+mise run ci:matrix bindings --pretty
 ```
 
 ## How Tools Fit Together

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,23 +51,23 @@ runnable example, a published package, and finally a downstream SDK or app that
 depends on a published release. Nothing is published to a package registry yet,
 and no downstream SDK consumes a release from this repository.
 
-Legend: 🟢 present; `-` not yet; binding tracking issues linked where work is
-planned.
+Legend: 🟢 present; 🟡 example without a binding yet; `-` not yet; binding
+tracking issues linked where work is planned.
 
-| Language                                                          | Binding           | Example               | Package | Ecosystem |
-| ----------------------------------------------------------------- | ----------------- | --------------------- | ------- | --------- |
-| [Zig](/maplibre-native-ffi/development/bindings-zig/)             | 🟢                | zig-map, zig-readback | -       | -         |
-| [Rust](/maplibre-native-ffi/development/bindings-rust/)           | 🟢                | rust-map              | -       | -         |
-| [Java (FFM)](/maplibre-native-ffi/development/bindings-java-ffm/) | 🟢                | lwjgl-map             | -       | -         |
-| [Swift](/maplibre-native-ffi/development/bindings-swift/)         | [#44][issue-44]   | swift-map (C API)     | -       | -         |
-| [Go](/maplibre-native-ffi/development/bindings-go/)               | [#43][issue-43]   | -                     | -       | -         |
-| [Kotlin](/maplibre-native-ffi/development/bindings-kotlin/)       | [#47][issue-47]   | -                     | -       | -         |
-| [Python](/maplibre-native-ffi/development/bindings-python/)       | [#49][issue-49]   | -                     | -       | -         |
-| [Node.js](/maplibre-native-ffi/development/bindings-node/)        | [#50][issue-50]   | -                     | -       | -         |
-| [Dart](/maplibre-native-ffi/development/bindings-dart/)           | [#51][issue-51]   | -                     | -       | -         |
-| [C#](/maplibre-native-ffi/development/bindings-csharp/)           | [#48][issue-48]   | -                     | -       | -         |
-| [Java (JNI)](/maplibre-native-ffi/development/bindings-java-jni/) | [#46][issue-46]   | -                     | -       | -         |
-| [Vala](/maplibre-native-ffi/development/bindings-vala/)           | [#119][issue-119] | -                     | -       | -         |
+| Language                                                          | Binding                                                                           | Example                                                                                                                                                                                      | Package | Ecosystem |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------- |
+| [Zig](/maplibre-native-ffi/development/bindings-zig/)             | [🟢](https://github.com/maplibre/maplibre-native-ffi/tree/main/bindings/zig)      | [🟢 zig-map](https://github.com/maplibre/maplibre-native-ffi/tree/main/examples/zig-map), [🟢 zig-readback](https://github.com/maplibre/maplibre-native-ffi/tree/main/examples/zig-readback) | -       | -         |
+| [Rust](/maplibre-native-ffi/development/bindings-rust/)           | [🟢](https://github.com/maplibre/maplibre-native-ffi/tree/main/bindings/rust)     | [🟢 rust-map](https://github.com/maplibre/maplibre-native-ffi/tree/main/examples/rust-map)                                                                                                   | -       | -         |
+| [Java (FFM)](/maplibre-native-ffi/development/bindings-java-ffm/) | [🟢](https://github.com/maplibre/maplibre-native-ffi/tree/main/bindings/java-ffm) | [🟢 lwjgl-map](https://github.com/maplibre/maplibre-native-ffi/tree/main/examples/lwjgl-map)                                                                                                 | -       | -         |
+| [Swift](/maplibre-native-ffi/development/bindings-swift/)         | [#44][issue-44]                                                                   | [🟡 swift-map](https://github.com/maplibre/maplibre-native-ffi/tree/main/examples/swift-map) (C API)                                                                                         | -       | -         |
+| [Go](/maplibre-native-ffi/development/bindings-go/)               | [#43][issue-43]                                                                   | -                                                                                                                                                                                            | -       | -         |
+| [Kotlin](/maplibre-native-ffi/development/bindings-kotlin/)       | [#47][issue-47]                                                                   | -                                                                                                                                                                                            | -       | -         |
+| [Python](/maplibre-native-ffi/development/bindings-python/)       | [#49][issue-49]                                                                   | -                                                                                                                                                                                            | -       | -         |
+| [Node.js](/maplibre-native-ffi/development/bindings-node/)        | [#50][issue-50]                                                                   | -                                                                                                                                                                                            | -       | -         |
+| [Dart](/maplibre-native-ffi/development/bindings-dart/)           | [#51][issue-51]                                                                   | -                                                                                                                                                                                            | -       | -         |
+| [C#](/maplibre-native-ffi/development/bindings-csharp/)           | [#48][issue-48]                                                                   | -                                                                                                                                                                                            | -       | -         |
+| [Java (JNI)](/maplibre-native-ffi/development/bindings-java-jni/) | [#46][issue-46]                                                                   | -                                                                                                                                                                                            | -       | -         |
+| [Vala](/maplibre-native-ffi/development/bindings-vala/)           | [#119][issue-119]                                                                 | -                                                                                                                                                                                            | -       | -         |
 
 [issue-22]: https://github.com/maplibre/maplibre-native-ffi/issues/22
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -46,8 +46,7 @@ from mise environment profiles (for example `windows-x64-vulkan`).
 
 ### Language bindings
 
-Legend: 🟢 present; 🟡 example without a binding yet; `-` not yet; binding
-tracking issues linked where work is planned.
+Legend: 🟢 present; 🟡 example without a binding yet; `-` not yet.
 
 | Language                                                          | Binding                                                                           | Example                                                                                                                                                                                      | Package | Ecosystem |
 | ----------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------- |

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -33,9 +33,6 @@ APIs, including custom layers and shader registry access, are not yet included.
 Legend: 🟢 built and tested in CI; ❌ not yet implemented; `-` not applicable on
 that platform.
 
-The platform table reflects [CI native variants](/maplibre-native-ffi/development/overview/#ci-variant-matrix)
-from mise environment profiles (for example `windows-x64-vulkan`).
-
 | Platform | OpenGL            | Vulkan            | Metal             | WebGPU            |
 | -------- | ----------------- | ----------------- | ----------------- | ----------------- |
 | Linux    | ❌ [#23][issue-23] | 🟢                | -                 | ❌ [#37][issue-37] |

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -46,11 +46,6 @@ from mise environment profiles (for example `windows-x64-vulkan`).
 
 ### Language bindings
 
-Bindings mature in stages: an in-repo implementation under `bindings/`, a
-runnable example, a published package, and finally a downstream SDK or app that
-depends on a published release. Nothing is published to a package registry yet,
-and no downstream SDK consumes a release from this repository.
-
 Legend: 🟢 present; 🟡 example without a binding yet; `-` not yet; binding
 tracking issues linked where work is planned.
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -30,7 +30,11 @@ returns `0`.
 The C API covers most of the MapLibre Native API surface. Advanced extension
 APIs, including custom layers and shader registry access, are not yet included.
 
-Legend: 🟢 built and tested in CI; ❌ not yet implemented.
+Legend: 🟢 built and tested in CI; ❌ not yet implemented; `-` not applicable on
+that platform.
+
+The platform table reflects [CI native variants](/maplibre-native-ffi/development/overview/#ci-variant-matrix)
+from mise environment profiles (for example `windows-x64-vulkan`).
 
 | Platform | OpenGL            | Vulkan            | Metal             | WebGPU            |
 | -------- | ----------------- | ----------------- | ----------------- | ----------------- |
@@ -38,11 +42,32 @@ Legend: 🟢 built and tested in CI; ❌ not yet implemented.
 | Android  | ❌ [#24][issue-24] | ❌ [#24][issue-24] | -                 | ❌ [#37][issue-37] |
 | macOS    | -                 | 🟢                | 🟢                | ❌ [#37][issue-37] |
 | iOS      | -                 | -                 | ❌ [#25][issue-25] | ❌ [#37][issue-37] |
-| Windows  | ❌ [#22][issue-22] | ❌ [#21][issue-21] | -                 | ❌ [#37][issue-37] |
+| Windows  | ❌ [#22][issue-22] | 🟢                | -                 | ❌ [#37][issue-37] |
 
-[issue-20]: https://github.com/maplibre/maplibre-native-ffi/issues/20
+### Language bindings
 
-[issue-21]: https://github.com/maplibre/maplibre-native-ffi/issues/21
+Bindings mature in stages: an in-repo implementation under `bindings/`, a
+runnable example, a published package, and finally a downstream SDK or app that
+depends on a published release. Nothing is published to a package registry yet,
+and no downstream SDK consumes a release from this repository.
+
+Legend: 🟢 present; `-` not yet; binding tracking issues linked where work is
+planned.
+
+| Language                                                          | Binding           | Example               | Package | Ecosystem |
+| ----------------------------------------------------------------- | ----------------- | --------------------- | ------- | --------- |
+| [Zig](/maplibre-native-ffi/development/bindings-zig/)             | 🟢                | zig-map, zig-readback | -       | -         |
+| [Rust](/maplibre-native-ffi/development/bindings-rust/)           | 🟢                | rust-map              | -       | -         |
+| [Java (FFM)](/maplibre-native-ffi/development/bindings-java-ffm/) | 🟢                | lwjgl-map             | -       | -         |
+| [Swift](/maplibre-native-ffi/development/bindings-swift/)         | [#44][issue-44]   | swift-map (C API)     | -       | -         |
+| [Go](/maplibre-native-ffi/development/bindings-go/)               | [#43][issue-43]   | -                     | -       | -         |
+| [Kotlin](/maplibre-native-ffi/development/bindings-kotlin/)       | [#47][issue-47]   | -                     | -       | -         |
+| [Python](/maplibre-native-ffi/development/bindings-python/)       | [#49][issue-49]   | -                     | -       | -         |
+| [Node.js](/maplibre-native-ffi/development/bindings-node/)        | [#50][issue-50]   | -                     | -       | -         |
+| [Dart](/maplibre-native-ffi/development/bindings-dart/)           | [#51][issue-51]   | -                     | -       | -         |
+| [C#](/maplibre-native-ffi/development/bindings-csharp/)           | [#48][issue-48]   | -                     | -       | -         |
+| [Java (JNI)](/maplibre-native-ffi/development/bindings-java-jni/) | [#46][issue-46]   | -                     | -       | -         |
+| [Vala](/maplibre-native-ffi/development/bindings-vala/)           | [#119][issue-119] | -                     | -       | -         |
 
 [issue-22]: https://github.com/maplibre/maplibre-native-ffi/issues/22
 
@@ -53,3 +78,21 @@ Legend: 🟢 built and tested in CI; ❌ not yet implemented.
 [issue-25]: https://github.com/maplibre/maplibre-native-ffi/issues/25
 
 [issue-37]: https://github.com/maplibre/maplibre-native-ffi/issues/37
+
+[issue-43]: https://github.com/maplibre/maplibre-native-ffi/issues/43
+
+[issue-44]: https://github.com/maplibre/maplibre-native-ffi/issues/44
+
+[issue-46]: https://github.com/maplibre/maplibre-native-ffi/issues/46
+
+[issue-47]: https://github.com/maplibre/maplibre-native-ffi/issues/47
+
+[issue-48]: https://github.com/maplibre/maplibre-native-ffi/issues/48
+
+[issue-49]: https://github.com/maplibre/maplibre-native-ffi/issues/49
+
+[issue-50]: https://github.com/maplibre/maplibre-native-ffi/issues/50
+
+[issue-51]: https://github.com/maplibre/maplibre-native-ffi/issues/51
+
+[issue-119]: https://github.com/maplibre/maplibre-native-ffi/issues/119


### PR DESCRIPTION
## Summary

- Mark Windows Vulkan as built and tested in CI on the platform matrix.
- Add a language binding maturity table (binding, example, package, ecosystem) with tracking issues for planned bindings.
- Link the binding conventions page to the new table and document the bindings CI matrix preview command.