### PR TITLE
zig: migrate away from cImport to translate-c

### DIFF
--- a/bindings/zig/build.zig
+++ b/bindings/zig/build.zig
@@ -18,6 +18,7 @@ pub const RenderBackend = enum {
 
 pub const LinkOptions = struct {
     target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
     cmake_artifact_dir: std.Build.LazyPath,
     render_backend: RenderBackend,
     include_dirs: []const std.Build.LazyPath,
@@ -66,6 +67,84 @@ pub fn includeDirs(b: *std.Build) []const std.Build.LazyPath {
 pub fn addIncludePaths(module: *std.Build.Module, include_dirs: []const std.Build.LazyPath) void {
     for (include_dirs) |include_dir| {
         module.addIncludePath(include_dir);
+    }
+}
+
+fn addTranslateCIncludePaths(translate_c: *std.Build.Step.TranslateC, include_dirs: []const std.Build.LazyPath) void {
+    for (include_dirs) |include_dir| {
+        translate_c.addIncludePath(include_dir);
+    }
+}
+
+pub const CMacro = struct {
+    name: []const u8,
+    value: ?[]const u8 = null,
+};
+
+pub const TranslateCModuleOptions = struct {
+    root_source_file: std.Build.LazyPath,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    include_dirs: []const std.Build.LazyPath,
+    c_macros: []const CMacro = &.{},
+};
+
+pub fn translateCModule(b: *std.Build, options: TranslateCModuleOptions) *std.Build.Module {
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = options.root_source_file,
+        .target = options.target,
+        .optimize = options.optimize,
+    });
+    addTranslateCIncludePaths(translate_c, options.include_dirs);
+    for (options.c_macros) |c_macro| {
+        translate_c.defineCMacro(c_macro.name, c_macro.value);
+    }
+    return translate_c.createModule();
+}
+
+fn maplibreNativeCHeader(b: *std.Build) std.Build.LazyPath {
+    const header = b.addWriteFiles();
+    return header.add("maplibre_native_c_import.h", "#include <maplibre_native_c.h>\n");
+}
+
+fn vulkanBindingsHeader(b: *std.Build) std.Build.LazyPath {
+    const header = b.addWriteFiles();
+    return header.add("vulkan_bindings.h", "#include <vulkan/vulkan.h>\n");
+}
+
+fn eglBindingsHeader(b: *std.Build) std.Build.LazyPath {
+    const header = b.addWriteFiles();
+    return header.add("egl_bindings.h",
+        \\#define EGL_EGLEXT_PROTOTYPES 1
+        \\#include <EGL/egl.h>
+        \\#include <EGL/eglext.h>
+        \\
+    );
+}
+
+pub const RenderBackendTranslateCOptions = struct {
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    include_dirs: []const std.Build.LazyPath,
+    render_backend: RenderBackend,
+};
+
+pub fn addRenderBackendTranslateC(b: *std.Build, module: *std.Build.Module, options: RenderBackendTranslateCOptions) void {
+    if (options.render_backend == .vulkan) {
+        module.addImport("vulkan", translateCModule(b, .{
+            .root_source_file = vulkanBindingsHeader(b),
+            .target = options.target,
+            .optimize = options.optimize,
+            .include_dirs = options.include_dirs,
+        }));
+    }
+    if (options.render_backend == .opengl and (options.target.result.os.tag == .linux or options.target.result.os.tag == .macos)) {
+        module.addImport("egl", translateCModule(b, .{
+            .root_source_file = eglBindingsHeader(b),
+            .target = options.target,
+            .optimize = options.optimize,
+            .include_dirs = options.include_dirs,
+        }));
     }
 }
 
@@ -196,6 +275,7 @@ pub fn maplibreNativeModule(b: *std.Build, options: DependencyOptions) *std.Buil
 fn repoLinkOptions(options: BuildOptions) LinkOptions {
     return .{
         .target = options.target,
+        .optimize = options.optimize,
         .cmake_artifact_dir = options.cmake_artifact_dir,
         .render_backend = options.render_backend,
         .include_dirs = options.include_dirs,
@@ -205,12 +285,20 @@ fn repoLinkOptions(options: BuildOptions) LinkOptions {
 
 pub const IncludeOptions = struct {
     include_dirs: []const std.Build.LazyPath,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
 };
 
-/// Configures include paths and libc for `@cImport` without linking maplibre-native-c.
-pub fn addMaplibreNativeIncludes(module_: *std.Build.Module, options: IncludeOptions) void {
+/// Configures the raw C declarations without linking maplibre-native-c.
+pub fn addMaplibreNativeIncludes(b: *std.Build, module_: *std.Build.Module, options: IncludeOptions) void {
     addIncludePaths(module_, options.include_dirs);
     module_.link_libc = true;
+    module_.addImport("maplibre_native_c", translateCModule(b, .{
+        .root_source_file = maplibreNativeCHeader(b),
+        .target = options.target,
+        .optimize = options.optimize,
+        .include_dirs = options.include_dirs,
+    }));
 }
 
 /// Links a Zig module to the MapLibre Native C library and its backend-specific dependencies.
@@ -218,7 +306,11 @@ pub fn addMaplibreNativeIncludes(module_: *std.Build.Module, options: IncludeOpt
 /// Callers provide all filesystem paths explicitly so the helper works both from this
 /// package and from external consumers with a different build root layout.
 pub fn linkMaplibreNativeC(b: *std.Build, module_: *std.Build.Module, options: LinkOptions) void {
-    addMaplibreNativeIncludes(module_, .{ .include_dirs = options.include_dirs });
+    addMaplibreNativeIncludes(b, module_, .{
+        .include_dirs = options.include_dirs,
+        .target = options.target,
+        .optimize = options.optimize,
+    });
     if (options.target.result.os.tag == .windows) {
         module_.addObjectFile(options.cmake_artifact_dir.path(b, "maplibre-native-c.lib"));
     } else {
@@ -258,7 +350,11 @@ fn addMaplibreNativeDocs(
         .target = target,
         .optimize = optimize,
     });
-    addMaplibreNativeIncludes(docs_module, .{ .include_dirs = include_dirs });
+    addMaplibreNativeIncludes(b, docs_module, .{
+        .include_dirs = include_dirs,
+        .target = target,
+        .optimize = optimize,
+    });
 
     const doc_compile = b.addObject(.{
         .name = "maplibre_native_docs",
@@ -289,6 +385,12 @@ fn addBindingTests(b: *std.Build, options: BuildOptions, maplibre_native: *std.B
     const tests = addTestCompile(b, options, b.path("tests/main.zig"));
     tests.root_module.addImport("maplibre_native", maplibre_native);
     addRenderBackendOptions(b, tests.root_module, options.render_backend);
+    addRenderBackendTranslateC(b, tests.root_module, .{
+        .target = options.target,
+        .optimize = options.optimize,
+        .include_dirs = options.include_dirs,
+        .render_backend = options.render_backend,
+    });
     if (options.render_backend == .opengl) {
         const gl_bindings = zigglgen.generateBindingsModule(b, if (options.target.result.os.tag == .linux or options.target.result.os.tag == .macos)
             .{ .api = .gles, .version = .@"3.0" }

--- a/bindings/zig/build.zig
+++ b/bindings/zig/build.zig
@@ -105,6 +105,7 @@ pub fn translateCModule(b: *std.Build, options: TranslateCModuleOptions) *std.Bu
         .optimize = options.optimize,
     });
     addTranslateCIncludePaths(translate_c, options.include_dirs);
+    addPlatformSystemHeaderPaths(b, translate_c, options.target);
     for (options.c_macros) |c_macro| {
         translate_c.defineCMacro(c_macro.name, c_macro.value);
     }
@@ -172,15 +173,23 @@ fn addDependencyLibraryPaths(module: *std.Build.Module, dependency_library_dirs:
     }
 }
 
-pub fn addPlatformSystemPaths(b: *std.Build, module: *std.Build.Module, target: std.Build.ResolvedTarget) void {
+fn addPlatformSystemHeaderPaths(b: *std.Build, destination: anytype, target: std.Build.ResolvedTarget) void {
     if (!target.result.os.tag.isDarwin() and target.result.os.tag != .linux) return;
     const system_root = b.graph.environ_map.get("MLN_FFI_SYSTEM_ROOT") orelse return;
     if (system_root.len == 0) return;
 
     if (target.result.os.tag.isDarwin()) {
-        module.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ system_root, "System", "Library", "Frameworks" }) });
+        destination.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ system_root, "System", "Library", "Frameworks" }) });
     }
-    module.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ system_root, "usr", "include" }) });
+    destination.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ system_root, "usr", "include" }) });
+}
+
+pub fn addPlatformSystemPaths(b: *std.Build, module: *std.Build.Module, target: std.Build.ResolvedTarget) void {
+    addPlatformSystemHeaderPaths(b, module, target);
+    if (!target.result.os.tag.isDarwin() and target.result.os.tag != .linux) return;
+    const system_root = b.graph.environ_map.get("MLN_FFI_SYSTEM_ROOT") orelse return;
+    if (system_root.len == 0) return;
+
     module.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ system_root, "usr", "lib" }) });
     if (target.result.os.tag == .linux) {
         module.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ system_root, "usr", "lib64" }) });

