### PR TITLE
Show CI status on example badges in support matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:lint
+      - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-linux-arm64-vulkan:
@@ -72,7 +72,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:lint
+      - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-linux-x64-egl:
@@ -94,7 +94,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:lint
+      - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-linux-x64-vulkan:
@@ -116,7 +116,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:lint
+      - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-macos-arm64-metal:
@@ -139,7 +139,7 @@ jobs:
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:lint
+      - run: mise run //examples/rust-map:check
       - run: mise run //examples/swift-map:build
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
@@ -163,7 +163,7 @@ jobs:
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:lint
+      - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-macos-arm64-egl:
@@ -292,7 +292,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:lint
+      - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-windows-x64-wgl:
@@ -313,7 +313,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:lint
+      - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   required:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:test
+      - run: mise run //examples/rust-map:lint
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-linux-arm64-vulkan:
@@ -72,7 +72,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:test
+      - run: mise run //examples/rust-map:lint
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-linux-x64-egl:
@@ -94,7 +94,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:test
+      - run: mise run //examples/rust-map:lint
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-linux-x64-vulkan:
@@ -116,7 +116,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:test
+      - run: mise run //examples/rust-map:lint
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-macos-arm64-metal:
@@ -139,7 +139,7 @@ jobs:
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:test
+      - run: mise run //examples/rust-map:lint
       - run: mise run //examples/swift-map:build
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
@@ -163,7 +163,7 @@ jobs:
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:test
+      - run: mise run //examples/rust-map:lint
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-macos-arm64-egl:
@@ -292,7 +292,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:test
+      - run: mise run //examples/rust-map:lint
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   variant-windows-x64-wgl:
@@ -313,7 +313,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
-      - run: mise run //examples/rust-map:test
+      - run: mise run //examples/rust-map:lint
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
   required:

--- a/.mise/tasks/docs/generate-support-matrix
+++ b/.mise/tasks/docs/generate-support-matrix
@@ -140,7 +140,7 @@ def subproject_status(actions: dict[str, str], variant: Variant) -> Status | Non
         return "tested"
     if actions.get("test") and variant.supports_tests:
         return "tested"
-    if actions.get("build"):
+    if actions.get("build") or actions.get("lint"):
         return "build-only"
     return None
 

--- a/.mise/tasks/docs/generate-support-matrix
+++ b/.mise/tasks/docs/generate-support-matrix
@@ -140,7 +140,7 @@ def subproject_status(actions: dict[str, str], variant: Variant) -> Status | Non
         return "tested"
     if actions.get("test") and variant.supports_tests:
         return "tested"
-    if actions.get("build") or actions.get("lint"):
+    if actions.get("build") or actions.get("check"):
         return "build-only"
     return None
 

--- a/ci/manifest.py
+++ b/ci/manifest.py
@@ -81,14 +81,20 @@ class CiConfig(StrictManifestModel):
     build: NonEmptyString | None = None
     test: NonEmptyString | None = None
     run: NonEmptyString | None = None
+    lint: NonEmptyString | None = None
 
     @model_validator(mode="after")
     def require_action(self) -> "CiConfig":
-        if self.build is None and self.test is None and self.run is None:
+        if (
+            self.build is None
+            and self.test is None
+            and self.run is None
+            and self.lint is None
+        ):
             raise ValueError("[ci] must contain at least one action")
         return self
 
-    @field_validator("build", "test", "run")
+    @field_validator("build", "test", "run", "lint")
     @classmethod
     def require_task_name(cls, task: str | None) -> str | None:
         if task is not None and not TASK_PATTERN.fullmatch(task):

--- a/ci/manifest.py
+++ b/ci/manifest.py
@@ -81,7 +81,7 @@ class CiConfig(StrictManifestModel):
     build: NonEmptyString | None = None
     test: NonEmptyString | None = None
     run: NonEmptyString | None = None
-    lint: NonEmptyString | None = None
+    check: NonEmptyString | None = None
 
     @model_validator(mode="after")
     def require_action(self) -> "CiConfig":
@@ -89,12 +89,12 @@ class CiConfig(StrictManifestModel):
             self.build is None
             and self.test is None
             and self.run is None
-            and self.lint is None
+            and self.check is None
         ):
             raise ValueError("[ci] must contain at least one action")
         return self
 
-    @field_validator("build", "test", "run", "lint")
+    @field_validator("build", "test", "run", "check")
     @classmethod
     def require_task_name(cls, task: str | None) -> str | None:
         if task is not None and not TASK_PATTERN.fullmatch(task):

--- a/ci/subprojects/examples-rust-map.toml
+++ b/ci/subprojects/examples-rust-map.toml
@@ -5,4 +5,4 @@ exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]
 
 [ci]
-lint = "//examples/rust-map:lint"
+check = "//examples/rust-map:check"

--- a/ci/subprojects/examples-rust-map.toml
+++ b/ci/subprojects/examples-rust-map.toml
@@ -5,4 +5,4 @@ exclude = ["macos-arm64-egl"]
 os = ["linux", "macos", "windows"]
 
 [ci]
-test = "//examples/rust-map:test"
+lint = "//examples/rust-map:lint"

--- a/docs/src/components/SupportMatrix.astro
+++ b/docs/src/components/SupportMatrix.astro
@@ -119,26 +119,6 @@ function subprojectSupport(
     ];
   });
 }
