### PR TITLE
[codex] Add Windows ARM64 mise lock platform

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -324,6 +324,10 @@ url = "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3-lin
 checksum = "sha256:5221a13450c7a0219a2a0d1b6c9085eb06489721fafd8488ccebc1584175d2fb"
 url = "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3-macos-universal.tar.gz"
 
+[tools."aqua:Kitware/CMake"."platforms.windows-arm64"]
+checksum = "sha256:db6e902b5ba6a08d0abed136763c4bd95adda17e882d659c0f5d14fe158f7395"
+url = "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3-windows-arm64.zip"
+
 [tools."aqua:Kitware/CMake"."platforms.windows-x64"]
 checksum = "sha256:935ade9e5e8723583c07f44c5592cea2a1c8f65c56ca7e07b34c025c880e0bd6"
 url = "https://github.com/Kitware/CMake/releases/download/v4.3.3/cmake-4.3.3-windows-x86_64.zip"
@@ -352,6 +356,10 @@ url = "https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64"
 checksum = "sha256:349402ae32c35382c034b0c0af744ffb0d53a213888c44deec94a7810e144889"
 url = "https://github.com/apple/pkl/releases/download/0.31.0/pkl-macos-aarch64"
 
+[tools."aqua:apple/pkl"."platforms.windows-arm64"]
+checksum = "sha256:37d35ce8a165766502fb13799071d4cefa84d39fb455c75c471b47b9b5d12b04"
+url = "https://github.com/apple/pkl/releases/download/0.31.0/pkl-windows-amd64.exe"
+
 [tools."aqua:apple/pkl"."platforms.windows-x64"]
 checksum = "sha256:37d35ce8a165766502fb13799071d4cefa84d39fb455c75c471b47b9b5d12b04"
 url = "https://github.com/apple/pkl/releases/download/0.31.0/pkl-windows-amd64.exe"
@@ -375,6 +383,11 @@ checksum = "sha256:3a185bf8f46a7b7c8b910d111825907b1638d0ae503cb3c333ae205772354
 url = "https://github.com/astral-sh/uv/releases/download/0.11.11/uv-aarch64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
+[tools."aqua:astral-sh/uv"."platforms.windows-arm64"]
+checksum = "sha256:2f75a0db2c3530b6b3c24434dc38137f61ff1f4e5f2d7b4ddc5bcd142cf58b65"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.11/uv-x86_64-pc-windows-msvc.zip"
+provenance = "github-attestations"
+
 [tools."aqua:astral-sh/uv"."platforms.windows-x64"]
 checksum = "sha256:2f75a0db2c3530b6b3c24434dc38137f61ff1f4e5f2d7b4ddc5bcd142cf58b65"
 url = "https://github.com/astral-sh/uv/releases/download/0.11.11/uv-x86_64-pc-windows-msvc.zip"
@@ -396,6 +409,10 @@ url = "https://github.com/dprint/dprint/releases/download/0.53.2/dprint-x86_64-u
 checksum = "sha256:a185ba53f74e1e3a8ccdaf03a5d6f96b67d3fdf3f86d0d0f98950d15817eb0c4"
 url = "https://github.com/dprint/dprint/releases/download/0.53.2/dprint-aarch64-apple-darwin.zip"
 
+[tools."aqua:dprint/dprint"."platforms.windows-arm64"]
+checksum = "sha256:f18910879d6796b05b0666513391ab7963b346723c041dc4d777d3f43179e416"
+url = "https://github.com/dprint/dprint/releases/download/0.53.2/dprint-x86_64-pc-windows-msvc.zip"
+
 [tools."aqua:dprint/dprint"."platforms.windows-x64"]
 checksum = "sha256:f18910879d6796b05b0666513391ab7963b346723c041dc4d777d3f43179e416"
 url = "https://github.com/dprint/dprint/releases/download/0.53.2/dprint-x86_64-pc-windows-msvc.zip"