--- a/bindings/zig/build.zig
+++ b/bindings/zig/build.zig
@@ -81,6 +81,15 @@ pub const CMacro = struct {
     value: ?[]const u8 = null,
 };
 
+pub fn sdlTranslateCMacros(target: std.Build.ResolvedTarget) []const CMacro {
+    if (target.result.os.tag != .windows or target.result.abi != .msvc) return &.{};
+    return &.{
+        .{ .name = "SIZE_MAX", .value = "((size_t)-1)" },
+        .{ .name = "SDL_SINT64_C(c)", .value = "c##LL" },
+        .{ .name = "SDL_UINT64_C(c)", .value = "c##ULL" },
+    };
+}
+
 pub const TranslateCModuleOptions = struct {
     root_source_file: std.Build.LazyPath,
     target: std.Build.ResolvedTarget,

--- a/bindings/zig/src/c.zig
+++ b/bindings/zig/src/c.zig
@@ -1,3 +1,1 @@
-pub const raw = @cImport({
-    @cInclude("maplibre_native_c.h");
-});
+pub const raw = @import("maplibre_native_c");

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -10,18 +10,12 @@ const test_hooks = @import("test_hooks.zig");
 
 extern "c" fn MTLCreateSystemDefaultDevice() ?*anyopaque;
 
-const vk = if (build_options.supports_vulkan) @cImport({
-    @cInclude("vulkan/vulkan.h");
-}) else struct {};
+const vk = if (build_options.supports_vulkan) @import("vulkan") else struct {};
 
 const supports_wgl = build_options.supports_opengl and builtin.os.tag == .windows;
 const supports_egl = build_options.supports_opengl and (builtin.os.tag == .linux or builtin.os.tag == .macos);
 
-const egl = if (supports_egl) @cImport({
-    @cDefine("EGL_EGLEXT_PROTOTYPES", "1");
-    @cInclude("EGL/egl.h");
-    @cInclude("EGL/eglext.h");
-}) else struct {};
+const egl = if (supports_egl) @import("egl") else struct {};
 
 const gl = if (supports_wgl or supports_egl) @import("gl") else struct {};
 const wgl_test = if (supports_wgl) @import("wgl_test_context") else struct {};

--- a/examples/zig-map/build.zig
+++ b/examples/zig-map/build.zig
@@ -26,15 +26,21 @@ fn maplibreNativeModule(b: *std.Build, options: BuildOptions) *std.Build.Module 
     });
 }
 
