### PR TITLE
[codex] Add macOS EGL binding and example coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,13 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
       - run: mise run configure
       - run: mise run test
+      - run: mise run //bindings/dotnet:test
+      - run: mise run //bindings/kotlin:jvmTest
+      - run: mise run //bindings/kotlin:nativeTest
+      - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/lwjgl-map:build
+      - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-android-arm64-egl:
     name: variant / android-arm64-egl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
       - run: mise run //bindings/dotnet:test
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/kotlin:nativeTest
+      - run: mise run //bindings/rust:test
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -78,21 +78,19 @@ fn has_opengl_test_context_backend() -> bool {
         return false;
     }
 
-    let providers = crate::supported_opengl_context_providers();
     #[cfg(target_os = "linux")]
     {
-        providers.contains(OpenGLContextProviderMask::EGL)
+        crate::supported_opengl_context_providers().contains(OpenGLContextProviderMask::EGL)
     }
     #[cfg(target_os = "windows")]
     {
-        providers.contains(OpenGLContextProviderMask::WGL)
+        crate::supported_opengl_context_providers().contains(OpenGLContextProviderMask::WGL)
     }
     #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     {
         // The Rust test helper only implements Linux EGL and Windows WGL.
         // macOS EGL remains covered by bindings that can create a test context
         // and by the map examples until this helper grows a native EGL path.
-        let _ = providers;
         false
     }
 }

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -73,6 +73,30 @@ fn has_opengl_backend() -> bool {
     crate::supported_render_backends().contains(RenderBackendMask::OPENGL)
 }
 