@@ -413,6 +430,10 @@ checksum = "sha256:f39bf9a1f520d27f86f2bdf4d6dbb2574c05e84f656171ed65c4e534b86b9
 url = "https://github.com/facebook/ktfmt/releases/download/v0.62/ktfmt-0.62-with-dependencies.jar"
 
 [tools."aqua:facebook/ktfmt"."platforms.macos-arm64"]
+checksum = "sha256:f39bf9a1f520d27f86f2bdf4d6dbb2574c05e84f656171ed65c4e534b86b9965"
+url = "https://github.com/facebook/ktfmt/releases/download/v0.62/ktfmt-0.62-with-dependencies.jar"
+
+[tools."aqua:facebook/ktfmt"."platforms.windows-arm64"]
 checksum = "sha256:f39bf9a1f520d27f86f2bdf4d6dbb2574c05e84f656171ed65c4e534b86b9965"
 url = "https://github.com/facebook/ktfmt/releases/download/v0.62/ktfmt-0.62-with-dependencies.jar"
 
@@ -436,6 +457,10 @@ url = "https://github.com/google/google-java-format/releases/download/v1.35.0/go
 checksum = "sha256:563f066c324687885b5f4039325f8952fbb9aaf3d67c68e0b2eafccc8069d3b8"
 url = "https://github.com/google/google-java-format/releases/download/v1.35.0/google-java-format_darwin-arm64"
 
+[tools."aqua:google/google-java-format"."platforms.windows-arm64"]
+checksum = "sha256:2451e70f7805ce51dc026c0ca6b76b689b20c99c5e5769412ae5235f59f3a427"
+url = "https://github.com/google/google-java-format/releases/download/v1.35.0/google-java-format_windows-x86-64.exe"
+
 [tools."aqua:google/google-java-format"."platforms.windows-x64"]
 checksum = "sha256:2451e70f7805ce51dc026c0ca6b76b689b20c99c5e5769412ae5235f59f3a427"
 url = "https://github.com/google/google-java-format/releases/download/v1.35.0/google-java-format_windows-x86-64.exe"
@@ -455,6 +480,10 @@ url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-x86_64-unknown-lin
 [tools."aqua:jdx/hk"."platforms.macos-arm64"]
 checksum = "sha256:17bd1d9eccbfc894c4b0191871a964dc67df80c1bfbee072e5c12d4bb893a8a6"
 url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-aarch64-apple-darwin.tar.gz"
+
+[tools."aqua:jdx/hk"."platforms.windows-arm64"]
+checksum = "sha256:6ba41fab25ed0c3c01fb1accb25e7d2eb71c67dea6362b7f7933f43fec4455f6"
+url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-aarch64-pc-windows-msvc.zip"
 
 [tools."aqua:jdx/hk"."platforms.windows-x64"]
 checksum = "sha256:94c7c460d05748524a96583b656e8dec31a11a30ce6a997b9a5b5d8ec4d1b7e7"
@@ -476,6 +505,10 @@ url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-unknow
 checksum = "sha256:ab6c69a6541e18ffca7bd950dd4cc867ea9267d0f91115c13aa650cde6634d62"
 url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-universal-apple-darwin.tar.gz"
 
+[tools."aqua:jdx/usage"."platforms.windows-arm64"]
+checksum = "sha256:dbd715edae475941a306b247d285163f62970a4f966988ea66d772d8ec5777d4"
+url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-aarch64-pc-windows-msvc.zip"
+
 [tools."aqua:jdx/usage"."platforms.windows-x64"]
 checksum = "sha256:628b8743d552f2cff2dee2b783a4827ef555409def3fb9ec536117d96cda2018"
 url = "https://github.com/jdx/usage/releases/download/v3.3.0/usage-x86_64-pc-windows-msvc.zip"
@@ -495,6 +528,10 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 [tools."aqua:koalaman/shellcheck"."platforms.macos-arm64"]
 checksum = "sha256:56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz"