-fn addSdlTranslateCWorkarounds(module: *std.Build.Module, target: std.Build.ResolvedTarget) void {
-    if (target.result.os.tag != .windows or target.result.abi != .msvc) return;
+fn sdlTranslateCMacros(target: std.Build.ResolvedTarget) []const maplibre_build.CMacro {
+    if (target.result.os.tag != .windows or target.result.abi != .msvc) return &.{};
+    return &.{
+        .{ .name = "SIZE_MAX", .value = "((size_t)-1)" },
+        .{ .name = "SDL_SINT64_C(c)", .value = "c##LL" },
+        .{ .name = "SDL_UINT64_C(c)", .value = "c##ULL" },
+    };
+}
 
-    // Zig 0.16 translate-c cannot parse MSVC's non-standard i64/ui64 integer
-    // literal suffixes when SDL3 headers expose them through @cImport. Keep the
-    // workaround local to zig-map: it is the only Zig target that imports SDL.
-    module.addCMacro("SIZE_MAX", "((size_t)-1)");
-    module.addCMacro("SDL_SINT64_C(c)", "c##LL");
-    module.addCMacro("SDL_UINT64_C(c)", "c##ULL");
+fn cBindingsHeader(b: *std.Build, backend: maplibre_build.RenderBackend) std.Build.LazyPath {
+    return switch (backend) {
+        .metal => b.path("c_metal.h"),
+        .opengl => b.path("c_opengl.h"),
+        .vulkan => b.path("c_vulkan.h"),
+    };
 }
 
 fn addZigMapExample(b: *std.Build, options: BuildOptions) *std.Build.Step.Compile {
@@ -50,7 +56,13 @@ fn addZigMapExample(b: *std.Build, options: BuildOptions) *std.Build.Step.Compil
 
     maplibre_build.addRenderBackendOptions(b, root_module, options.render_backend);
     maplibre_build.addIncludePaths(root_module, options.include_dirs);
-    addSdlTranslateCWorkarounds(root_module, options.target);
+    root_module.addImport("c", maplibre_build.translateCModule(b, .{
+        .root_source_file = cBindingsHeader(b, options.render_backend),
+        .target = options.target,
+        .optimize = options.optimize,
+        .include_dirs = options.include_dirs,
+        .c_macros = sdlTranslateCMacros(options.target),
+    }));
     root_module.addImport("maplibre_native", maplibreNativeModule(b, options));
     if (options.render_backend == .opengl) {
         const gl_bindings = zigglgen.generateBindingsModule(b, if (options.target.result.os.tag == .linux or options.target.result.os.tag == .macos)

--- a/examples/zig-map/build.zig
+++ b/examples/zig-map/build.zig
@@ -22,15 +22,6 @@ fn maplibreNativeModule(b: *std.Build, options: BuildOptions) *std.Build.Module 
     });
 }
 
-fn sdlTranslateCMacros(target: std.Build.ResolvedTarget) []const maplibre_build.CMacro {
-    if (target.result.os.tag != .windows or target.result.abi != .msvc) return &.{};
-    return &.{
-        .{ .name = "SIZE_MAX", .value = "((size_t)-1)" },
-        .{ .name = "SDL_SINT64_C(c)", .value = "c##LL" },
-        .{ .name = "SDL_UINT64_C(c)", .value = "c##ULL" },
-    };
-}
-
 fn cBindingsHeader(b: *std.Build, backend: maplibre_build.RenderBackend) std.Build.LazyPath {
     return switch (backend) {
         .metal => b.path("c_metal.h"),
@@ -57,7 +48,7 @@ fn addZigMapExample(b: *std.Build, options: BuildOptions) *std.Build.Step.Compil
         .target = options.target,
         .optimize = options.optimize,
         .include_dirs = options.include_dirs,
-        .c_macros = sdlTranslateCMacros(options.target),
+        .c_macros = maplibre_build.sdlTranslateCMacros(options.target),
     }));
     root_module.addImport("maplibre_native", maplibreNativeModule(b, options));
     if (options.render_backend == .opengl) {

--- a/examples/zig-map/c.zig
+++ b/examples/zig-map/c.zig
@@ -1,12 +1,6 @@
 const build_options = @import("build_options");
 
-pub const c = if (build_options.supports_metal) @cImport({
-    @cInclude("SDL3/SDL.h");
-    @cInclude("SDL3/SDL_metal.h");
-}) else if (build_options.supports_vulkan) @cImport({
-    @cInclude("SDL3/SDL.h");
-    @cInclude("SDL3/SDL_vulkan.h");
-    @cInclude("vulkan/vulkan.h");
-}) else if (build_options.supports_opengl) @cImport({
-    @cInclude("SDL3/SDL.h");
-}) else @compileError("zig-map currently supports Metal, OpenGL, and Vulkan variants");
+pub const c = if (build_options.supports_metal or build_options.supports_vulkan or build_options.supports_opengl)
+    @import("c")
+else
+    @compileError("zig-map currently supports Metal, OpenGL, and Vulkan variants");

--- a/examples/zig-map/c_metal.h
+++ b/examples/zig-map/c_metal.h
@@ -1,0 +1,2 @@
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_metal.h>

--- a/examples/zig-map/c_opengl.h
+++ b/examples/zig-map/c_opengl.h
@@ -1,0 +1,1 @@
+#include <SDL3/SDL.h>

--- a/examples/zig-map/c_vulkan.h
+++ b/examples/zig-map/c_vulkan.h
@@ -1,0 +1,3 @@
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_vulkan.h>
+#include <vulkan/vulkan.h>

--- a/examples/zig-readback/build.zig
+++ b/examples/zig-readback/build.zig
@@ -21,12 +21,25 @@ fn maplibreNativeModule(b: *std.Build, options: BuildOptions) *std.Build.Module 
     });
 }
 
