### PR TITLE
Use dprint cmakefmt plugin

### DIFF
--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -43,14 +43,6 @@
   "exec": {
     "commands": [
       {
-        "command": "cmakefmt --line-width {{line_width}} --tab-size {{indent_width}} -",
-        "exts": ["cmake"],
-      },
-      {
-        "command": "cmakefmt --line-width {{line_width}} --tab-size {{indent_width}} -",
-        "fileNames": ["cmakelists.txt", "cmakelists.txt.in"],
-      },
-      {
         "command": "mise run _ktfmt --google-style - --stdin-name={{file_path}}",
         "exts": ["kt", "kts"],
       },
@@ -79,6 +71,7 @@
   },
   "plugins": [
     "https://plugins.dprint.dev/sargunv/dprint-clang-format-0.1.0.wasm",
+    "https://plugins.dprint.dev/sargunv/dprint-cmakefmt-0.1.0.wasm",
     "https://plugins.dprint.dev/exec-0.6.2.json@df98f54ffd3092b8a841aedd6d098a2651f16d0a796a40535774f1a8b4b9d463",
     "https://plugins.dprint.dev/ruff-0.7.0.wasm",
     "https://plugins.dprint.dev/oxc-0.20.0.wasm",

--- a/mise.lock
+++ b/mise.lock
@@ -865,34 +865,6 @@ conda_deps = [
 version = "10.0.203"
 backend = "core:dotnet"
 
-[[tools."github:cmakefmt/cmakefmt"]]
-version = "1.3.0"
-backend = "github:cmakefmt/cmakefmt"
-
-[tools."github:cmakefmt/cmakefmt"."platforms.linux-arm64"]
-checksum = "sha256:85363f90d90939dd846fdc6ef65feb9ba1b6777a5733118a2e83781c896564bb"
-url = "https://github.com/cmakefmt/cmakefmt/releases/download/v1.3.0/cmakefmt-1.3.0-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/cmakefmt/cmakefmt/releases/assets/405499421"
-provenance = "github-attestations"
-
-[tools."github:cmakefmt/cmakefmt"."platforms.linux-x64"]
-checksum = "sha256:c914aebe64d0b3d2cfb82bf91bf9c2a7df6a73f69b42f01cd659e634935c1cae"
-url = "https://github.com/cmakefmt/cmakefmt/releases/download/v1.3.0/cmakefmt-1.3.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/cmakefmt/cmakefmt/releases/assets/405499413"
-provenance = "github-attestations"
-
-[tools."github:cmakefmt/cmakefmt"."platforms.macos-arm64"]
-checksum = "sha256:7c87caaa045eca0fa748378cc42c60045106021eb8f65f54fccccdb318dcf8c8"
-url = "https://github.com/cmakefmt/cmakefmt/releases/download/v1.3.0/cmakefmt-1.3.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/cmakefmt/cmakefmt/releases/assets/405499422"
-provenance = "github-attestations"
-
-[tools."github:cmakefmt/cmakefmt"."platforms.windows-x64"]
-checksum = "sha256:f036bdf5c712ec0ad7e1842cadb9d7c509f45bd05ecb9de5f4de067bbaab6eb4"
-url = "https://github.com/cmakefmt/cmakefmt/releases/download/v1.3.0/cmakefmt-1.3.0-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/cmakefmt/cmakefmt/releases/assets/405499418"
-provenance = "github-attestations"
-
 [[tools."github:prefix-dev/pixi"]]
 version = "0.68.1"
 backend = "github:prefix-dev/pixi"

--- a/mise.toml
+++ b/mise.toml
@@ -46,7 +46,6 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 "conda:glslang" = { version = "16.3.0", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
 "conda:pkg-config" = { version = "0.29.2", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
 "conda:vulkan-tools" = { version = "1.4.341.0", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 conda package
-"github:cmakefmt/cmakefmt" = { version = "1.3.0", os = ["linux", "macos", "windows/x64"] } # no Windows ARM64 release asset
 "aqua:XcodesOrg/xcodes" = { version = "1.6.2", os = ["macos"] }
 
 # Node.js ecosystem


### PR DESCRIPTION
## Summary
Use the `sargunv/dprint-cmakefmt` dprint plugin for CMake formatting and remove the now-unused standalone `cmakefmt` mise tool.

## Test plan
Ran targeted dprint checks for `dprint.jsonc`, `CMakeLists.txt`, and `cmake/**/*.cmake`, plus an intentional CMake misformat/fix smoke test before committing.