+fn has_opengl_test_context_backend() -> bool {
+    if !has_opengl_backend() {
+        return false;
+    }
+
+    let providers = crate::supported_opengl_context_providers();
+    #[cfg(target_os = "linux")]
+    {
+        providers.contains(OpenGLContextProviderMask::EGL)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        providers.contains(OpenGLContextProviderMask::WGL)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        // The Rust test helper only implements Linux EGL and Windows WGL.
+        // macOS EGL remains covered by bindings that can create a test context
+        // and by the map examples until this helper grows a native EGL path.
+        let _ = providers;
+        false
+    }
+}
+
 fn create_opengl_owned_texture_session(
     map: &MapHandle,
     extent: RenderTargetExtent,
@@ -1308,7 +1332,7 @@ fn opengl_context_provider_mask_is_exposed_semantically() {
 #[test]
 // Spec coverage: BND-162.
 fn opengl_owned_texture_session_attaches_with_platform_context() {
-    if !has_opengl_backend() {
+    if !has_opengl_test_context_backend() {
         return;
     }
     let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
@@ -1348,7 +1372,7 @@ fn opengl_owned_texture_session_attaches_with_platform_context() {
 #[test]
 // Spec coverage: BND-162.
 fn opengl_surface_session_renders_with_platform_context() {
-    if !has_opengl_backend() {
+    if !has_opengl_test_context_backend() {
         return;
     }
     let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
@@ -1373,7 +1397,7 @@ fn opengl_surface_session_renders_with_platform_context() {
 #[test]
 // Spec coverage: BND-162 and BND-171.
 fn opengl_borrowed_texture_session_renders_with_platform_context() {
-    if !has_opengl_backend() {
+    if !has_opengl_test_context_backend() {
         return;
     }
     let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();

--- a/ci/subprojects/bindings-dotnet.toml
+++ b/ci/subprojects/bindings-dotnet.toml
@@ -1,3 +1,2 @@
 [requires]
-exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]

--- a/ci/subprojects/bindings-kotlin-jvm.toml
+++ b/ci/subprojects/bindings-kotlin-jvm.toml
@@ -2,7 +2,6 @@ label = "Kotlin/JVM"
 source_directory = "bindings/kotlin"
 
 [requires]
-exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]
 
 [ci]

--- a/ci/subprojects/bindings-kotlin-native.toml
+++ b/ci/subprojects/bindings-kotlin-native.toml
@@ -2,7 +2,7 @@ label = "Kotlin/Native"
 source_directory = "bindings/kotlin"
 
 [requires]
-exclude = ["linux-arm64-egl", "linux-arm64-vulkan", "macos-arm64-egl"]
+exclude = ["linux-arm64-egl", "linux-arm64-vulkan"]
 os = ["linux", "macos"]
 
 [ci]

--- a/ci/subprojects/bindings-rust.toml
+++ b/ci/subprojects/bindings-rust.toml
@@ -1,5 +1,2 @@
 [requires]
-# The Rust binding tests use glutin_egl_sys for their test-only EGL context, and
-# that crate does not expose EGL on Apple platforms.
-exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]

--- a/ci/subprojects/bindings-rust.toml
+++ b/ci/subprojects/bindings-rust.toml
@@ -1,3 +1,5 @@
 [requires]
+# The Rust binding tests use glutin_egl_sys for their test-only EGL context, and
+# that crate does not expose EGL on Apple platforms.
 exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]

--- a/ci/subprojects/bindings-swift.toml
+++ b/ci/subprojects/bindings-swift.toml
@@ -1,3 +1,2 @@
 [requires]
-exclude = ["macos-arm64-egl"]
 os = ["macos", "ios"]

--- a/ci/subprojects/examples-lwjgl-map.toml
+++ b/ci/subprojects/examples-lwjgl-map.toml
@@ -1,3 +1,2 @@
 [requires]
-exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]

--- a/ci/subprojects/examples-rust-map.toml
+++ b/ci/subprojects/examples-rust-map.toml
@@ -1,4 +1,6 @@
 [requires]
+# glutin disables its EGL backend on Apple platforms; adding macOS EGL would require a
+# separate EGL windowing path instead of the existing winit/glutin OpenGL pattern.
 exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]
 

--- a/ci/subprojects/examples-zig-map.toml
+++ b/ci/subprojects/examples-zig-map.toml
@@ -1,3 +1,2 @@
 [requires]
-exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -156,8 +156,11 @@ Graphics API selection follows one of these patterns:
   matches the active native build variant (for example `zig-map`, `rust-map`,
   `swift-map`).
 - **Multi-context examples** ship a graphics context per targeted API and select
-  the active API at startup from `supportedRenderBackends()` and platform policy
-  (for example `lwjgl-map`, `dotnet-map`).
+  the active API at startup from `supportedRenderBackends()` (for example
+  `lwjgl-map`, `dotnet-map`).
+
+OpenGL examples that can run with multiple context providers select EGL or WGL
+from `supportedOpenGLContextProviders()`.
 
 Each process run uses one graphics API. Render-target mode selection follows the
 active profile ([Entry](#entry) or [Entry and shell](#entry-and-shell)).

--- a/examples/dotnet-map/IGraphicsContext.cs
+++ b/examples/dotnet-map/IGraphicsContext.cs
@@ -48,7 +48,7 @@ internal static class GraphicsContext
         }
 
         throw new InvalidOperationException(
-            "The loaded MapLibre native library does not support a backend usable by dotnet-map on this platform."
+            "The loaded MapLibre native library does not support a backend usable by dotnet-map."
         );
     }
 }

--- a/examples/dotnet-map/IGraphicsContext.cs
+++ b/examples/dotnet-map/IGraphicsContext.cs
@@ -32,7 +32,7 @@ internal static class GraphicsContext
         RenderBackend backends
     )
     {
-        if (OperatingSystem.IsMacOS() && backends.HasFlag(RenderBackend.Metal))
+        if (backends.HasFlag(RenderBackend.Metal))
         {
             return MetalContext.Create(title, width, height);
         }

--- a/examples/dotnet-map/IGraphicsContext.cs
+++ b/examples/dotnet-map/IGraphicsContext.cs
@@ -37,7 +37,7 @@ internal static class GraphicsContext
             return MetalContext.Create(title, width, height);
         }
 
-        if (!OperatingSystem.IsMacOS() && backends.HasFlag(RenderBackend.OpenGL))
+        if (backends.HasFlag(RenderBackend.OpenGL))
         {
             return OpenGLContext.Create(title, width, height);
         }

--- a/examples/dotnet-map/NativeLibraryResolver.cs
+++ b/examples/dotnet-map/NativeLibraryResolver.cs
@@ -61,6 +61,7 @@ internal static class NativeLibraryResolver
                 "vulkan",
             ],
             "vulkan" => ["libvulkan.so.1", "vulkan"],
+            "EGL" when OperatingSystem.IsMacOS() => ["libEGL.dylib", "EGL"],
             "EGL" when OperatingSystem.IsLinux() => ["libEGL.so.1", "libEGL.so", "EGL"],
             _ => [],
         };

