### PR TITLE
[codex] Remove Linux libopengl Pixi dependency

### DIFF
--- a/cmake/render/opengl.cmake
+++ b/cmake/render/opengl.cmake
@@ -41,7 +41,7 @@ function(mln_configure_opengl_backend target)
           ${MLN_FFI_ANDROID_EGL_LIBRARY} ${MLN_FFI_ANDROID_GLESV3_LIBRARY}
           ${CMAKE_DL_LIBS})
     else()
-      find_package(OpenGL REQUIRED EGL)
+      find_package(OpenGL REQUIRED COMPONENTS EGL GLES3)
       target_link_libraries(${target} PRIVATE OpenGL::EGL ${CMAKE_DL_LIBS})
     endif()
     list(APPEND MLN_FFI_VENDOR_OPENGL_SOURCES

--- a/pixi.lock
+++ b/pixi.lock
@@ -51,8 +51,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
@@ -140,8 +138,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.5-h86ecc28_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-devel-1.7.0-hd24410f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
@@ -710,24 +706,6 @@ packages:
   license_family: BSD
   size: 218500
   timestamp: 1745825989535
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
-  sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
-  md5: 7df50d44d4a14d6c31a2c54f2cd92157
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  license: LicenseRef-libglvnd
-  size: 50757
-  timestamp: 1731330993524
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-devel-1.7.0-ha4b6fd6_2.conda
-  sha256: b347798eba61ce8d7a65372cf0cf6066c328e5717ab69ae251c6822e6f664f23
-  md5: 75b039b1e51525f4572f828be8441970
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libopengl 1.7.0 ha4b6fd6_2
-  license: LicenseRef-libglvnd
-  size: 15460
-  timestamp: 1731331007610
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
   sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
   md5: 2446ac1fe030c2aa6141386c1f5a6aed
@@ -1695,22 +1673,6 @@ packages:
   license_family: BSD
   size: 220653
   timestamp: 1745826021156
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_2.conda
-  sha256: e359df399fb2f308774237384414e318fac8870c1bf6481bdc67ae16e0bd2a02
-  md5: cf9d12bfab305e48d095a4c79002c922
-  depends:
-  - libglvnd 1.7.0 hd24410f_2
-  license: LicenseRef-libglvnd
-  size: 56355
-  timestamp: 1731331001820
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-devel-1.7.0-hd24410f_2.conda
-  sha256: 1b108b3ea9b0b9ae2b14638702ca391f89d9f2ffcd1772cfe704007221f6e9d9
-  md5: c758a285b03a6d339911347f2b03728d
-  depends:
-  - libopengl 1.7.0 hd24410f_2
-  license: LicenseRef-libglvnd
-  size: 15554
-  timestamp: 1731331011229
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.6.1-h80f16a2_0.conda
   sha256: 059214f037fa5e51080f5aced39466993b2311a01d871086bd6d2a59bfbf59b5
   md5: c781f98ca7b987f968369bc768b2cd55

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,8 +24,6 @@ libjpeg-turbo = ">=3.1,<4"
 libpng = ">=1.6,<2"
 libuv = ">=1,<2"
 libwebp = ">=1.6,<2"
-libegl-devel = ">=1.7.0,<2"
-libopengl-devel = ">=1.7.0,<2"
 libgles-devel = ">=1.7.0,<2"
 
 [target.linux-aarch64.dependencies]
@@ -35,8 +33,6 @@ libjpeg-turbo = ">=3.1,<4"
 libpng = ">=1.6,<2"
 libuv = ">=1,<2"
 libwebp = ">=1.6,<2"
-libegl-devel = ">=1.7.0,<2"
-libopengl-devel = ">=1.7.0,<2"
 libgles-devel = ">=1.7.0,<2"
 
 [target.osx-arm64.dependencies]


### PR DESCRIPTION
## Summary
Remove Linux `libopengl-devel` from Pixi by requesting EGL plus GLES3 from CMake's OpenGL finder.

## Test plan
Validated on Fedora VM with a fresh Pixi env and `mise -E linux-arm64-egl run configure && mise -E linux-arm64-egl run build`.
