### PR TITLE
[codex] Restore Java on Windows ARM

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -991,24 +991,28 @@ checksum = "sha256:20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d32
 url = "https://dl.google.com/go/go1.26.3.windows-amd64.zip"
 
 [[tools.java]]
-version = "temurin-25.0.3+9.0.LTS"
+version = "zulu-25.34.17.0"
 backend = "core:java"
 
 [tools.java."platforms.linux-arm64"]
-checksum = "sha256:3e4287cb98870ba824ed698854bdc27cff984254caf66dd12cc291e7bfdde26b"
-url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.3_9.tar.gz"
+checksum = "sha256:2610e5c64df94cee5fb591d70183c5bf8532d8e1d394c754e8ba06751bcceb1b"
+url = "https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-linux_aarch64.tar.gz"
 
 [tools.java."platforms.linux-x64"]
-checksum = "sha256:69264a7a211bf5029830d07bc3370f879769d62ebc5b5488e90c9343a2da0e1f"
-url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_linux_hotspot_25.0.3_9.tar.gz"
+checksum = "sha256:3a93235f4e5b313232647916219e91dc5cca0b9835c9b52a404ba58c43571697"
+url = "https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-linux_x64.tar.gz"
 
 [tools.java."platforms.macos-arm64"]
-checksum = "sha256:7baab4d69a15554e119b86ff78d40e3fdc28819b5b322955c913cebfe3f6a37c"
-url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.tar.gz"
+checksum = "sha256:74847e7ac930ad143950607421dd6c0a7ccb3d1cbbd8b1665f24ab62b8b7de42"
+url = "https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-macosx_aarch64.tar.gz"
+
+[tools.java."platforms.windows-arm64"]
+checksum = "sha256:60b6b1faa1a93fea8e64b09f2b9ab136a86b02428f004f8378cfb04cd818a0d4"
+url = "https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-win_aarch64.zip"
 
 [tools.java."platforms.windows-x64"]
-checksum = "sha256:709312cd0420296d9b9de917fe6e28a5b979e875ee5ab91783fb79bcd5857235"
-url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.zip"
+checksum = "sha256:ddd68ee54e78b6b19388f517b8a61fbed2856ae3320febe42449bac3021e2729"
+url = "https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-win_x64.zip"
 
 [[tools.node]]
 version = "24.11.0"

--- a/mise.toml
+++ b/mise.toml
@@ -54,7 +54,7 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 "aqua:pnpm/pnpm" = "10.33.2"
 
 # Java/Kotlin ecosystem
-"core:java" = { version = "temurin-25.0.3+9.0.LTS", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 Temurin metadata
+"core:java" = "zulu-25.34.17.0"
 "aqua:facebook/ktfmt" = "0.62"
 "aqua:google/google-java-format" = "1.35.0"
 


### PR DESCRIPTION
## Summary

Switch the mise-managed JDK from Temurin to Zulu so Java is available on Windows ARM64.

## Test plan

Ran `mise lock java`, `mise install java --dry-run --locked`, and `git diff --check`.

## AI assistance

- **Tools:** Codex
- **Models:** GPT-5
- **Context:** Used Codex to update the mise Java tool pin, regenerate the Java lockfile entries, validate the lockfile, and publish this PR.