+
+[tools."aqua:koalaman/shellcheck"."platforms.windows-arm64"]
+checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
+url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.zip"
 
 [tools."aqua:koalaman/shellcheck"."platforms.windows-x64"]
 checksum = "sha256:8a4e35ab0b331c85d73567b12f2a444df187f483e5079ceffa6bda1faa2e740e"
@@ -516,6 +553,10 @@ url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-linu
 checksum = "sha256:c99048673aa765960a99cf10c6ddb9f1fad506099ff0a0e137ad8960a88f321b"
 url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-mac.zip"
 
+[tools."aqua:ninja-build/ninja"."platforms.windows-arm64"]
+checksum = "sha256:e52f0bdef9dfb1003229dbd6508a508c4073fd017247002adc66e5e806cb0391"
+url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-winarm64.zip"
+
 [tools."aqua:ninja-build/ninja"."platforms.windows-x64"]
 checksum = "sha256:07fc8261b42b20e71d1720b39068c2e14ffcee6396b76fb7a795fb460b78dc65"
 url = "https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-win.zip"
@@ -536,6 +577,10 @@ url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-x64"
 checksum = "sha256:a99a4d5d0e6bd3728949c24ff74a2f2f2d07f73bc48fd308e4eea75d8e72acdc"
 url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-macos-arm64"
 
+[tools."aqua:pnpm/pnpm"."platforms.windows-arm64"]
+checksum = "sha256:3d1af71e9da7081efd58f95942e1f7e2107bf8fcdae03eb2331c0b6cea59510b"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-win-x64.exe"
+
 [tools."aqua:pnpm/pnpm"."platforms.windows-x64"]
 checksum = "sha256:3d1af71e9da7081efd58f95942e1f7e2107bf8fcdae03eb2331c0b6cea59510b"
 url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-win-x64.exe"
@@ -555,6 +600,10 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.8/actionlint_1
 [tools."aqua:rhysd/actionlint"."platforms.macos-arm64"]
 checksum = "sha256:ffb1f6c429a51dc9f37af9d11f96c16bd52f54b713bf7f8bd92f7fce9fd4284a"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.8/actionlint_1.7.8_darwin_arm64.tar.gz"
+
+[tools."aqua:rhysd/actionlint"."platforms.windows-arm64"]
+checksum = "sha256:76cbb407e2de15df97969aae51d6fb46aaae9e73a48da06b1c3157cb9f2ee766"
+url = "https://github.com/rhysd/actionlint/releases/download/v1.7.8/actionlint_1.7.8_windows_arm64.zip"
 
 [tools."aqua:rhysd/actionlint"."platforms.windows-x64"]
 checksum = "sha256:8cae2385eb69b93084ea2e6a4bce57233feb56ab16b3087bea25cbc0abadb0cc"
@@ -924,6 +973,14 @@ url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/41828687
 [tools."github:prefix-dev/pixi"."platforms.macos-arm64".provenance.slsa]
 url = "https://github.com/prefix-dev/pixi/releases/download/v0.68.1/attestations-aarch64-apple-darwin.intoto.jsonl"
 
+[tools."github:prefix-dev/pixi"."platforms.windows-arm64"]
+checksum = "sha256:fbd58f6f0247b14b3df4e06a0763ed2c366dbbd874fbf1aebef0a5f782c42753"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.68.1/pixi-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/418286891"
+
+[tools."github:prefix-dev/pixi"."platforms.windows-arm64".provenance.slsa]
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.68.1/attestations-aarch64-pc-windows-msvc.intoto.jsonl"
+
 [tools."github:prefix-dev/pixi"."platforms.windows-x64"]
 checksum = "sha256:71de85bd7cbf645f43a7381f1396e35a6764d508668785a46dd88d67323745b3"
 url = "https://github.com/prefix-dev/pixi/releases/download/v0.68.1/pixi-x86_64-pc-windows-msvc.zip"