-fn addSdlTranslateCWorkarounds(module: *std.Build.Module, target: std.Build.ResolvedTarget) void {
-    if (target.result.os.tag != .windows or target.result.abi != .msvc) return;
+fn sdlTranslateCMacros(target: std.Build.ResolvedTarget) []const maplibre_build.CMacro {
+    if (target.result.os.tag != .windows or target.result.abi != .msvc) return &.{};
+    return &.{
+        .{ .name = "SIZE_MAX", .value = "((size_t)-1)" },
+        .{ .name = "SDL_SINT64_C(c)", .value = "c##LL" },
+        .{ .name = "SDL_UINT64_C(c)", .value = "c##ULL" },
+    };
+}
 
-    module.addCMacro("SIZE_MAX", "((size_t)-1)");
-    module.addCMacro("SDL_SINT64_C(c)", "c##LL");
-    module.addCMacro("SDL_UINT64_C(c)", "c##ULL");
+fn addSdlTranslateC(b: *std.Build, module: *std.Build.Module, options: BuildOptions) void {
+    if (options.render_backend == .opengl and options.target.result.os.tag == .windows) {
+        module.addImport("sdl", maplibre_build.translateCModule(b, .{
+            .root_source_file = b.path("sdl_bindings.h"),
+            .target = options.target,
+            .optimize = options.optimize,
+            .include_dirs = options.include_dirs,
+            .c_macros = sdlTranslateCMacros(options.target),
+        }));
+    }
 }
 
 fn addReadbackExample(b: *std.Build, options: BuildOptions) *std.Build.Step.Compile {
@@ -41,8 +54,14 @@ fn addReadbackExample(b: *std.Build, options: BuildOptions) *std.Build.Step.Comp
 
     maplibre_build.addRenderBackendOptions(b, example.root_module, options.render_backend);
     maplibre_build.addIncludePaths(example.root_module, options.include_dirs);
+    maplibre_build.addRenderBackendTranslateC(b, example.root_module, .{
+        .target = options.target,
+        .optimize = options.optimize,
+        .include_dirs = options.include_dirs,
+        .render_backend = options.render_backend,
+    });
+    addSdlTranslateC(b, example.root_module, options);
     if (options.render_backend == .opengl and options.target.result.os.tag == .windows) {
-        addSdlTranslateCWorkarounds(example.root_module, options.target);
         for (options.dependency_library_dirs) |dependency_library_dir| {
             example.root_module.addLibraryPath(dependency_library_dir);
             example.root_module.addRPath(dependency_library_dir);

--- a/examples/zig-readback/build.zig
+++ b/examples/zig-readback/build.zig
@@ -21,15 +21,6 @@ fn maplibreNativeModule(b: *std.Build, options: BuildOptions) *std.Build.Module 
     });
 }
 
-fn sdlTranslateCMacros(target: std.Build.ResolvedTarget) []const maplibre_build.CMacro {
-    if (target.result.os.tag != .windows or target.result.abi != .msvc) return &.{};
-    return &.{
-        .{ .name = "SIZE_MAX", .value = "((size_t)-1)" },
-        .{ .name = "SDL_SINT64_C(c)", .value = "c##LL" },
-        .{ .name = "SDL_UINT64_C(c)", .value = "c##ULL" },
-    };
-}
-
 fn addSdlTranslateC(b: *std.Build, module: *std.Build.Module, options: BuildOptions) void {
     if (options.render_backend == .opengl and options.target.result.os.tag == .windows) {
         module.addImport("sdl", maplibre_build.translateCModule(b, .{
@@ -37,7 +28,7 @@ fn addSdlTranslateC(b: *std.Build, module: *std.Build.Module, options: BuildOpti
             .target = options.target,
             .optimize = options.optimize,
             .include_dirs = options.include_dirs,
-            .c_macros = sdlTranslateCMacros(options.target),
+            .c_macros = maplibre_build.sdlTranslateCMacros(options.target),
         }));
     }
 }

--- a/examples/zig-readback/main.zig
+++ b/examples/zig-readback/main.zig
@@ -5,21 +5,13 @@ const maplibre = @import("maplibre_native");
 
 extern "c" fn MTLCreateSystemDefaultDevice() ?*anyopaque;
 
-const vk = if (build_options.supports_vulkan) @cImport({
-    @cInclude("vulkan/vulkan.h");
-}) else struct {};
+const vk = if (build_options.supports_vulkan) @import("vulkan") else struct {};
 
 const supports_egl = build_options.supports_opengl and (builtin.os.tag == .linux or builtin.os.tag == .macos);
 
-const egl = if (supports_egl) @cImport({
-    @cDefine("EGL_EGLEXT_PROTOTYPES", "1");
-    @cInclude("EGL/egl.h");
-    @cInclude("EGL/eglext.h");
-}) else struct {};
+const egl = if (supports_egl) @import("egl") else struct {};
 
-const sdl = if (build_options.supports_opengl and builtin.os.tag == .windows) @cImport({
-    @cInclude("SDL3/SDL.h");
-}) else struct {};
+const sdl = if (build_options.supports_opengl and builtin.os.tag == .windows) @import("sdl") else struct {};
 
 const width = 512;
 const height = 512;

--- a/examples/zig-readback/sdl_bindings.h
+++ b/examples/zig-readback/sdl_bindings.h
@@ -1,0 +1,1 @@
+#include <SDL3/SDL.h>

--- a/src/c_api/tests/zig/README.md
+++ b/src/c_api/tests/zig/README.md
@@ -1,8 +1,8 @@
 # Raw Zig C ABI tests
 
-These tests exercise `maplibre_native_c.h` directly through Zig `@cImport`. They
-stay below the public Zig binding so they can cover raw ABI behavior that the
-binding hides on purpose.
+These tests exercise `maplibre_native_c.h` directly through Zig's translated C
+module. They stay below the public Zig binding so they can cover raw ABI
+behavior that the binding hides on purpose.
 
 Keep tests here only when they need unsafe C ABI shapes that the binding cannot
 construct: null input or output pointers, undersized structs, unknown raw enum

--- a/src/c_api/tests/zig/build.zig
+++ b/src/c_api/tests/zig/build.zig
@@ -20,6 +20,12 @@ fn addCTests(b: *std.Build, options: BuildOptions) *std.Build.Step.Compile {
         }),
     });
     maplibre_build.addRenderBackendOptions(b, c_tests.root_module, options.render_backend);