--- a/examples/dotnet-map/OpenGLContext.cs
+++ b/examples/dotnet-map/OpenGLContext.cs
@@ -37,7 +37,7 @@ internal sealed unsafe class OpenGLContext : IGraphicsContext
 
     public static OpenGLContext Create(string title, int width, int height)
     {
-        if (OperatingSystem.IsLinux())
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
         {
             return CreateEgl(title, width, height);
         }
@@ -48,7 +48,7 @@ internal sealed unsafe class OpenGLContext : IGraphicsContext
         }
 
         throw new InvalidOperationException(
-            "dotnet-map OpenGL context creation is supported on Linux/EGL and Windows/WGL."
+            "dotnet-map OpenGL context creation is supported on Linux/EGL, macOS/EGL, and Windows/WGL."
         );
     }
 

--- a/examples/dotnet-map/OpenGLContext.cs
+++ b/examples/dotnet-map/OpenGLContext.cs
@@ -37,18 +37,19 @@ internal sealed unsafe class OpenGLContext : IGraphicsContext
 
     public static OpenGLContext Create(string title, int width, int height)
     {
-        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        var providers = Maplibre.SupportedOpenGLContextProviders();
+        if (providers.HasFlag(OpenGLContextProvider.Egl))
         {
             return CreateEgl(title, width, height);
         }
 
-        if (OperatingSystem.IsWindows())
+        if (providers.HasFlag(OpenGLContextProvider.Wgl))
         {
             return CreateWgl(title, width, height);
         }
 
         throw new InvalidOperationException(
-            "dotnet-map OpenGL context creation is supported on Linux/EGL, macOS/EGL, and Windows/WGL."
+            "The loaded MapLibre native library does not support an OpenGL context provider usable by dotnet-map."
         );
     }
 

--- a/examples/dotnet-map/Program.cs
+++ b/examples/dotnet-map/Program.cs
@@ -91,7 +91,9 @@ internal static class Program
     {
         if (OperatingSystem.IsMacOS())
         {
-            return backends.HasFlag(RenderBackend.Metal) || backends.HasFlag(RenderBackend.Vulkan);
+            return backends.HasFlag(RenderBackend.Metal)
+                || backends.HasFlag(RenderBackend.OpenGL)
+                || backends.HasFlag(RenderBackend.Vulkan);
         }
 
         return backends.HasFlag(RenderBackend.OpenGL) || backends.HasFlag(RenderBackend.Vulkan);

--- a/examples/dotnet-map/Program.cs
+++ b/examples/dotnet-map/Program.cs
@@ -27,7 +27,7 @@ internal static class Program
             if (!SupportsUsableBackend(backends))
             {
                 Console.Error.WriteLine(
-                    "The loaded MapLibre native library does not support a backend usable by dotnet-map on this platform."
+                    "The loaded MapLibre native library does not support a backend usable by dotnet-map."
                 );
                 return 1;
             }

--- a/examples/dotnet-map/Program.cs
+++ b/examples/dotnet-map/Program.cs
@@ -89,14 +89,9 @@ internal static class Program
 
     private static bool SupportsUsableBackend(RenderBackend backends)
     {
-        if (OperatingSystem.IsMacOS())
-        {
-            return backends.HasFlag(RenderBackend.Metal)
-                || backends.HasFlag(RenderBackend.OpenGL)
-                || backends.HasFlag(RenderBackend.Vulkan);
-        }
-
-        return backends.HasFlag(RenderBackend.OpenGL) || backends.HasFlag(RenderBackend.Vulkan);
+        return backends.HasFlag(RenderBackend.Metal)
+            || backends.HasFlag(RenderBackend.OpenGL)
+            || backends.HasFlag(RenderBackend.Vulkan);
     }
 
     private static bool PrintNativeLog(LogRecord record)

--- a/examples/lwjgl-map/build.gradle.kts
+++ b/examples/lwjgl-map/build.gradle.kts
@@ -66,10 +66,16 @@ tasks.withType<JavaCompile>().configureEach { options.release = 24 }
 
 val nativeLibraryPathProperty = "org.maplibre.nativeffi.library.path"
 val nativeLibraryPath = maplibreNativeC.libraryPath
+val nativeRuntimeLibraryPath =
+  maplibreNativeC.runtimeLibraryDirs.joinToString(File.pathSeparator) { it.absolutePath }
 
 tasks.withType<JavaExec>().configureEach {
   jvmArgs(lwjglMapJvmArgs)
+  systemProperty("org.lwjgl.librarypath", nativeRuntimeLibraryPath)
   systemProperty(nativeLibraryPathProperty, nativeLibraryPath.absolutePath)
   inputs.file(nativeLibraryPath).withPropertyName("maplibreNativeCLibrary")
+  inputs
+    .files(maplibreNativeC.runtimeLibraryDirs)
+    .withPropertyName("maplibreNativeCRuntimeLibraryDirs")
   inputs.file(maplibreNativeC.propertiesFile).withPropertyName("maplibreNativeCProperties")
 }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/GraphicsContext.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/GraphicsContext.kt
@@ -29,7 +29,7 @@ internal interface GraphicsContext : AutoCloseable {
         return VulkanContext.create(title, width, height)
       }
       throw IllegalStateException(
-        "The loaded MapLibre native library does not support a backend usable by lwjgl-map on this platform"
+        "The loaded MapLibre native library does not support a backend usable by lwjgl-map"
       )
     }
   }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/GraphicsContext.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/GraphicsContext.kt
