### PR TITLE
Restructure map example spec to prep for mobile

### DIFF
--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -31,7 +31,7 @@ profile**. Implement a mobile example by reading **Shared baseline** and
 | Style, camera, map/runtime     | [Shared defaults](#shared-defaults)                     |
 | Module layout                  | [Architecture](#architecture)                           |
 | Startup and shutdown ordering  | [Lifecycle](#lifecycle)                                 |
-| Pump and render loop           | [Frame loop](#frame-loop)                               |
+| Host loop (pump and render)    | [Frame loop](#frame-loop)                               |
 | Extent and scale               | [Viewport](#viewport)                                   |
 | Runtime, map, render session   | [Map state](#map-state)                                 |
 | All render-target modes        | [Render-target modes](#render-target-modes)             |
@@ -223,32 +223,54 @@ On host termination or fatal error, close resources in order:
 
 ### Frame loop
 
+The C API treats runtime pumping and presentation as separate concerns.
+`run_once` advances native scheduler work and fills the event queue; it is not
+display-driven. `render_update` draws only when `render_pending` is true.
+
+`*-map` examples integrate both through a **display-paced host loop** on the
+owner thread: each iteration always pumps the runtime; it renders only when
+needed.
+
+#### Host loop iteration
+
 Each iteration has two phases: pump (always) and render (only when
 `render_pending` is true).
 
-Every example MUST run one pump iteration per display refresh tick. Subscribe
-through the host toolkit's display refresh mechanism (for example swapchain
-frame callbacks, `CADisplayLink`, or `Choreographer`).
-
-#### Pump (every iteration)
-
-Handle resize (reattach the render target when required) and input (may set
-`render_pending`).
+1. Handle input and resize (may set `render_pending`).
+2. Pump: call `run_once`, drain runtime events, run `finishFrame()`.
+3. Render: call `render_update` when `render_pending` is true.
 
 ```mermaid
 sequenceDiagram
-  participant EL as Event loop
+  participant EL as Host loop
   participant RT as Runtime
   participant BE as Backend
 
-  EL->>EL: Poll or receive window + input events
+  EL->>EL: Input and resize
   EL->>RT: run_once()
   EL->>RT: drain events → may set render_pending
   EL->>BE: finishFrame()
 ```
 
-`finishFrame()` runs every pump iteration: swapchain or surface upkeep, resize
+`finishFrame()` runs every iteration: swapchain or surface upkeep, resize
 handling, and present hooks as required by the host graphics API.
+
+#### Cadence
+
+While the map is visible and the example is active:
+
+- MUST run at least one host loop iteration per display refresh period.
+- MUST subscribe to the host toolkit's display refresh mechanism (for example
+  swapchain frame callbacks, `CADisplayLink`, or `Choreographer`) to pace the
+  loop.
+- Desktop examples MAY wake an additional iteration on input or resize before
+  the next display refresh.
+
+Display refresh paces the loop; it does not replace `run_once`. Each iteration
+MUST call `run_once` exactly once.
+
+When the profile stops the loop (for example mobile background), runtime
+progress stalls until the loop resumes.
 
 #### Render (`render_pending`)
 
@@ -271,7 +293,8 @@ sequenceDiagram
 
 Requirements:
 
-- MUST call runtime `run_once` once per loop iteration while the app is running.
+- MUST call runtime `run_once` once per host loop iteration while the loop is
+  running.
 - MUST drain runtime events each iteration and set `render_pending` when:
   - `map_render_update_available` targets this map (new map content to draw), or
   - `map_render_frame_finished` targets this map and `needs_repaint` is true
@@ -584,11 +607,11 @@ Mobile `*-map` examples add:
 Mobile examples keep map state alive across brief disappear and background
 transitions. They tear down only on view destruction or app termination.
 
-| Transition                          | Behavior                                                                           |
-| ----------------------------------- | ---------------------------------------------------------------------------------- |
-| View will appear / app foreground   | Start the display-refresh pump. Refresh viewport. Set `render_pending`.            |
-| View did disappear / app background | Stop the display-refresh pump. Keep runtime, map, and render-target handles alive. |
-| View destroyed / app termination    | Run [Shared shutdown](#shutdown).                                                  |
+| Transition                          | Behavior                                                                   |
+| ----------------------------------- | -------------------------------------------------------------------------- |
+| View will appear / app foreground   | Start the display-paced host loop. Refresh viewport. Set `render_pending`. |
+| View did disappear / app background | Stop the host loop. Keep runtime, map, and render-target handles alive.    |
+| View destroyed / app termination    | Run [Shared shutdown](#shutdown).                                          |
 
 If `render_update` returns `invalid_state` after resume, follow the existing
 reattach path for the active render target.

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -50,17 +50,19 @@ profile**. Implement a mobile example by reading **Shared baseline** and
 
 ### Implementations
 
-| Example              | Profile | Binding  | Toolkit         | Platforms             | Backends              |
-| -------------------- | ------- | -------- | --------------- | --------------------- | --------------------- |
-| `examples/zig-map`   | Desktop | Zig      | SDL3            | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
-| `examples/rust-map`  | Desktop | Rust     | winit           | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
-| `examples/lwjgl-map` | Desktop | Java FFM | GLFW, LWJGL     | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
-| `examples/swift-map` | Desktop | Swift    | AppKit, SwiftUI | macOS                 | Metal                 |
+| Example               | Profile | Binding  | Toolkit         | Platforms             | Backends              |
+| --------------------- | ------- | -------- | --------------- | --------------------- | --------------------- |
+| `examples/zig-map`    | Desktop | Zig      | SDL3            | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
+| `examples/rust-map`   | Desktop | Rust     | winit           | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
+| `examples/lwjgl-map`  | Desktop | Java FFM | GLFW, LWJGL     | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
+| `examples/dotnet-map` | Desktop | C#       | GLFW            | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
+| `examples/swift-map`  | Desktop | Swift    | AppKit, SwiftUI | macOS                 | Metal                 |
 
 For examples built by native render-backend variant, “Backends” is the union of
-supported configured variants. A binary that selects one native render backend
-exposes that graphics API for that binary; the example as a whole exposes the
-union across configured variants.
+supported configured variants. Each native library artifact includes one render
+backend. A single run uses one graphics API, selected at build time
+(build-variant examples) or at startup from the loaded library (multi-context
+examples).
 
 ---
 
@@ -169,10 +171,22 @@ active render-target mode. Graphics context code owns API-level resources
 attached `RenderSessionHandle`, mode-specific resources, resize behavior,
 `render_update`, and close behavior.
 
-When a build variant selects a single native render backend, the example SHOULD
-compile only the matching graphics API implementation and its platform glue.
-Backend selection happens at build time. Render-target mode selection follows
-the active profile ([Entry](#entry) or [Entry and shell](#entry-and-shell)).
+The loaded native library reports one render backend per library artifact
+through `mln_supported_render_backend_mask()`. Examples built across native
+render-backend variants expose the union of those backends in the
+[Implementations](#implementations) table.
+
+Graphics API selection follows one of these patterns:
+
+- **Build-variant examples** compile only the graphics API implementation that
+  matches the active native build variant (for example `zig-map`, `rust-map`,
+  `swift-map`).
+- **Multi-context examples** ship a graphics context per targeted API and select
+  the active API at startup from `supportedRenderBackends()` and platform policy
+  (for example `lwjgl-map`, `dotnet-map`).
+
+Each process run uses one graphics API. Render-target mode selection follows the
+active profile ([Entry](#entry) or [Entry and shell](#entry-and-shell)).
 
 Adding a graphics API or render-target mode MUST require localized changes. Keep
 each graphics API and render-target mode in its own variant, class, or submodule
@@ -187,8 +201,8 @@ Order MUST be:
 1. Parse profile entry configuration and validate the selected render mode.
 2. Read and log the loaded library's supported native render backends from
    `mln_supported_render_backend_mask()`, then validate that the loaded native
-   library supports the graphics backend(s) this binary targets; fail fast with
-   a readable message if not.
+   library supports the graphics API selected for this run; fail fast with a
+   readable message if not.
 3. Create the host presentation surface and initialize the graphics backend for
    the selected graphics API.
 4. Create runtime (`:memory:` cache).

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -589,17 +589,24 @@ Mobile `*-map` examples add:
 
 ### Lifecycle
 
-Mobile examples keep map state alive across brief disappear and background
-transitions. They tear down only on view destruction or app termination.
+Mobile examples keep runtime and map state alive across brief disappear and
+background transitions. They tear down only on view destruction or app
+termination.
 
-| Transition                          | Behavior                                                                   |
-| ----------------------------------- | -------------------------------------------------------------------------- |
-| View will appear / app foreground   | Start the display-paced host loop. Refresh viewport. Set `render_pending`. |
-| View did disappear / app background | Stop the host loop. Keep runtime, map, and render-target handles alive.    |
-| View destroyed / app termination    | Run [Shared shutdown](#shutdown).                                          |
+Track view visibility and app foreground separately. Run the display-paced host
+loop only while the view is visible and the app is in the foreground.
 
-If `render_update` returns `invalid_state` after resume, follow the existing
-reattach path for the active render target.
+When the host toolkit destroys or invalidates the presentation surface, detach
+the render target. Keep runtime and map handles alive. Reattach when a fresh
+surface is available.
+
+| Transition                       | Behavior                                                                                                                                                       |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| View will appear                 | Mark the view visible. If the app is in the foreground, start the host loop, refresh viewport, attach or reattach the render target, and set `render_pending`. |
+| View did disappear               | Mark the view not visible. Stop the host loop. Detach the render target when the presentation surface is destroyed or invalidated.                             |
+| App foreground                   | Mark the app foreground. If the view is visible, start the host loop, refresh viewport, attach or reattach the render target, and set `render_pending`.        |
+| App background                   | Mark the app background. Stop the host loop. Detach the render target when the presentation surface is destroyed or invalidated.                               |
+| View destroyed / app termination | Run [Shared shutdown](#shutdown).                                                                                                                              |
 
 ### Entry and shell
 
@@ -630,8 +637,8 @@ Implementations MUST provide the following touch interactions:
 | Two-finger vertical drag (shove) | `pitch -= 0.1 × Δy` degrees (clamp to `[0, 60]`), where `Δy` is the change in average touch Y in logical coordinates since the last update.                                                             |
 | Double-tap                       | Zoom `1.25` about the tap location with animation (~`160` ms).                                                                                                                                          |
 
-On pointer down that starts a drag, cancel in-flight camera transitions before
-applying deltas.
+On any gesture begin, cancel in-flight camera transitions before applying
+deltas.
 
 Input handlers return whether the camera changed so the frame loop can set
 `render_pending`.

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -16,39 +16,12 @@ The specification has three sections:
    and keyboard/mouse input.
 3. [Mobile profile](#mobile-profile) — embedded view hosts with touch input.
 
-Implement a desktop example by reading **Shared baseline** and **Desktop
-profile**. Implement a mobile example by reading **Shared baseline** and
-**Mobile profile**.
+Implement a desktop example by reading Shared baseline and Desktop profile.
+Implement a mobile example by reading Shared baseline and Mobile profile.
 
 ---
 
-## Profiles
-
-### Routing
-
-| Concern                        | Section                                                 |
-| ------------------------------ | ------------------------------------------------------- |
-| Style, camera, map/runtime     | [Shared defaults](#shared-defaults)                     |
-| Module layout                  | [Architecture](#architecture)                           |
-| Startup and shutdown ordering  | [Lifecycle](#lifecycle)                                 |
-| Host loop (pump and render)    | [Frame loop](#frame-loop)                               |
-| Extent and scale               | [Viewport](#viewport)                                   |
-| Runtime, map, render session   | [Map state](#map-state)                                 |
-| All render-target modes        | [Render-target modes](#render-target-modes)             |
-| Texture compositor pass        | [Compositor shaders](#compositor-shaders)               |
-| Resize and reattach mechanics  | [Resize mechanics](#resize-mechanics)                   |
-| What to log                    | [Diagnostics](#diagnostics)                             |
-| Attach descriptors per API     | [Graphics API](#graphics-api)                           |
-| Which modes each profile ships | [Render-target coverage](#render-target-coverage)       |
-| CLI and mode selection         | [Desktop profile → Entry](#entry)                       |
-| Window and process lifecycle   | [Desktop profile → Shell and window](#shell-and-window) |
-| Keyboard and mouse             | [Desktop profile → Input](#input)                       |
-| View lifecycle and layout      | [Mobile profile → Entry and shell](#entry-and-shell)    |
-| View lifecycle transitions     | [Mobile profile → Lifecycle](#lifecycle-1)              |
-| Touch gestures                 | [Mobile profile → Input](#input-1)                      |
-| Platform log sinks             | [Mobile profile → Logging](#logging)                    |
-
-### Implementations
+## Implementations
 
 | Example               | Profile | Binding  | Toolkit         | Platforms             | Backends              |
 | --------------------- | ------- | -------- | --------------- | --------------------- | --------------------- |
@@ -277,8 +250,6 @@ While the map is visible and the example is active:
 - MUST subscribe to the host toolkit's display refresh mechanism (for example
   swapchain frame callbacks, `CADisplayLink`, or `Choreographer`) to pace the
   loop.
-- Desktop examples MAY wake an additional iteration on input or resize before
-  the next display refresh.
 
 Display refresh paces the loop; it does not replace `run_once`. Each iteration
 MUST call `run_once` exactly once.

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -44,6 +44,7 @@ profile**. Implement a mobile example by reading **Shared baseline** and
 | Window and process lifecycle   | [Desktop profile → Shell and window](#shell-and-window) |
 | Keyboard and mouse             | [Desktop profile → Input](#input)                       |
 | View lifecycle and layout      | [Mobile profile → Entry and shell](#entry-and-shell)    |
+| View lifecycle transitions     | [Mobile profile → Lifecycle](#lifecycle-1)              |
 | Touch gestures                 | [Mobile profile → Input](#input-1)                      |
 | Platform log sinks             | [Mobile profile → Logging](#logging)                    |
 
@@ -194,10 +195,9 @@ Order MUST be:
 5. Create map with extent from the initial viewport and continuous mode.
 6. Load style and apply initial camera.
 7. Attach render target for the selected mode.
-8. Print startup information:
+8. Emit startup information:
    - active render-target mode identifier
    - active render-target status line
-   - profile control help
 
 On failure after partial setup, release already-created handles in reverse order
 (render target → map → runtime → graphics).
@@ -338,9 +338,10 @@ replacement for the same graphics context, map, and mode.
 
 ### Render-target modes
 
-Three modes MUST be modeled in every example's architecture (render-target
-discriminant/class and attach paths). Profile sections define which modes each
-example implements ([Render-target coverage](#render-target-coverage)).
+Shared baseline defines three render-target modes (discriminant/class, attach
+paths, and present behavior). Each example implements only the modes required by
+its profile ([Render-target coverage](#render-target-coverage)). Example
+architecture MUST model each implemented mode.
 
 #### Mode comparison
 
@@ -426,7 +427,8 @@ Profile sections define which host events trigger resize
 - SHOULD register a native log callback during startup and clear it on shutdown.
 - On setup or camera failure, print a short message including the native status
   and diagnostic strings returned by the C API.
-- On startup, print the three items listed in [Startup](#startup) step 8.
+- On startup, emit the items listed in [Startup](#startup) step 8 through the
+  profile logging sink.
 
 ### Graphics API
 
@@ -513,6 +515,11 @@ flags.
   size and content scale (see [Viewport](#viewport)).
 - Shutdown triggers on window close.
 
+### Startup logging
+
+On startup, print the items listed in [Startup](#startup) step 8 to stdout, plus
+the control help text from [Input](#input) below.
+
 ### Input
 
 #### Control scheme
@@ -572,6 +579,20 @@ Mobile `*-map` examples add:
 - Touch camera controls.
 - View lifecycle integration (appear, disappear, foreground, background).
 
+### Lifecycle
+
+Mobile examples keep map state alive across brief disappear and background
+transitions. They tear down only on view destruction or app termination.
+
+| Transition                          | Behavior                                                                           |
+| ----------------------------------- | ---------------------------------------------------------------------------------- |
+| View will appear / app foreground   | Start the display-refresh pump. Refresh viewport. Set `render_pending`.            |
+| View did disappear / app background | Stop the display-refresh pump. Keep runtime, map, and render-target handles alive. |
+| View destroyed / app termination    | Run [Shared shutdown](#shutdown).                                                  |
+
+If `render_update` returns `invalid_state` after resume, follow the existing
+reattach path for the active render target.
+
 ### Entry and shell
 
 - The map view fills the available layout area or the screen.
@@ -585,17 +606,21 @@ Mobile `*-map` examples add:
 
 ### Input
 
+Use separate pan, pinch-scale, rotation, and shove recognizers. Pinch and
+rotation MAY recognize simultaneously. Shove MUST NOT recognize simultaneously
+with pinch or rotation.
+
 #### Control scheme
 
 Implementations MUST provide the following touch interactions:
 
-| Interaction              | Behavior                                                                                         |
-| ------------------------ | ------------------------------------------------------------------------------------------------ |
-| One-finger drag          | `move_by` with pointer delta in logical coordinates.                                             |
-| Two-finger rotate        | Adjust bearing by `0.5 × Δθ` degrees, where `Δθ` is the change in angle between the two touches. |
-| Two-finger vertical drag | Adjust pitch by `0.5 × Δy` degrees (same sign convention as desktop rotate drag).                |
-| Pinch                    | Zoom about the gesture centroid: `scale_by(2^(Δ * 0.25), anchor)`. Pinch apart zooms in.         |
-| Double-tap               | Zoom `1.25` about the tap location with keyboard animation (~`160` ms).                          |
+| Interaction                      | Behavior                                                                                                                                                                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| One-finger drag                  | `move_by` with pointer delta in logical coordinates.                                                                                                                                                    |
+| Pinch                            | On begin, record `zoom₀`. On change, `jump_to` zoom `zoom₀ + log₂(S)` about the gesture centroid, where `S` is the scale recognizer's cumulative scale factor since the gesture began (`1.0` at begin). |
+| Two-finger rotate                | Adjust bearing by `−Δθ` degrees, where `Δθ` is the rotation recognizer's delta in degrees since the last update.                                                                                        |
+| Two-finger vertical drag (shove) | `pitch -= 0.1 × Δy` degrees (clamp to `[0, 60]`), where `Δy` is the change in average touch Y in logical coordinates since the last update.                                                             |
+| Double-tap                       | Zoom `1.25` about the tap location with animation (~`160` ms).                                                                                                                                          |
 
 On pointer down that starts a drag, cancel in-flight camera transitions before
 applying deltas.
@@ -610,6 +635,7 @@ Input handlers return whether the camera changed so the frame loop can set
 
 ### Logging
 
-- Emit startup and viewport diagnostics through the platform log sink (for
-  example `OSLog` on Apple platforms or `logcat` on Android).
-- Control help is not printed to stdout on mobile.
+- Emit [Startup](#startup) step 8 items and viewport diagnostics through the
+  platform log sink (for example `OSLog` on Apple platforms or `logcat` on
+  Android).
+- Control help is not required on mobile.

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -8,41 +8,53 @@ sidebar:
 Specification for interactive `*-map` example programs: small apps that exercise
 language bindings and render-target integrations through a focused map demo.
 
-## Scope
+The specification has three sections:
 
-### What every example provides
+1. [Shared baseline](#shared-baseline) — map, render-session, frame-loop, and
+   graphics contracts common to every profile.
+2. [Desktop profile](#desktop-profile) — windowed desktop hosts with CLI entry
+   and keyboard/mouse input.
+3. [Mobile profile](#mobile-profile) — embedded view hosts with touch input.
 
-- All map, runtime, and render access from application code through the
-  project’s language binding for that language.
-- One top-level map window with resize support.
-- Continuous map mode: runtime pumping, event draining, and repaint driven by
-  map render events and user input.
-- Initial style URL and camera per [Shared defaults](#shared-defaults).
-- Camera controls per [Input](#input).
-- Support for the three render-target modes on every graphics API the example
-  ships, either in one binary or across configured native render-backend
-  variants (see [Render-target modes](#render-target-modes)).
-- Every graphics API the window toolkit and target platform can support across
-  configured variants (Vulkan, Metal, OpenGL/EGL as applicable).
-- Graceful process exit when the user closes the window.
-- Startup logging that identifies the selected render-target mode and which
-  native render backends the loaded library supports.
-
-### What an example is not
-
-A `*-map` program is a focused map demo. It MUST NOT include automated tests or
-packaging/installer UX.
+Implement a desktop example by reading **Shared baseline** and **Desktop
+profile**. Implement a mobile example by reading **Shared baseline** and
+**Mobile profile**.
 
 ---
 
-## Implementations
+## Profiles
 
-| Example              | Binding  | Toolkit         | Platforms             | Backends              |
-| -------------------- | -------- | --------------- | --------------------- | --------------------- |
-| `examples/zig-map`   | Zig      | SDL3            | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
-| `examples/rust-map`  | Rust     | winit           | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
-| `examples/lwjgl-map` | Java FFM | GLFW, LWJGL     | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
-| `examples/swift-map` | Swift    | AppKit, SwiftUI | macOS                 | Metal                 |
+### Routing
+
+| Concern                        | Section                                                 |
+| ------------------------------ | ------------------------------------------------------- |
+| Style, camera, map/runtime     | [Shared defaults](#shared-defaults)                     |
+| Module layout                  | [Architecture](#architecture)                           |
+| Startup and shutdown ordering  | [Lifecycle](#lifecycle)                                 |
+| Pump and render loop           | [Frame loop](#frame-loop)                               |
+| Extent and scale               | [Viewport](#viewport)                                   |
+| Runtime, map, render session   | [Map state](#map-state)                                 |
+| All render-target modes        | [Render-target modes](#render-target-modes)             |
+| Texture compositor pass        | [Compositor shaders](#compositor-shaders)               |
+| Resize and reattach mechanics  | [Resize mechanics](#resize-mechanics)                   |
+| What to log                    | [Diagnostics](#diagnostics)                             |
+| Attach descriptors per API     | [Graphics API](#graphics-api)                           |
+| Which modes each profile ships | [Render-target coverage](#render-target-coverage)       |
+| CLI and mode selection         | [Desktop profile → Entry](#entry)                       |
+| Window and process lifecycle   | [Desktop profile → Shell and window](#shell-and-window) |
+| Keyboard and mouse             | [Desktop profile → Input](#input)                       |
+| View lifecycle and layout      | [Mobile profile → Entry and shell](#entry-and-shell)    |
+| Touch gestures                 | [Mobile profile → Input](#input-1)                      |
+| Platform log sinks             | [Mobile profile → Logging](#logging)                    |
+
+### Implementations
+
+| Example              | Profile | Binding  | Toolkit         | Platforms             | Backends              |
+| -------------------- | ------- | -------- | --------------- | --------------------- | --------------------- |
+| `examples/zig-map`   | Desktop | Zig      | SDL3            | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
+| `examples/rust-map`  | Desktop | Rust     | winit           | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
+| `examples/lwjgl-map` | Desktop | Java FFM | GLFW, LWJGL     | Linux, macOS, Windows | Vulkan, Metal, OpenGL |
+| `examples/swift-map` | Desktop | Swift    | AppKit, SwiftUI | macOS                 | Metal                 |
 
 For examples built by native render-backend variant, “Backends” is the union of
 supported configured variants. A binary that selects one native render backend
@@ -51,14 +63,39 @@ union across configured variants.
 
 ---
 
-## Shared defaults
+## Shared baseline
 
-### Style
+### Scope
+
+#### What every example provides
+
+- All map, runtime, and render access from application code through the
+  project’s language binding for that language.
+- Continuous map mode: runtime pumping, event draining, and repaint driven by
+  map render events and user input.
+- Initial style URL and camera per [Shared defaults](#shared-defaults).
+- Camera controls per the active profile ([Desktop profile → Input](#input) or
+  [Mobile profile → Input](#input-1)).
+- Every graphics API the host toolkit and target platform can support across
+  configured variants (Vulkan, Metal, OpenGL/EGL as applicable).
+- Render-target coverage per the active profile
+  ([Render-target coverage](#render-target-coverage)).
+- Startup logging that identifies the active render-target mode and which native
+  render backends the loaded library supports.
+
+#### What an example is not
+
+A `*-map` program is a focused map demo. It MUST NOT include automated tests or
+packaging/installer UX.
+
+### Shared defaults
+
+#### Style
 
 - Style URL: `https://tiles.openfreemap.org/styles/bright`
 - Load the style during map initialization, before the first render.
 
-### Initial camera
+#### Initial camera
 
 | Field   | Value                                                     |
 | ------- | --------------------------------------------------------- |
@@ -69,63 +106,14 @@ union across configured variants.
 
 Apply with an immediate `jump_to` on startup.
 
-### Window
-
-- Initial logical size: `960` × `640` pixels.
-- Window MUST be resizable.
-- High-DPI / Retina: derive map `RenderTargetExtent` from the window’s drawable
-  size and content scale (see [Viewport](#viewport)).
-
-### Map and runtime
+#### Map and runtime
 
 - Runtime cache path: `:memory:` (in-memory).
 - Map mode: continuous (`MLN_MAP_MODE_CONTINUOUS`).
 
-### Compositor shaders (texture modes)
+### Architecture
 
-For `owned-texture` and `borrowed-texture`, the host-owned compositor that
-samples the map texture into the window swapchain MUST use a fullscreen triangle
-covering the viewport:
-
-- Vertex shader: three corners with pass-through UVs spanning the visible
-  `[0, 1] × [0, 1]` texture range (large-triangle technique).
-- Fragment shader: `texture(map_texture, uv)` (straight copy, standard UV
-  orientation).
-
-SPIR-V, MSL, or GLSL source MAY differ by backend; the GPU output MUST match
-that pass.
-
----
-
-## Command-line interface
-
-### Render-target selection
-
-The process MUST accept a render-target mode name:
-
-| Mode                          | CLI value          |
-| ----------------------------- | ------------------ |
-| Session-owned texture         | `owned-texture`    |
-| Caller-owned borrowed texture | `borrowed-texture` |
-| Native window surface         | `native-surface`   |
-
-The mode is a required positional argument (for example
-`zig-map owned-texture`). There is no default mode.
-
-On `--help`, print usage listing the three mode names and exit `0` before
-creating a window. On invalid arguments, print usage listing the three mode
-names and exit `1` before creating a window.
-
-### Other flags
-
-The only permitted flag is `--help`. Implementations MUST NOT add other CLI
-flags.
-
----
-
-## Architecture
-
-### Overview
+#### Overview
 
 Every `*-map` example splits host responsibilities into the same logical
 modules. Names differ by language; boundaries MUST NOT be collapsed into a
@@ -149,30 +137,30 @@ flowchart TB
     CP[Compositor]
     SC[Presentation]
   end
-  CLI --> shell
+  Entry[Entry] --> shell
   shell --> mapstate
   mapstate --> gfx
   RS -->|texture modes| CP
   RS -->|native-surface| SC
 ```
 
-### Logical modules
+#### Logical modules
 
 | Module           | Responsibility                                                                                                          |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| App shell        | Process entry, argument parsing, toolkit lifecycle, main event loop, idle pacing, shutdown ordering.                    |
+| App shell        | Profile entry, toolkit lifecycle, main event loop, shutdown ordering.                                                   |
 | Viewport         | Map logical size, physical drawable size, and `scale_factor` for `RenderTargetExtent`.                                  |
 | Map state        | Owns runtime, map, and active render target; loads style and initial camera.                                            |
-| Graphics context | Creates/configures the top-level window and owns host graphics API context and presentation resources.                  |
+| Graphics context | Creates/configures the host presentation surface and owns host graphics API context and presentation resources.         |
 | Render target    | Owns the render session and mode-specific resources such as compositors, borrowed textures/images, and acquired frames. |
 | Compositor       | Host pass that draws a map-owned or borrowed texture into the swapchain.                                                |
-| Input            | Pointer and keyboard → map camera APIs; prints control help once at startup.                                            |
+| Input            | Pointer and/or touch → map camera APIs; profile-specific control help.                                                  |
 | Diagnostics      | Optional log callback and consistent error messages on failed setup or camera commands.                                 |
 
 Implementations SHOULD mirror this layout in the source tree (separate files or
 packages per module).
 
-### Graphics API and mode matrix
+#### Graphics API and mode matrix
 
 The example architecture MUST model the active graphics API separately from the
 active render-target mode. Graphics context code owns API-level resources
@@ -182,52 +170,50 @@ attached `RenderSessionHandle`, mode-specific resources, resize behavior,
 
 When a build variant selects a single native render backend, the example SHOULD
 compile only the matching graphics API implementation and its platform glue.
-Backend selection can happen at build time; render-target mode selection remains
-a runtime CLI choice.
+Backend selection happens at build time. Render-target mode selection follows
+the active profile ([Entry](#entry) or [Entry and shell](#entry-and-shell)).
 
 Adding a graphics API or render-target mode MUST require localized changes. Keep
 each graphics API and render-target mode in its own variant, class, or submodule
 rather than branching ad hoc through shared draw code.
 
----
+### Lifecycle
 
-## Lifecycle
-
-### Startup
+#### Startup
 
 Order MUST be:
 
-1. Parse CLI and validate selected render mode.
+1. Parse profile entry configuration and validate the selected render mode.
 2. Read and log the loaded library's supported native render backends from
    `mln_supported_render_backend_mask()`, then validate that the loaded native
    library supports the graphics backend(s) this binary targets; fail fast with
    a readable message if not.
-3. Create the top-level window and initialize the graphics backend for the
-   selected graphics API.
+3. Create the host presentation surface and initialize the graphics backend for
+   the selected graphics API.
 4. Create runtime (`:memory:` cache).
 5. Create map with extent from the initial viewport and continuous mode.
 6. Load style and apply initial camera.
 7. Attach render target for the selected mode.
 8. Print startup information:
-   - active render-target mode CLI value
+   - active render-target mode identifier
    - active render-target status line
-   - control help
+   - profile control help
 
 On failure after partial setup, release already-created handles in reverse order
 (render target → map → runtime → graphics).
 
-### Shutdown
+#### Shutdown
 
-On window close or fatal error, close resources in order:
+On host termination or fatal error, close resources in order:
 
 1. Finish or wait on in-flight GPU work if the backend requires it.
 2. Render target (compositor and borrowed texture/image before or with the
    session, according to graphics API lifetime rules).
 3. Map
 4. Runtime
-5. Graphics context and window.
+5. Graphics context and host presentation surface.
 
-### Handle ownership
+#### Handle ownership
 
 - One runtime per process (owner thread drives `run_once` / pump).
 - One map per runtime for the demo.
@@ -235,19 +221,19 @@ On window close or fatal error, close resources in order:
 - Map configuration (style, camera) uses the map handle; render-target extent
   and present use the render target.
 
----
-
-## Frame loop
+### Frame loop
 
 Each iteration has two phases: pump (always) and render (only when
 `render_pending` is true).
 
-### Pump (every iteration)
+Every example MUST run one pump iteration per display refresh tick. Subscribe
+through the host toolkit's display refresh mechanism (for example swapchain
+frame callbacks, `CADisplayLink`, or `Choreographer`).
 
-While polling, handle resize (reattach the render target when required) and
-input (may set `render_pending`). Toolkits that use callbacks or timers instead
-of a single poll API MUST run one pump iteration per display refresh tick (for
-example an `NSTimer` on `swift-map`).
+#### Pump (every iteration)
+
+Handle resize (reattach the render target when required) and input (may set
+`render_pending`).
 
 ```mermaid
 sequenceDiagram
@@ -255,7 +241,7 @@ sequenceDiagram
   participant RT as Runtime
   participant BE as Backend
 
-  EL->>EL: Poll window + input events
+  EL->>EL: Poll or receive window + input events
   EL->>RT: run_once()
   EL->>RT: drain events → may set render_pending
   EL->>BE: finishFrame()
@@ -264,7 +250,7 @@ sequenceDiagram
 `finishFrame()` runs every pump iteration: swapchain or surface upkeep, resize
 handling, and present hooks as required by the host graphics API.
 
-### Render (`render_pending`)
+#### Render (`render_pending`)
 
 ```mermaid
 sequenceDiagram
@@ -296,28 +282,24 @@ Requirements:
 - MUST clear `render_pending` after `render_update` returns success.
 - On `invalid_state` from `render_update`, leave `render_pending` set and
   continue the pump loop (no frame was drawn yet).
-- SHOULD idle-sleep briefly when an iteration makes no progress (event poll,
-  render, or runtime work).
 
 Texture modes: after a successful `render_update`, MUST run the compositor pass
-to copy the map texture into the window swapchain before present.
+to copy the map texture into the host swapchain before present.
 
----
-
-## Viewport
+### Viewport
 
 The viewport value MUST contain:
 
 | Field                               | Meaning                                                                   |
 | ----------------------------------- | ------------------------------------------------------------------------- |
 | `logical_width`, `logical_height`   | Map coordinate extent passed to `MapOptions` / `RenderTargetExtent`.      |
-| `physical_width`, `physical_height` | Drawable pixels of the window framebuffer.                                |
+| `physical_width`, `physical_height` | Drawable pixels of the host framebuffer.                                  |
 | `scale_factor`                      | Ratio between physical and logical sizes (content scale / pixel density). |
 
 Derivation rules:
 
-- Read logical and physical sizes from the window toolkit after creation and on
-  every resize / backing-scale change.
+- Read logical and physical sizes from the host toolkit after surface creation
+  and on every resize or backing-scale change.
 - Compute logical dimensions from physical size and scale when the toolkit only
   exposes physical pixels (use `ceil(physical / scale)`, minimum `1`).
 - Log viewport changes at informational level with field labels
@@ -326,64 +308,60 @@ Derivation rules:
 Pass `logical_*` and `scale_factor` to map creation, session attach, and session
 `resize`.
 
----
-
-## Map state
+### Map state
 
 The map state module owns the runtime, map, and render session handles plus
 map-specific setup.
 
-### Creation
+#### Creation
 
 - Create runtime with `:memory:` cache.
 - Create map with current viewport extent and continuous mode.
 - Load [style URL](#style).
 - Apply [initial camera](#initial-camera).
-- Attach a render target by dispatching on active graphics API and CLI-selected
+- Attach a render target by dispatching on active graphics API and selected
   mode.
 
-### Event drain
+#### Event drain
 
 - Drain all pending runtime events each frame.
 - Set `render_pending` for the frame loop when either:
   - `map_render_update_available` targets this map, or
   - `map_render_frame_finished` targets this map and `needs_repaint` is true.
 
-### Resize API
+#### Resize API
 
 Expose `resize(viewport)` for the active render target. Resize API-level
 resources separately when the graphics context requires it. When the active
 render target reports `needsReattachOnResize`, destroy it and attach a
 replacement for the same graphics context, map, and mode.
 
----
+### Render-target modes
 
-## Render-target modes
+Three modes MUST be modeled in every example's architecture (render-target
+discriminant/class and attach paths). Profile sections define which modes each
+example implements ([Render-target coverage](#render-target-coverage)).
 
-Three modes MUST be modeled in every example’s architecture (CLI parsing,
-render-target discriminant/class, and attach paths). Each example MUST implement
-all three modes on every graphics API the example binary exposes.
+#### Mode comparison
 
-### Mode comparison
-
-| CLI value          | C API concept                            | Compositor | Role                                                        |
+| Mode identifier    | C API concept                            | Compositor | Role                                                        |
 | ------------------ | ---------------------------------------- | ---------- | ----------------------------------------------------------- |
 | `owned-texture`    | Session-owned backend texture            | Required   | Map allocates texture, host samples it.                     |
 | `borrowed-texture` | Caller-owned texture borrowed by session | Required   | Host allocates exportable texture; session renders into it. |
-| `native-surface`   | Window presentation surface              | None       | Map renders directly to the window presentation target.     |
+| `native-surface`   | Window presentation surface              | None       | Map renders directly to the host presentation target.       |
 
-### Startup status lines
+#### Startup status lines
 
-Startup MUST print the active mode’s CLI value and exactly one line from this
+Startup MUST print the active mode identifier and exactly one line from this
 table:
 
-| CLI value          | Printed line                                                                                       |
+| Mode identifier    | Printed line                                                                                       |
 | ------------------ | -------------------------------------------------------------------------------------------------- |
 | `owned-texture`    | `render target status: samples MapLibre-owned texture frames into the host swapchain`              |
 | `borrowed-texture` | `render target status: renders into a host-owned texture, then samples it into the host swapchain` |
 | `native-surface`   | `render target status: renders directly to the host window surface`                                |
 
-### `owned-texture`
+#### `owned-texture`
 
 - Attach with the C API owned-texture descriptor for the active graphics API.
 - Pass the host graphics context handles required by that descriptor (see
@@ -391,7 +369,7 @@ table:
 - On `render_update`, acquire the frame/image from the session, draw via
   compositor, release/close the frame per the C API frame lifetime rules.
 
-### `borrowed-texture`
+#### `borrowed-texture`
 
 - Host creates an exportable texture sized to the viewport (see
   [Graphics API](#graphics-api)).
@@ -399,24 +377,36 @@ table:
 - On `render_update`, sample that texture through the same compositor path as
   `owned-texture`.
 - On resize, recreate the host texture and re-attach the session (see
-  [Resize](#resize); `needsReattachOnResize` is `true` for this mode).
+  [Resize mechanics](#resize-mechanics); `needsReattachOnResize` is `true` for
+  this mode).
 
-### `native-surface`
+#### `native-surface`
 
-- Attach with the C API surface descriptor for window presentation (see
+- Attach with the C API surface descriptor for host presentation (see
   [Graphics API](#graphics-api)).
 - `render_update` presents through the surface render target directly.
 - `drawTexture` MUST NOT be called for this mode.
 - On resize, call session `resize` and rebuild host presentation; reattach when
-  the window toolkit supplies a new surface handle.
+  the host toolkit supplies a new surface handle.
 
----
+### Compositor shaders
 
-## Resize
+For `owned-texture` and `borrowed-texture`, the host-owned compositor that
+samples the map texture into the host swapchain MUST use a fullscreen triangle
+covering the viewport:
 
-- Subscribe to window size, framebuffer size, and display-scale / content-scale
-  events (as available on the platform).
-- Recompute viewport; skip rendering if extent is empty.
+- Vertex shader: three corners with pass-through UVs spanning the visible
+  `[0, 1] × [0, 1]` texture range (large-triangle technique).
+- Fragment shader: `texture(map_texture, uv)` (straight copy, standard UV
+  orientation).
+
+SPIR-V, MSL, or GLSL source MAY differ by backend; the GPU output MUST match
+that pass.
+
+### Resize mechanics
+
+- Recompute viewport on host size or scale changes; skip rendering if extent is
+  empty.
 - `needsReattachOnResize()` is a render-target method. It returns `true` for
   `borrowed-texture` because the host-owned exportable texture is fixed to the
   viewport size: resize destroys the render target, recreates the texture, and
@@ -427,11 +417,105 @@ table:
   graphics context and active render target in place.
 - Set `render_pending` after any resize.
 
+Profile sections define which host events trigger resize
+([Desktop profile → Resize triggers](#resize-triggers) or
+[Mobile profile → Resize triggers](#resize-triggers-1)).
+
+### Diagnostics
+
+- SHOULD register a native log callback during startup and clear it on shutdown.
+- On setup or camera failure, print a short message including the native status
+  and diagnostic strings returned by the C API.
+- On startup, print the three items listed in [Startup](#startup) step 8.
+
+### Graphics API
+
+Attach descriptors and shared context handles for each graphics API the example
+binary targets. Implement only the modes required by the active profile
+([Render-target coverage](#render-target-coverage)).
+
+#### Vulkan
+
+- One shared Vulkan context (`VkInstance`, `VkDevice`, queue, and
+  `VkSurfaceKHR`) for compositor and render session.
+- `owned-texture`: Vulkan owned-texture descriptor with those shared handles.
+- `borrowed-texture`: exportable `VkImage` and view sized to the viewport;
+  borrowed-texture descriptor.
+- `native-surface`: surface / swapchain presentation descriptor for the host
+  `VkSurfaceKHR`.
+
+#### Metal
+
+- `native-surface`: Metal surface descriptor for the host `CAMetalLayer`.
+- `owned-texture`: Metal owned-texture descriptor; shared device and layer
+  handles required by the C API.
+- `borrowed-texture`: exportable Metal texture sized to the viewport;
+  borrowed-texture descriptor.
+
+#### OpenGL / EGL / WGL
+
+- `native-surface`: OpenGL/EGL/WGL surface descriptor for the host platform GL
+  surface.
+- `owned-texture`: OpenGL owned-texture descriptor; shared GL context handles
+  required by the C API.
+- `borrowed-texture`: exportable GL texture sized to the viewport;
+  borrowed-texture descriptor.
+
+### Render-target coverage
+
+| Profile | Required modes on every graphics API build variant the example ships |
+| ------- | -------------------------------------------------------------------- |
+| Desktop | `owned-texture`, `borrowed-texture`, `native-surface`                |
+| Mobile  | `native-surface`                                                     |
+
 ---
 
-## Input
+## Desktop profile
 
-### Control scheme
+### Scope
+
+Desktop `*-map` examples add:
+
+- One top-level resizable map window.
+- CLI render-target mode selection across all three modes.
+- Keyboard and mouse camera controls.
+- Graceful process exit when the user closes the window.
+
+### Entry
+
+#### Render-target selection
+
+The process MUST accept a render-target mode name:
+
+| Mode                          | CLI value          |
+| ----------------------------- | ------------------ |
+| Session-owned texture         | `owned-texture`    |
+| Caller-owned borrowed texture | `borrowed-texture` |
+| Native window surface         | `native-surface`   |
+
+The mode is a required positional argument (for example
+`zig-map owned-texture`). There is no default mode.
+
+On `--help`, print usage listing the three mode names and exit `0` before
+creating a window. On invalid arguments, print usage listing the three mode
+names and exit `1` before creating a window.
+
+#### Other flags
+
+The only permitted flag is `--help`. Implementations MUST NOT add other CLI
+flags.
+
+### Shell and window
+
+- Initial logical size: `960` × `640` pixels.
+- Window MUST be resizable.
+- High-DPI / Retina: derive map `RenderTargetExtent` from the window's drawable
+  size and content scale (see [Viewport](#viewport)).
+- Shutdown triggers on window close.
+
+### Input
+
+#### Control scheme
 
 Implementations MUST provide the following interactions and MUST print this help
 text once at startup:
@@ -448,7 +532,7 @@ Controls:
   0: reset pitch and bearing
 ```
 
-### Behavioral constants
+#### Behavioral constants
 
 | Interaction                   | Behavior                                                                                                                                                                               |
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -471,46 +555,61 @@ applying deltas.
 Input handlers return whether the camera changed so the frame loop can set
 `render_pending`.
 
----
+### Resize triggers
 
-## Diagnostics
-
-- SHOULD register a native log callback during startup and clear it on shutdown.
-- On setup or camera failure, print a short message including the native status
-  and diagnostic strings returned by the C API.
-- On startup, print the three items listed in [Startup](#startup) step 8.
+- Subscribe to window size, framebuffer size, and display-scale / content-scale
+  events (as available on the platform).
 
 ---
 
-## Graphics API
+## Mobile profile
 
-Each example MUST expose every API below that its toolkit and platform can
-support, and MUST implement all three render-target modes on each exposed API.
-Attach descriptors and shared context handles:
+### Scope
 
-### Vulkan
+Mobile `*-map` examples add:
 
-- One shared Vulkan context (`VkInstance`, `VkDevice`, queue, and
-  `VkSurfaceKHR`) for compositor and render session.
-- `owned-texture`: Vulkan owned-texture descriptor with those shared handles.
-- `borrowed-texture`: exportable `VkImage` and view sized to the viewport;
-  borrowed-texture descriptor.
-- `native-surface`: surface / swapchain presentation descriptor for the window
-  `VkSurfaceKHR`.
+- A full-screen or layout-driven map view embedded in the platform app shell.
+- Touch camera controls.
+- View lifecycle integration (appear, disappear, foreground, background).
 
-### Metal
+### Entry and shell
 
-- `native-surface`: Metal surface descriptor for the window `CAMetalLayer`.
-- `owned-texture`: Metal owned-texture descriptor; shared device and layer
-  handles required by the C API.
-- `borrowed-texture`: exportable Metal texture sized to the viewport;
-  borrowed-texture descriptor.
+- The map view fills the available layout area or the screen.
+- Derive the initial viewport from the view's layout bounds and content scale
+  after the view is on screen.
+- Attach `native-surface` for the host `CAMetalLayer`, `VkSurfaceKHR`, or
+  platform GL surface supplied by the view.
+- Shutdown follows view destruction or app termination.
+- Minimal platform bundle files required to run on device or simulator are
+  permitted. Store distribution and installer UX remain out of scope.
 
-### OpenGL / EGL / WGL
+### Input
 
-- `native-surface`: OpenGL/EGL/WGL surface descriptor for the window’s platform
-  GL surface.
-- `owned-texture`: OpenGL owned-texture descriptor; shared GL context handles
-  required by the C API.
-- `borrowed-texture`: exportable GL texture sized to the viewport;
-  borrowed-texture descriptor.
+#### Control scheme
+
+Implementations MUST provide the following touch interactions:
+
+| Interaction              | Behavior                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------ |
+| One-finger drag          | `move_by` with pointer delta in logical coordinates.                                             |
+| Two-finger rotate        | Adjust bearing by `0.5 × Δθ` degrees, where `Δθ` is the change in angle between the two touches. |
+| Two-finger vertical drag | Adjust pitch by `0.5 × Δy` degrees (same sign convention as desktop rotate drag).                |
+| Pinch                    | Zoom about the gesture centroid: `scale_by(2^(Δ * 0.25), anchor)`. Pinch apart zooms in.         |
+| Double-tap               | Zoom `1.25` about the tap location with keyboard animation (~`160` ms).                          |
+
+On pointer down that starts a drag, cancel in-flight camera transitions before
+applying deltas.
+
+Input handlers return whether the camera changed so the frame loop can set
+`render_pending`.
+
+### Resize triggers
+
+- Subscribe to layout changes, orientation changes, safe-area changes, and
+  display-scale / content-scale changes (as available on the platform).
+
+### Logging
+
+- Emit startup and viewport diagnostics through the platform log sink (for
+  example `OSLog` on Apple platforms or `logcat` on Android).
+- Control help is not printed to stdout on mobile.

--- a/examples/dotnet-map/Shell.cs
+++ b/examples/dotnet-map/Shell.cs
@@ -26,9 +26,8 @@ internal static class Shell
         Console.WriteLine($"render target status: {mode.Status}");
         InputController.PrintControls();
 
-        // TODO(map-example-spec): Drive the pump from a display-refresh callback instead of
-        // polling GLFW events and waiting with a timeout when idle. See Frame loop in the
-        // map example spec.
+        // TODO(map-example-spec): Replace poll-and-wait with a display-paced host loop
+        // (pace on display refresh; desktop may also wake on input). See Frame loop.
         while (!graphics.ShouldClose)
         {
             graphics.PollEvents();

--- a/examples/dotnet-map/Shell.cs
+++ b/examples/dotnet-map/Shell.cs
@@ -26,8 +26,7 @@ internal static class Shell
         Console.WriteLine($"render target status: {mode.Status}");
         InputController.PrintControls();
 
-        // TODO(map-example-spec): Replace poll-and-wait with a display-paced host loop
-        // (pace on display refresh; desktop may also wake on input). See Frame loop.
+        // TODO(map-example-spec): Replace poll-and-wait with a display-paced host loop. See Frame loop.
         while (!graphics.ShouldClose)
         {
             graphics.PollEvents();

--- a/examples/dotnet-map/Shell.cs
+++ b/examples/dotnet-map/Shell.cs
@@ -26,6 +26,9 @@ internal static class Shell
         Console.WriteLine($"render target status: {mode.Status}");
         InputController.PrintControls();
 
+        // TODO(map-example-spec): Drive the pump from a display-refresh callback instead of
+        // polling GLFW events and waiting with a timeout when idle. See Frame loop in the
+        // map example spec.
         while (!graphics.ShouldClose)
         {
             graphics.PollEvents();

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Shell.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Shell.java
@@ -29,6 +29,9 @@ final class Shell {
         System.out.println("render target status: " + mode.status());
         InputController.printControls();
         installResizeCallbacks(graphics.window(), viewport);
+        // TODO(map-example-spec): Drive the pump from a display-refresh callback instead of
+        // polling GLFW events and waiting with a timeout when idle. See Frame loop in the
+        // map example spec.
         while (!glfwWindowShouldClose(graphics.window())) {
           glfwPollEvents();
           if (viewport.consumeChanged()) {

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Shell.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Shell.java
@@ -29,8 +29,8 @@ final class Shell {
         System.out.println("render target status: " + mode.status());
         InputController.printControls();
         installResizeCallbacks(graphics.window(), viewport);
-        // TODO(map-example-spec): Replace poll-and-wait with a display-paced host loop
-        // (pace on display refresh; desktop may also wake on input). See Frame loop.
+        // TODO(map-example-spec): Replace poll-and-wait with a display-paced host loop. See Frame
+        // loop.
         while (!glfwWindowShouldClose(graphics.window())) {
           glfwPollEvents();
           if (viewport.consumeChanged()) {

--- a/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Shell.java
+++ b/examples/lwjgl-map/src/main/java/org/maplibre/nativeffi/examples/lwjglmap/Shell.java
@@ -29,9 +29,8 @@ final class Shell {
         System.out.println("render target status: " + mode.status());
         InputController.printControls();
         installResizeCallbacks(graphics.window(), viewport);
-        // TODO(map-example-spec): Drive the pump from a display-refresh callback instead of
-        // polling GLFW events and waiting with a timeout when idle. See Frame loop in the
-        // map example spec.
+        // TODO(map-example-spec): Replace poll-and-wait with a display-paced host loop
+        // (pace on display refresh; desktop may also wake on input). See Frame loop.
         while (!glfwWindowShouldClose(graphics.window())) {
           glfwPollEvents();
           if (viewport.consumeChanged()) {

--- a/examples/rust-map/src/shell.rs
+++ b/examples/rust-map/src/shell.rs
@@ -52,6 +52,8 @@ impl Shell {
 
 impl ApplicationHandler for Shell {
     fn new_events(&mut self, event_loop: &ActiveEventLoop, _cause: StartCause) {
+        // TODO(map-example-spec): Drive the pump from a display-refresh callback instead of
+        // a fixed timer. See Frame loop in the map example spec.
         event_loop.set_control_flow(ControlFlow::WaitUntil(
             Instant::now() + Duration::from_millis(4),
         ));

--- a/examples/rust-map/src/shell.rs
+++ b/examples/rust-map/src/shell.rs
@@ -52,8 +52,8 @@ impl Shell {
 
 impl ApplicationHandler for Shell {
     fn new_events(&mut self, event_loop: &ActiveEventLoop, _cause: StartCause) {
-        // TODO(map-example-spec): Drive the pump from a display-refresh callback instead of
-        // a fixed timer. See Frame loop in the map example spec.
+        // TODO(map-example-spec): Replace fixed timer with a display-paced host loop
+        // (pace on display refresh; desktop may also wake on input). See Frame loop.
         event_loop.set_control_flow(ControlFlow::WaitUntil(
             Instant::now() + Duration::from_millis(4),
         ));

--- a/examples/rust-map/src/shell.rs
+++ b/examples/rust-map/src/shell.rs
@@ -52,8 +52,7 @@ impl Shell {
 
 impl ApplicationHandler for Shell {
     fn new_events(&mut self, event_loop: &ActiveEventLoop, _cause: StartCause) {
-        // TODO(map-example-spec): Replace fixed timer with a display-paced host loop
-        // (pace on display refresh; desktop may also wake on input). See Frame loop.
+        // TODO(map-example-spec): Replace fixed timer with a display-paced host loop. See Frame loop.
         event_loop.set_control_flow(ControlFlow::WaitUntil(
             Instant::now() + Duration::from_millis(4),
         ));

--- a/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
+++ b/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
@@ -126,8 +126,8 @@ final class MetalMapView: NSView {
 
   private func startTimerIfNeeded() {
     guard timer == nil else { return }
-    // TODO(map-example-spec): Drive the pump from a display-refresh callback (for example
-    // CVDisplayLink) instead of a fixed NSTimer. See Frame loop in the map example spec.
+    // TODO(map-example-spec): Replace fixed NSTimer with a display-paced host loop
+    // (pace on display refresh). See Frame loop.
     timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
       Task { @MainActor in self?.tick() }
     }

--- a/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
+++ b/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
@@ -126,8 +126,7 @@ final class MetalMapView: NSView {
 
   private func startTimerIfNeeded() {
     guard timer == nil else { return }
-    // TODO(map-example-spec): Replace fixed NSTimer with a display-paced host loop
-    // (pace on display refresh). See Frame loop.
+    // TODO(map-example-spec): Replace fixed NSTimer with a display-paced host loop. See Frame loop.
     timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
       Task { @MainActor in self?.tick() }
     }

--- a/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
+++ b/examples/swift-map/Sources/SwiftMap/MetalMapView.swift
@@ -126,6 +126,8 @@ final class MetalMapView: NSView {
 
   private func startTimerIfNeeded() {
     guard timer == nil else { return }
+    // TODO(map-example-spec): Drive the pump from a display-refresh callback (for example
+    // CVDisplayLink) instead of a fixed NSTimer. See Frame loop in the map example spec.
     timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
       Task { @MainActor in self?.tick() }
     }

--- a/examples/zig-map/main.zig
+++ b/examples/zig-map/main.zig
@@ -79,6 +79,8 @@ pub fn main(init_args: std.process.Init) !void {
     var has_presented_frame = false;
     var render_pending = true;
     var input_controller = input.Controller{};
+    // TODO(map-example-spec): Drive the pump from a display-refresh callback instead of
+    // polling SDL events and sleeping when idle. See Frame loop in the map example spec.
     while (running) {
         const pool = if (build_options.supports_metal) objc.AutoreleasePool.init() else {};
         defer if (build_options.supports_metal) pool.deinit();

--- a/examples/zig-map/main.zig
+++ b/examples/zig-map/main.zig
@@ -79,8 +79,8 @@ pub fn main(init_args: std.process.Init) !void {
     var has_presented_frame = false;
     var render_pending = true;
     var input_controller = input.Controller{};
-    // TODO(map-example-spec): Drive the pump from a display-refresh callback instead of
-    // polling SDL events and sleeping when idle. See Frame loop in the map example spec.
+    // TODO(map-example-spec): Replace poll-and-sleep with a display-paced host loop
+    // (pace on display refresh; desktop may also wake on input). See Frame loop.
     while (running) {
         const pool = if (build_options.supports_metal) objc.AutoreleasePool.init() else {};
         defer if (build_options.supports_metal) pool.deinit();

--- a/examples/zig-map/main.zig
+++ b/examples/zig-map/main.zig
@@ -79,8 +79,7 @@ pub fn main(init_args: std.process.Init) !void {
     var has_presented_frame = false;
     var render_pending = true;
     var input_controller = input.Controller{};
-    // TODO(map-example-spec): Replace poll-and-sleep with a display-paced host loop
-    // (pace on display refresh; desktop may also wake on input). See Frame loop.
+    // TODO(map-example-spec): Replace poll-and-sleep with a display-paced host loop. See Frame loop.
     while (running) {
         const pool = if (build_options.supports_metal) objc.AutoreleasePool.init() else {};
         defer if (build_options.supports_metal) pool.deinit();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorganizes the map example specification into shared baseline, desktop profile, and mobile profile sections; addresses review feedback on profile-scoped coverage, lifecycle, gestures, and startup logging; adds display-refresh pump TODOs to desktop examples.

## Test plan

Documentation-only spec changes plus TODO comments in desktop examples; no behavior changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdff3c1a-4205-4ac3-946b-220e2b47eaf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdff3c1a-4205-4ac3-946b-220e2b47eaf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

