### PR TITLE
[codex] Pin Windows CI to VS 2022 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
           - mise_env: macos-arm64-vulkan
             runner: macos-latest
           - mise_env: windows-x64-vulkan
-            runner: windows-latest
+            runner: windows-2022
           - mise_env: windows-x64-wgl
-            runner: windows-latest
+            runner: windows-2022
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ci-deps


### PR DESCRIPTION
Pin Windows CI jobs to the VS 2022 runner so conda-forge's locked `vs2022_win-64` compiler activation can find `cl.exe`.