@@ -1,6 +1,5 @@
 package org.maplibre.nativeffi.examples.lwjglmap
 
-import java.util.Locale
 import org.maplibre.nativeffi.render.RenderBackend
 
 internal interface GraphicsContext : AutoCloseable {
@@ -20,7 +19,7 @@ internal interface GraphicsContext : AutoCloseable {
       height: Int,
       backends: Set<RenderBackend>,
     ): GraphicsContext {
-      if (isMac() && backends.contains(RenderBackend.METAL)) {
+      if (backends.contains(RenderBackend.METAL)) {
         return MetalContext.create(title, width, height)
       }
       if (backends.contains(RenderBackend.OPENGL)) {
@@ -33,8 +32,5 @@ internal interface GraphicsContext : AutoCloseable {
         "The loaded MapLibre native library does not support a backend usable by lwjgl-map on this platform"
       )
     }
-
-    @JvmStatic
-    fun isMac(): Boolean = System.getProperty("os.name").lowercase(Locale.ROOT).contains("mac")
   }
 }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/GraphicsContext.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/GraphicsContext.kt
@@ -23,7 +23,7 @@ internal interface GraphicsContext : AutoCloseable {
       if (isMac() && backends.contains(RenderBackend.METAL)) {
         return MetalContext.create(title, width, height)
       }
-      if (!isMac() && backends.contains(RenderBackend.OPENGL)) {
+      if (backends.contains(RenderBackend.OPENGL)) {
         return OpenGLContext.create(title, width, height)
       }
       if (backends.contains(RenderBackend.VULKAN)) {

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/Main.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/Main.kt
@@ -67,11 +67,7 @@ internal object Main {
   }
 
   private fun supportsUsableBackend(backends: Set<RenderBackend>): Boolean =
-    if (GraphicsContext.isMac()) {
-      RenderBackend.METAL in backends ||
-        RenderBackend.OPENGL in backends ||
-        RenderBackend.VULKAN in backends
-    } else {
-      RenderBackend.OPENGL in backends || RenderBackend.VULKAN in backends
-    }
+    RenderBackend.METAL in backends ||
+      RenderBackend.OPENGL in backends ||
+      RenderBackend.VULKAN in backends
 }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/Main.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/Main.kt
@@ -11,7 +11,7 @@ internal object Main {
     val backends = Maplibre.supportedRenderBackends()
     println("native render backends: $backends")
     check(supportsUsableBackend(backends)) {
-      "The loaded MapLibre native library does not support a backend usable by lwjgl-map on this platform"
+      "The loaded MapLibre native library does not support a backend usable by lwjgl-map"
     }
     Maplibre.setLogCallback { record ->
       System.err.printf(

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/Main.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/Main.kt
@@ -68,7 +68,9 @@ internal object Main {
 
   private fun supportsUsableBackend(backends: Set<RenderBackend>): Boolean =
     if (GraphicsContext.isMac()) {
-      RenderBackend.METAL in backends || RenderBackend.VULKAN in backends
+      RenderBackend.METAL in backends ||
+        RenderBackend.OPENGL in backends ||
+        RenderBackend.VULKAN in backends
     } else {
       RenderBackend.OPENGL in backends || RenderBackend.VULKAN in backends
     }

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLContext.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLContext.kt
@@ -106,9 +106,9 @@ internal class OpenGLContext private constructor(val isGles: Boolean, private va
   internal companion object {
     fun create(title: String, width: Int, height: Int): OpenGLContext =
       when {
-        isLinux() -> createEgl(title, width, height)
+        isLinux() || isMac() -> createEgl(title, width, height)
         isWindows() -> createWgl(title, width, height)
-        else -> error("LWJGL OpenGL context is only supported on Linux and Windows")
+        else -> error("LWJGL OpenGL context is only supported on Linux, macOS, and Windows")
       }
 
     private fun createEgl(title: String, width: Int, height: Int): OpenGLContext {
@@ -186,6 +186,9 @@ internal class OpenGLContext private constructor(val isGles: Boolean, private va
 
     private fun isLinux(): Boolean =
       System.getProperty("os.name").lowercase(Locale.ROOT).contains("linux")
+
+    private fun isMac(): Boolean =
+      System.getProperty("os.name").lowercase(Locale.ROOT).contains("mac")
 
     private fun isWindows(): Boolean =
       System.getProperty("os.name").lowercase(Locale.ROOT).contains("windows")

--- a/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLContext.kt
+++ b/examples/lwjgl-map/src/main/kotlin/org/maplibre/nativeffi/examples/lwjglmap/OpenGLContext.kt
@@ -1,6 +1,5 @@
 package org.maplibre.nativeffi.examples.lwjglmap
 
-import java.util.Locale
 import org.lwjgl.glfw.GLFW.GLFW_CLIENT_API
 import org.lwjgl.glfw.GLFW.GLFW_CONTEXT_CREATION_API
 import org.lwjgl.glfw.GLFW.GLFW_CONTEXT_VERSION_MAJOR
@@ -104,12 +103,17 @@ internal class OpenGLContext private constructor(val isGles: Boolean, private va
   }
 
   internal companion object {
-    fun create(title: String, width: Int, height: Int): OpenGLContext =
-      when {
-        isLinux() || isMac() -> createEgl(title, width, height)
-        isWindows() -> createWgl(title, width, height)
-        else -> error("LWJGL OpenGL context is only supported on Linux, macOS, and Windows")
+    fun create(title: String, width: Int, height: Int): OpenGLContext {
+      val providers = Maplibre.supportedOpenGLContextProviders()
+      return when {
+        OpenGLContextProvider.EGL in providers -> createEgl(title, width, height)
+        OpenGLContextProvider.WGL in providers -> createWgl(title, width, height)
+        else ->
+          error(
+            "The loaded MapLibre native library does not support an OpenGL context provider usable by lwjgl-map"
+          )
       }
+    }
 
     private fun createEgl(title: String, width: Int, height: Int): OpenGLContext {
       check(OpenGLContextProvider.EGL in Maplibre.supportedOpenGLContextProviders()) {
@@ -183,15 +187,6 @@ internal class OpenGLContext private constructor(val isGles: Boolean, private va
         throw error
       }
     }
-
-    private fun isLinux(): Boolean =
-      System.getProperty("os.name").lowercase(Locale.ROOT).contains("linux")
-
-    private fun isMac(): Boolean =
-      System.getProperty("os.name").lowercase(Locale.ROOT).contains("mac")
-
-    private fun isWindows(): Boolean =
-      System.getProperty("os.name").lowercase(Locale.ROOT).contains("windows")
 
     private fun getDc(hwnd: Long): Long = User32.GetDC(hwnd)
 

--- a/examples/rust-map/src/main.rs
+++ b/examples/rust-map/src/main.rs
@@ -42,7 +42,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let backends = maplibre_native::supported_render_backends();
     println!("native render backends: {}", render_backend_label(backends));
     if !supports_usable_backend(backends) {
-        return Err("the loaded MapLibre native library does not support a backend usable by rust-map on this platform".into());
+        return Err(
+            "the loaded MapLibre native library does not support the backend required by rust-map"
+                .into(),
+        );
     }
     maplibre_native::set_log_callback(|record| {
         eprintln!(


### PR DESCRIPTION
## Summary

Enable macOS EGL coverage for bindings and map examples that can support it, including Rust bindings with only the Rust-specific OpenGL test-context gap skipped, and align example backend selection with native backend/provider support masks.

## Test plan

Ran macOS EGL builds/tests for Zig map, LWJGL map, .NET map, .NET bindings, Kotlin JVM, Kotlin Native, Swift, Rust bindings, plus Rust map Vulkan test coverage, `git diff --check`, formatter/actionlint hooks, and CI workflow generation checks.

## AI assistance

- **Tools:** Codex
- **Models:** GPT-5
- **Context:** Used Codex to inspect the existing Zig EGL path, update matching bindings/examples, audit backend-selection policy, run validation, and prepare the PR.