### PR TITLE
Enable Swift binding CI on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - run: mise run //bindings/dotnet:test
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/rust:test
+      - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
@@ -70,6 +71,7 @@ jobs:
       - run: mise run //bindings/dotnet:test
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/rust:test
+      - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
@@ -92,6 +94,7 @@ jobs:
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/kotlin:nativeTest
       - run: mise run //bindings/rust:test
+      - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
@@ -114,6 +117,7 @@ jobs:
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/kotlin:nativeTest
       - run: mise run //bindings/rust:test
+      - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check

--- a/bindings/swift/Sources/MaplibreNative/Support/NativeHandleLeakReporter.swift
+++ b/bindings/swift/Sources/MaplibreNative/Support/NativeHandleLeakReporter.swift
@@ -1,8 +1,3 @@
-#if canImport(Darwin)
-  import Darwin
-#elseif canImport(Glibc)
-  import Glibc
-#endif
 import Foundation
 
 struct NativeHandleLeak: Equatable {
@@ -11,12 +6,8 @@ struct NativeHandleLeak: Equatable {
 }
 
 private func writeStandardError(_ message: String) {
-  message.withCString { message in
-    #if canImport(Darwin)
-      _ = Darwin.write(STDERR_FILENO, message, strlen(message))
-    #elseif canImport(Glibc)
-      _ = Glibc.write(STDERR_FILENO, message, strlen(message))
-    #endif
+  if let data = message.data(using: .utf8) {
+    FileHandle.standardError.write(data)
   }
 }
 

--- a/bindings/swift/Sources/MaplibreNative/Support/NativeHandleLeakReporter.swift
+++ b/bindings/swift/Sources/MaplibreNative/Support/NativeHandleLeakReporter.swift
@@ -1,4 +1,8 @@
-import Darwin
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#endif
 import Foundation
 
 struct NativeHandleLeak: Equatable {
@@ -6,14 +10,22 @@ struct NativeHandleLeak: Equatable {
   let address: UInt
 }
 
+private func writeStandardError(_ message: String) {
+  message.withCString { message in
+    #if canImport(Darwin)
+      _ = Darwin.write(STDERR_FILENO, message, strlen(message))
+    #elseif canImport(Glibc)
+      _ = Glibc.write(STDERR_FILENO, message, strlen(message))
+    #endif
+  }
+}
+
 enum NativeHandleLeakReporter {
   private static let lock = NSLock()
   private static let defaultHandler: @Sendable (NativeHandleLeak)
     -> Void = { leak in
       let message = "Leaked \(leak.typeName) native handle 0x\(String(leak.address, radix: 16)); close handles explicitly on their owner thread.\n"
-      message.withCString { message in
-        _ = Darwin.write(STDERR_FILENO, message, strlen(message))
-      }
+      writeStandardError(message)
     }
 
   private nonisolated(unsafe) static var handler = defaultHandler

--- a/ci/subprojects/bindings-swift.toml
+++ b/ci/subprojects/bindings-swift.toml
@@ -1,2 +1,2 @@
 [requires]
-os = ["macos", "ios"]
+os = ["linux", "macos", "ios"]

--- a/mise.lock
+++ b/mise.lock
@@ -952,6 +952,9 @@ targets = "aarch64-linux-android,x86_64-linux-android"
 version = "6.3.1"
 backend = "core:swift"
 
+[tools.swift."platforms.linux-x64"]
+checksum = "blake3:33fab728a9bd1b86e01b4a54aa2e1b6c29bdec48e8deb189c37fbdd46b016af0"
+
 [tools.swift."platforms.macos-arm64"]
 checksum = "blake3:7c85377fa6d9bdbeec3f6724522835c59d31483906d5bee41ec41807eff0ab00"
 

--- a/mise.lock
+++ b/mise.lock
@@ -952,6 +952,9 @@ targets = "aarch64-linux-android,x86_64-linux-android"
 version = "6.3.1"
 backend = "core:swift"
 
+[tools.swift."platforms.linux-arm64"]
+checksum = "blake3:5757beba33d3dff25fb750a239936827ab0350e65b28ea37a3924449883c6429"
+
 [tools.swift."platforms.linux-x64"]
 checksum = "blake3:8a95707e406fa824266e95319f9f906415871df8f8dce47304a90302ec9977e8"
 

--- a/mise.lock
+++ b/mise.lock
@@ -953,7 +953,7 @@ version = "6.3.1"
 backend = "core:swift"
 
 [tools.swift."platforms.linux-x64"]
-checksum = "blake3:33fab728a9bd1b86e01b4a54aa2e1b6c29bdec48e8deb189c37fbdd46b016af0"
+checksum = "blake3:8a95707e406fa824266e95319f9f906415871df8f8dce47304a90302ec9977e8"
 
 [tools.swift."platforms.macos-arm64"]
 checksum = "blake3:7c85377fa6d9bdbeec3f6724522835c59d31483906d5bee41ec41807eff0ab00"

--- a/mise.toml
+++ b/mise.toml
@@ -61,7 +61,7 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 "aqua:astral-sh/uv" = "0.11.11"
 
 # Swift ecosystem
-"core:swift" = { version = "6.3.1", os = ["macos"] }
+"core:swift" = { version = "6.3.1", os = ["linux", "macos"] }
 swiftformat = { version = "0.61.1", backend = "github:nicklockwood/SwiftFormat", no_app = true, rename_exe = "swiftformat" }
 
 # Other ecosystems


### PR DESCRIPTION
## Summary

Enable Swift tooling and binding tests on Linux CI.

## Test plan

Ran Swift binding tests on linux-x64 Vulkan and EGL plus generated workflow/support-matrix checks.

## AI assistance

- **Tools:** Zed coding agent
- **Models:** GPT-5.5
- **Context:** Used to inspect CI/mise configuration, make the Linux Swift binding changes, run validation, and open this draft PR.