### PR TITLE
fix windows mise shell args

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,8 +10,8 @@ lockfile_platforms = ["linux-x64", "linux-arm64", "macos-arm64", "windows-x64"]
 pin = true
 experimental = true
 python.uv_venv_auto = "create|source"
-windows_default_file_shell_args = 'pixi run --locked -x "C:/Program Files/Git/bin/bash.exe" -e -lc "source \"$MLN_FFI_REPO_ROOT/.mise/bin/windows-msvc-path.sh\"; exec \"C:/Program Files/Git/bin/bash.exe\" \"$@\"" _'
-windows_default_inline_shell_args = 'pixi run --locked -x "C:/Program Files/Git/bin/bash.exe" -e -lc "source \"$MLN_FFI_REPO_ROOT/.mise/bin/windows-msvc-path.sh\"; eval \"$1\"" _'
+windows_default_file_shell_args = 'pixi run --locked -x "C:/Program Files/Git/bin/bash.exe" -e -lc "source ""$MLN_FFI_REPO_ROOT/.mise/bin/windows-msvc-path.sh""; exec ""C:/Program Files/Git/bin/bash.exe"" ""$@""" _'
+windows_default_inline_shell_args = 'pixi run --locked -x "C:/Program Files/Git/bin/bash.exe" -e -lc "source ""$MLN_FFI_REPO_ROOT/.mise/bin/windows-msvc-path.sh""; eval ""$1""" _'
 unix_default_file_shell_args = "bash"
 unix_default_inline_shell_args = "pixi run --locked -x bash -e -lc"
 # On Windows, the Microsoft Store Python alias in WindowsApps can appear before


### PR DESCRIPTION
https://github.com/jdx/mise/pull/10148 made a breaking change to windows mise shell parsing, updating our config to align.

windows contributors will likely need to ensure their mise is up to date.

## AI assistance

- **Tools:** Codex
- **Models:** GPT-5
- **Context:** Investigated Windows CI failures, identified the mise Windows shell parser change, and applied the focused quoting fix.