+    maplibre_build.addRenderBackendTranslateC(b, c_tests.root_module, .{
+        .target = options.target,
+        .optimize = options.optimize,
+        .include_dirs = options.include_dirs,
+        .render_backend = options.render_backend,
+    });
     if (options.target.result.os.tag == .windows or options.target.result.os.tag == .linux or options.target.result.os.tag == .macos) {
         const gl_bindings = zigglgen.generateBindingsModule(b, if (options.target.result.os.tag == .linux or options.target.result.os.tag == .macos)
             .{ .api = .gles, .version = .@"3.0" }
@@ -38,6 +44,7 @@ fn addCTests(b: *std.Build, options: BuildOptions) *std.Build.Step.Compile {
     }
     maplibre_build.linkMaplibreNativeC(b, c_tests.root_module, .{
         .target = options.target,
+        .optimize = options.optimize,
         .cmake_artifact_dir = options.cmake_artifact_dir,
         .render_backend = options.render_backend,
         .include_dirs = options.include_dirs,

--- a/src/c_api/tests/zig/support.zig
+++ b/src/c_api/tests/zig/support.zig
@@ -3,21 +3,13 @@ const builtin = @import("builtin");
 const build_options = @import("build_options");
 const testing = std.testing;
 
-pub const c = @cImport({
-    @cInclude("maplibre_native_c.h");
-});
+pub const c = @import("maplibre_native_c");
 
-const vk = if (build_options.supports_vulkan) @cImport({
-    @cInclude("vulkan/vulkan.h");
-}) else struct {};
+const vk = if (build_options.supports_vulkan) @import("vulkan") else struct {};
 
 const supports_egl = build_options.supports_opengl and (builtin.os.tag == .linux or builtin.os.tag == .macos);
 
-const egl = if (supports_egl) @cImport({
-    @cDefine("EGL_EGLEXT_PROTOTYPES", "1");
-    @cInclude("EGL/egl.h");
-    @cInclude("EGL/eglext.h");
-}) else struct {};
+const egl = if (supports_egl) @import("egl") else struct {};
 
 const wgl_test = if (build_options.supports_opengl and builtin.os.tag == .windows) @import("wgl_test_context") else struct {};
 


### PR DESCRIPTION
Zig is removing direct cImport, and moving that functionality to the build system instead.

More info here: https://codeberg.org/ziglang/zig/pulls/31892

resolves #206.