### PR TITLE
Fix Zig map controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,10 @@ that's not already a mise task, use `mise exec -- pixi run ...`.
 
 ## Pull requests
 
-When you open a pull request, write **Summary** and **Test plan** in at most one
-sentence of prose each. I will expand the PR description if more detail is
-needed. More context: [AI_POLICY.md](./AI_POLICY.md).
+When you open a pull request, follow the repository PR template and write
+**Summary** and **Test plan** in at most one sentence each. The user will expand
+the PR description if more detail is needed. More context:
+[AI_POLICY.md](./AI_POLICY.md).
 
 ## Project Invariants
 

--- a/examples/zig-map/input.zig
+++ b/examples/zig-map/input.zig
@@ -120,7 +120,7 @@ pub fn logControls() void {
 }
 
 fn handleMouseWheel(wheel: c.SDL_MouseWheelEvent, map: *maplibre.MapHandle) !Result {
-    const delta: f64 = -wheel.y;
+    const delta: f64 = wheel.y;
     if (delta == 0) return .{ .handled = true };
 
     const anchor = point(wheel.mouse_x, wheel.mouse_y);
@@ -146,22 +146,22 @@ fn handleKeyDown(
 
     switch (key.scancode) {
         scancode(c.SDL_SCANCODE_LEFT), scancode(c.SDL_SCANCODE_A) => {
-            try expectCameraStatus(map.moveBy(-pan_step, 0), "keyboard pan failed");
+            try expectCameraStatus(map.moveByAnimated(pan_step, 0, animation), "keyboard pan failed");
         },
         scancode(c.SDL_SCANCODE_RIGHT), scancode(c.SDL_SCANCODE_D) => {
-            try expectCameraStatus(map.moveBy(pan_step, 0), "keyboard pan failed");
+            try expectCameraStatus(map.moveByAnimated(-pan_step, 0, animation), "keyboard pan failed");
         },
         scancode(c.SDL_SCANCODE_UP), scancode(c.SDL_SCANCODE_W) => {
-            try expectCameraStatus(map.moveBy(0, -pan_step), "keyboard pan failed");
+            try expectCameraStatus(map.moveByAnimated(0, pan_step, animation), "keyboard pan failed");
         },
         scancode(c.SDL_SCANCODE_DOWN), scancode(c.SDL_SCANCODE_S) => {
-            try expectCameraStatus(map.moveBy(0, pan_step), "keyboard pan failed");
+            try expectCameraStatus(map.moveByAnimated(0, -pan_step, animation), "keyboard pan failed");
         },
         scancode(c.SDL_SCANCODE_EQUALS), scancode(c.SDL_SCANCODE_KP_PLUS) => {
-            try expectCameraStatus(map.scaleBy(zoom_step, center), "keyboard zoom failed");
+            try expectCameraStatus(map.scaleByAnimated(zoom_step, center, animation), "keyboard zoom failed");
         },
         scancode(c.SDL_SCANCODE_MINUS), scancode(c.SDL_SCANCODE_KP_MINUS) => {
-            try expectCameraStatus(map.scaleBy(1.0 / zoom_step, center), "keyboard zoom failed");
+            try expectCameraStatus(map.scaleByAnimated(1.0 / zoom_step, center, animation), "keyboard zoom failed");
         },
         scancode(c.SDL_SCANCODE_Q) => try adjustBearingAnimated(map, -bearing_step, animation),
         scancode(c.SDL_SCANCODE_E) => try adjustBearingAnimated(map, bearing_step, animation),

--- a/mise.lock
+++ b/mise.lock
@@ -439,6 +439,7 @@ provenance = "minisign"
 [tools.zig."platforms.linux-x64"]
 checksum = "sha256:70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00"
 url = "https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz"
+provenance = "minisign"
 
 [tools.zig."platforms.macos-arm64"]
 checksum = "sha256:b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489"


### PR DESCRIPTION
## Summary

Align the Zig map example controls with the Rust, LWJGL, and Swift examples and clarify PR guidance in AGENTS.md.

## Test plan

Ran `zig fmt examples/zig-map/input.zig` and `mise run //examples/zig-map:build`.

## AI assistance

- **Tools:** Codex
- **Models:** GPT-5.5
- **Context:** Used Codex to compare map example input controllers, patch Zig controls, update AGENTS.md, and create this draft PR.