@@ -951,6 +1008,11 @@ checksum = "sha256:d0085ecd250c56a65cc33aa371d59ecf856e7e338960f3e80cb1a953ff2d8
 url = "https://github.com/sargunv/jvl/releases/download/v2026.05.03/jvl-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/sargunv/jvl/releases/assets/411400582"
 
+[tools."github:sargunv/jvl"."platforms.windows-arm64"]
+checksum = "sha256:fd641debbac338b8cd59869b06ad77f95ff462c8d5d00dd046bd2af18e399440"
+url = "https://github.com/sargunv/jvl/releases/download/v2026.05.03/jvl-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/sargunv/jvl/releases/assets/411400581"
+
 [tools."github:sargunv/jvl"."platforms.windows-x64"]
 checksum = "sha256:adf29d4f9ff98b21492590d8887689093ea521792dbbbe80e032eb6ec37149e9"
 url = "https://github.com/sargunv/jvl/releases/download/v2026.05.03/jvl-x86_64-pc-windows-msvc.zip"
@@ -971,6 +1033,10 @@ url = "https://dl.google.com/go/go1.26.3.linux-amd64.tar.gz"
 [tools.go."platforms.macos-arm64"]
 checksum = "sha256:875cf54a15311eee2c99b9dd67c68c4a49351d489ab622bf2cfd28c8f2078d3c"
 url = "https://dl.google.com/go/go1.26.3.darwin-arm64.tar.gz"
+
+[tools.go."platforms.windows-arm64"]
+checksum = "sha256:95cd63bc6b0da77409ba819215afea9ddf5702c55a3b20af3dd90ea95c7b130c"
+url = "https://dl.google.com/go/go1.26.3.windows-arm64.zip"
 
 [tools.go."platforms.windows-x64"]
 checksum = "sha256:20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d3224a"
@@ -1012,6 +1078,10 @@ url = "https://nodejs.org/dist/v24.11.0/node-v24.11.0-linux-x64.tar.gz"
 checksum = "sha256:0be2ab2816a4fa02d1acff014a434f29f56d8d956f5af6a98b70ced6c5f4d201"
 url = "https://nodejs.org/dist/v24.11.0/node-v24.11.0-darwin-arm64.tar.gz"
 
+[tools.node."platforms.windows-arm64"]
+checksum = "sha256:12d3b1aa9696b7411e115a4fa2aef57f95560b5ee16bb62cd69843e535ec72be"
+url = "https://nodejs.org/dist/v24.11.0/node-v24.11.0-win-arm64.zip"
+
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:1054540bce22b54ec7e50ebc078ec5d090700a77657607a58f6a64df21f49fdd"
 url = "https://nodejs.org/dist/v24.11.0/node-v24.11.0-win-x64.zip"
@@ -1033,6 +1103,11 @@ provenance = "github-attestations"
 [tools.python."platforms.macos-arm64"]
 checksum = "sha256:6f304f4ec30854611f23316578302235fb517cd970519ecdd11a8c4db87fd843"
 url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-aarch64-apple-darwin-install_only_stripped.tar.gz"
+provenance = "github-attestations"
+
+[tools.python."platforms.windows-arm64"]
+checksum = "sha256:d0cf4212d08a34ecdd614bc655d6502afcf61ce16cf5f566fca6c63884a9d1df"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-aarch64-pc-windows-msvc-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.windows-x64"]
@@ -1077,6 +1152,11 @@ checksum = "sha256:b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c
 url = "https://github.com/nicklockwood/SwiftFormat/releases/download/0.61.1/swiftformat.zip"
 url_api = "https://api.github.com/repos/nicklockwood/SwiftFormat/releases/assets/406639783"
 
