### PR TITLE
Move C API Doxygen config to docs/doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 build/
 target/
 bindings/*/bin/
-docs/api/c/gen/
+docs/doxygen/gen/
 docs/public/reference/
 .zig-cache/
 .ruff_cache/

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -2,7 +2,7 @@ PROJECT_NAME = "MapLibre Native C API"
 PROJECT_BRIEF = "Public C ABI for the MapLibre Native wrapper."
 QUIET = YES
 
-OUTPUT_DIRECTORY = api/c/gen
+OUTPUT_DIRECTORY = doxygen/gen
 INPUT = ../include
 FILE_PATTERNS = *.h
 RECURSIVE = YES

--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -1,9 +1,9 @@
 [tasks."api:c"]
 run = [
-  "rm -rf api/c/gen public/reference/c",
-  "mkdir -p api/c/gen public/reference",
-  "doxygen api/c/Doxyfile",
-  "cp -a api/c/gen/html/. public/reference/c/",
+  "rm -rf doxygen/gen public/reference/c",
+  "mkdir -p doxygen/gen public/reference",
+  "doxygen doxygen/Doxyfile",
+  "cp -a doxygen/gen/html/. public/reference/c/",
 ]
 
 [tasks."api:rust"]


### PR DESCRIPTION
Relocate the C API reference Doxygen project from `docs/api/c/` to `docs/doxygen/` 