-
-function bindingSupport(
-  environment: EnvironmentColumn & { backends: Backend[] },
-): { label: string; status: Status; url: string }[] {
-  return subprojectSupport(
-    supportMatrix.bindings,
-    environment,
-    (binding, support) => supportLabel(binding.label, environment, support),
-  );
-}
-
-function exampleSupport(
-  environment: EnvironmentColumn & { backends: Backend[] },
-): { label: string; status: Status; url: string }[] {
-  return subprojectSupport(
-    supportMatrix.examples,
-    environment,
-    (example) => example.label,
-  );
-}
 ---
 
 <p>
@@ -164,8 +144,16 @@ function exampleSupport(
   </thead>
   <tbody>
     {environmentRows.map((environment) => {
-      const bindings = bindingSupport(environment);
-      const examples = exampleSupport(environment);
+      const bindings = subprojectSupport(
+        supportMatrix.bindings,
+        environment,
+        (binding, support) => supportLabel(binding.label, environment, support),
+      );
+      const examples = subprojectSupport(
+        supportMatrix.examples,
+        environment,
+        (example) => example.label,
+      );
       return (
         <tr>
           <th scope="row">{environment.label}</th>

--- a/docs/src/components/SupportMatrix.astro
+++ b/docs/src/components/SupportMatrix.astro
@@ -103,7 +103,10 @@ function supportLabel(
 function subprojectSupport(
   subprojects: SubprojectSupport[],
   environment: EnvironmentColumn & { backends: Backend[] },
-  labelFor: (subproject: SubprojectSupport, support: EnvironmentSupport) => string,
+  labelFor: (
+    subproject: SubprojectSupport,
+    support: EnvironmentSupport,
+  ) => string,
 ): { label: string; status: Status; url: string }[] {
   return subprojects.flatMap((subproject) => {
     const support = environmentSupport(subproject, environment.environment);

--- a/docs/src/components/SupportMatrix.astro
+++ b/docs/src/components/SupportMatrix.astro
@@ -100,31 +100,43 @@ function supportLabel(
   return `${label} (${support.backends.map((backend) => backend.backendLabel).join(", ")})`;
 }
 
-function bindingSupport(
+function subprojectSupport(
+  subprojects: SubprojectSupport[],
   environment: EnvironmentColumn & { backends: Backend[] },
+  labelFor: (subproject: SubprojectSupport, support: EnvironmentSupport) => string,
 ): { label: string; status: Status; url: string }[] {
-  return supportMatrix.bindings.flatMap((binding) => {
-    const support = environmentSupport(binding, environment.environment);
+  return subprojects.flatMap((subproject) => {
+    const support = environmentSupport(subproject, environment.environment);
     if (!support) {
       return [];
     }
     return [
       {
-        label: supportLabel(binding.label, environment, support),
+        label: labelFor(subproject, support),
         status: supportStatus(support),
-        url: sourceUrl(binding.sourceDirectory),
+        url: sourceUrl(subproject.sourceDirectory),
       },
     ];
   });
 }
 
+function bindingSupport(
+  environment: EnvironmentColumn & { backends: Backend[] },
+): { label: string; status: Status; url: string }[] {
+  return subprojectSupport(
+    supportMatrix.bindings,
+    environment,
+    (binding, support) => supportLabel(binding.label, environment, support),
+  );
+}
+
 function exampleSupport(
-  environment: EnvironmentColumn,
-): { label: string; url: string }[] {
-  return supportMatrix.examples.flatMap((example) =>
-    environmentSupport(example, environment.environment)
-      ? [{ label: example.label, url: sourceUrl(example.sourceDirectory) }]
-      : [],
+  environment: EnvironmentColumn & { backends: Backend[] },
+): { label: string; status: Status; url: string }[] {
+  return subprojectSupport(
+    supportMatrix.examples,
+    environment,
+    (example) => example.label,
   );
 }
 ---
@@ -187,7 +199,7 @@ function exampleSupport(
                 <a class="support-badge-link" href={example.url}>
                   <Badge
                     text={example.label}
-                    variant="default"
+                    variant={badgeVariant(example.status)}
                     size="small"
                   />
                 </a>{" "}

--- a/examples/rust-map/mise.toml
+++ b/examples/rust-map/mise.toml
@@ -20,7 +20,7 @@ esac
 cargo build -p rust-map --no-default-features --features "$feature"
 '''
 
-[tasks.lint]
+[tasks.check]
 depends = [":build"]
 dir = "{{env.MLN_FFI_REPO_ROOT}}"
 run = '''

--- a/examples/rust-map/mise.toml
+++ b/examples/rust-map/mise.toml
@@ -20,7 +20,7 @@ esac
 cargo build -p rust-map --no-default-features --features "$feature"
 '''
 
-[tasks.test]
+[tasks.lint]
 depends = [":build"]
 dir = "{{env.MLN_FFI_REPO_ROOT}}"
 run = '''


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wire example badges in the docs support matrix through the same CI-derived status logic as bindings, so zig-readback shows as tested and build-only examples show as built only.

## Test plan

- [x] `mise run //docs:build` and confirm example badges use green/caution variants matching bindings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-246176ba-fdf5-452a-a3d3-122f0af2693f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-246176ba-fdf5-452a-a3d3-122f0af2693f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