+[tools.swiftformat."platforms.windows-arm64"]
+checksum = "sha256:6c59015fc50224a0e67e8a463d8f194481806d4b514619d4f2f1d3ec830b517a"
+url = "https://github.com/nicklockwood/SwiftFormat/releases/download/0.61.1/SwiftFormat.arm64.msi"
+url_api = "https://api.github.com/repos/nicklockwood/SwiftFormat/releases/assets/406642520"
+
 [tools.swiftformat."platforms.windows-x64"]
 checksum = "sha256:709779781c37d0f4020b5e3fa8ade4070340c37b980f3826b84d61c35ccb6a25"
 url = "https://github.com/nicklockwood/SwiftFormat/releases/download/0.61.1/SwiftFormat.amd64.msi"
@@ -1099,6 +1179,10 @@ provenance = "minisign"
 [tools.zig."platforms.macos-arm64"]
 checksum = "sha256:b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489"
 url = "https://ziglang.org/download/0.16.0/zig-aarch64-macos-0.16.0.tar.xz"
+
+[tools.zig."platforms.windows-arm64"]
+checksum = "sha256:aee38316ee4111717900f45dd3130145c39289e105541d737eb8c5ed653c78ef"
+url = "https://ziglang.org/download/0.16.0/zig-aarch64-windows-0.16.0.zip"
 
 [tools.zig."platforms.windows-x64"]
 checksum = "sha256:68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e"

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,13 @@ experimental_monorepo_root = true
 
 [settings]
 lockfile = true
-lockfile_platforms = ["linux-x64", "linux-arm64", "macos-arm64", "windows-x64"]
+lockfile_platforms = [
+  "linux-x64",
+  "linux-arm64",
+  "macos-arm64",
+  "windows-x64",
+  "windows-arm64",
+]
 pin = true
 experimental = true
 python.uv_venv_auto = "create|source"
@@ -35,13 +41,13 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 "github:prefix-dev/pixi" = "0.68.1"
 "aqua:Kitware/CMake" = "4.3.3"
 "aqua:ninja-build/ninja" = "1.13.2"
-"conda:clang-format" = "22.1.7"
-"conda:clang-tools" = "22.1.7"
-"conda:doxygen" = "1.13.2"
-"conda:glslang" = "16.3.0"
-"conda:pkg-config" = "0.29.2"
-"conda:vulkan-tools" = "1.4.341.0"
-"github:cmakefmt/cmakefmt" = "1.3.0"
+"conda:clang-format" = { version = "22.1.7", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
+"conda:clang-tools" = { version = "22.1.7", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
+"conda:doxygen" = { version = "1.13.2", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
+"conda:glslang" = { version = "16.3.0", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
+"conda:pkg-config" = { version = "0.29.2", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
+"conda:vulkan-tools" = { version = "1.4.341.0", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
+"github:cmakefmt/cmakefmt" = { version = "1.3.0", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 release asset
 "aqua:XcodesOrg/xcodes" = { version = "1.6.2", os = ["macos"] }
 
 # Node.js ecosystem
@@ -49,7 +55,7 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 "aqua:pnpm/pnpm" = "10.33.2"
 
 # Java/Kotlin ecosystem
-"core:java" = "temurin-25.0.3+9.0.LTS"
+"core:java" = { version = "temurin-25.0.3+9.0.LTS", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 Temurin metadata
 "aqua:facebook/ktfmt" = "0.62"
 "aqua:google/google-java-format" = "1.35.0"
 


### PR DESCRIPTION
## Summary

Add Windows ARM64 to the mise lockfile platforms and mark unavailable tools as unsupported on that target.

This is an early step towards windows arm support; future PRs will work on making builds actually possible.

## Test plan

Ran `mise lock --platform windows-arm64 --dry-run` and `git diff --check HEAD~1..HEAD`.

## AI assistance

- **Tools:** Codex
- **Models:** GPT-5
- **Context:** Codex implemented the mise platform and lockfile update, resolved the rebase conflict, and opened this draft PR.
