### PR TITLE
Enable Rust binding builds for OpenHarmony arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
       - run: mise run configure
       - run: mise run build
+      - run: mise run //bindings/rust:build
   variant-ohos-arm64-vulkan:
     name: variant / ohos-arm64-vulkan
     runs-on: ubuntu-latest
@@ -307,6 +308,7 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
       - run: mise run configure
       - run: mise run build
+      - run: mise run //bindings/rust:build
   variant-windows-x64-vulkan:
     name: variant / windows-x64-vulkan
     runs-on: windows-2022

--- a/.mise/config.ohos-arm64-egl.toml
+++ b/.mise/config.ohos-arm64-egl.toml
@@ -2,6 +2,7 @@
 MLN_FFI_RENDER_BACKEND = "opengl"
 MLN_FFI_BUILD_DIR = "{{config_root}}/build/ohos-arm64-egl"
 MLN_FFI_ZIG_BUILD_ARGS = "-Dtarget=aarch64-linux-ohos"
+MLN_FFI_SYSTEM_ROOT = "{{env.OHOS_SDK_NATIVE}}/sysroot"
 OHOS_SDK_NATIVE = { required = true }
 MLN_FFI_CMAKE_ARGS = """
 -DCMAKE_TOOLCHAIN_FILE={{env.OHOS_SDK_NATIVE}}/build/cmake/ohos.toolchain.cmake
@@ -10,4 +11,9 @@ MLN_FFI_CMAKE_ARGS = """
 -DMLN_FFI_ENABLE_CLANG_TIDY=OFF
 """
 CMAKE_PREFIX_PATH = ""
-LIBCLANG_PATH = ""
+CARGO_BUILD_TARGET = "aarch64-unknown-linux-ohos"
+LIBCLANG_PATH = "{{config_root}}/.pixi/envs/default/lib"
+BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_ohos = "--target=aarch64-linux-ohos --sysroot={{env.OHOS_SDK_NATIVE}}/sysroot -I{{env.OHOS_SDK_NATIVE}}/sysroot/usr/include/aarch64-linux-ohos"
+CC_aarch64_unknown_linux_ohos = "{{env.OHOS_SDK_NATIVE}}/llvm/bin/clang --target=aarch64-linux-ohos --sysroot={{env.OHOS_SDK_NATIVE}}/sysroot"
+CXX_aarch64_unknown_linux_ohos = "{{env.OHOS_SDK_NATIVE}}/llvm/bin/clang++ --target=aarch64-linux-ohos --sysroot={{env.OHOS_SDK_NATIVE}}/sysroot"
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER = "{{env.OHOS_SDK_NATIVE}}/llvm/bin/clang"

--- a/.mise/config.ohos-arm64-vulkan.toml
+++ b/.mise/config.ohos-arm64-vulkan.toml
@@ -2,6 +2,7 @@
 MLN_FFI_RENDER_BACKEND = "vulkan"
 MLN_FFI_BUILD_DIR = "{{config_root}}/build/ohos-arm64-vulkan"
 MLN_FFI_ZIG_BUILD_ARGS = "-Dtarget=aarch64-linux-ohos"
+MLN_FFI_SYSTEM_ROOT = "{{env.OHOS_SDK_NATIVE}}/sysroot"
 OHOS_SDK_NATIVE = { required = true }
 MLN_FFI_CMAKE_ARGS = """
 -DCMAKE_TOOLCHAIN_FILE={{env.OHOS_SDK_NATIVE}}/build/cmake/ohos.toolchain.cmake
@@ -10,4 +11,9 @@ MLN_FFI_CMAKE_ARGS = """
 -DMLN_FFI_ENABLE_CLANG_TIDY=OFF
 """
 CMAKE_PREFIX_PATH = ""
-LIBCLANG_PATH = ""
+CARGO_BUILD_TARGET = "aarch64-unknown-linux-ohos"
+LIBCLANG_PATH = "{{config_root}}/.pixi/envs/default/lib"
+BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_ohos = "--target=aarch64-linux-ohos --sysroot={{env.OHOS_SDK_NATIVE}}/sysroot -I{{env.OHOS_SDK_NATIVE}}/sysroot/usr/include/aarch64-linux-ohos"
+CC_aarch64_unknown_linux_ohos = "{{env.OHOS_SDK_NATIVE}}/llvm/bin/clang --target=aarch64-linux-ohos --sysroot={{env.OHOS_SDK_NATIVE}}/sysroot"
+CXX_aarch64_unknown_linux_ohos = "{{env.OHOS_SDK_NATIVE}}/llvm/bin/clang++ --target=aarch64-linux-ohos --sysroot={{env.OHOS_SDK_NATIVE}}/sysroot"
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER = "{{env.OHOS_SDK_NATIVE}}/llvm/bin/clang"

--- a/.mise/tasks/native-metadata
+++ b/.mise/tasks/native-metadata
@@ -202,10 +202,26 @@ def write_swift_linker_flags(artifact: Artifact, out_dir: Path) -> None:
     write_lines(out_dir / f"{LIBRARY_NAME}.swift-linker-flags", linker_flags(artifact))
 
 
+def ohos_cargo_link_rustflags() -> list[str]:
+    ohos_sdk = os.environ.get("OHOS_SDK_NATIVE", "")
+    if not ohos_sdk:
+        return []
+
+    sysroot = Path(ohos_sdk) / "sysroot"
+    return [
+        "-Clink-arg=--target=aarch64-linux-ohos",
+        f"-Clink-arg=--sysroot={sysroot}",
+        "-Clink-arg=-fuse-ld=lld",
+    ]
+
+
 def write_cargo_rustflags(artifact: Artifact, out_dir: Path) -> None:
     flags = [
-        f"-Clink-arg=-Wl,-rpath,{runtime_dir}"
-        for runtime_dir in artifact.runtime_library_dirs
+        *ohos_cargo_link_rustflags(),
+        *(
+            f"-Clink-arg=-Wl,-rpath,{runtime_dir}"
+            for runtime_dir in artifact.runtime_library_dirs
+        ),
     ]
     encoded_flags = "\x1f".join(flags)
     lines = []
@@ -242,6 +258,23 @@ def write_zig_config(artifact: Artifact, out_dir: Path) -> None:
 
 def write_zig_libc_config(out_dir: Path) -> None:
     path = out_dir / f"{LIBRARY_NAME}.zig-libc"
+    ohos_sdk = os.environ.get("OHOS_SDK_NATIVE", "")
+    if ohos_sdk:
+        sysroot = Path(ohos_sdk) / "sysroot"
+        ohos_arch = "aarch64-linux-ohos"
+        write_lines(
+            path,
+            [
+                f"include_dir={sysroot / 'usr' / 'include' / ohos_arch}",
+                f"sys_include_dir={sysroot / 'usr' / 'include'}",
+                f"crt_dir={sysroot / 'usr' / 'lib' / ohos_arch}",
+                "msvc_lib_dir=",
+                "kernel32_lib_dir=",
+                "gcc_dir=",
+            ],
+        )
+        return
+
     system_root = os.environ.get("MLN_FFI_SYSTEM_ROOT", "")
     if not system_root:
         path.unlink(missing_ok=True)

--- a/.mise/tasks/native-metadata
+++ b/.mise/tasks/native-metadata
@@ -202,14 +202,29 @@ def write_swift_linker_flags(artifact: Artifact, out_dir: Path) -> None:
     write_lines(out_dir / f"{LIBRARY_NAME}.swift-linker-flags", linker_flags(artifact))
 
 
+def ohos_cargo_target() -> str | None:
+    cargo_target = os.environ.get("CARGO_BUILD_TARGET", "")
+    if cargo_target.endswith("-linux-ohos"):
+        return cargo_target
+    return None
+
+
+def ohos_clang_target() -> str | None:
+    cargo_target = ohos_cargo_target()
+    if cargo_target is None:
+        return None
+    return cargo_target.replace("-unknown-", "-")
+
+
 def ohos_cargo_link_rustflags() -> list[str]:
     ohos_sdk = os.environ.get("OHOS_SDK_NATIVE", "")
-    if not ohos_sdk:
+    clang_target = ohos_clang_target()
+    if not ohos_sdk or clang_target is None:
         return []
 
     sysroot = Path(ohos_sdk) / "sysroot"
     return [
-        "-Clink-arg=--target=aarch64-linux-ohos",
+        f"-Clink-arg=--target={clang_target}",
         f"-Clink-arg=--sysroot={sysroot}",
         "-Clink-arg=-fuse-ld=lld",
     ]
@@ -259,9 +274,9 @@ def write_zig_config(artifact: Artifact, out_dir: Path) -> None:
 def write_zig_libc_config(out_dir: Path) -> None:
     path = out_dir / f"{LIBRARY_NAME}.zig-libc"
     ohos_sdk = os.environ.get("OHOS_SDK_NATIVE", "")
-    if ohos_sdk:
+    ohos_arch = ohos_clang_target()
+    if ohos_sdk and ohos_arch is not None:
         sysroot = Path(ohos_sdk) / "sysroot"
-        ohos_arch = "aarch64-linux-ohos"
         write_lines(
             path,
             [

--- a/ci/subprojects/bindings-rust.toml
+++ b/ci/subprojects/bindings-rust.toml
@@ -1,2 +1,2 @@
 [requires]
-os = ["linux", "macos", "windows"]
+os = ["linux", "macos", "windows", "ohos"]

--- a/mise.lock
+++ b/mise.lock
@@ -884,7 +884,7 @@ backend = "core:rust"
 [tools.rust.options]
 components = "clippy,rustfmt"
 profile = "minimal"
-targets = "aarch64-linux-android,x86_64-linux-android"
+targets = "aarch64-linux-android,aarch64-unknown-linux-ohos,x86_64-linux-android"
 
 [[tools.swift]]
 version = "6.3.1"

--- a/mise.toml
+++ b/mise.toml
@@ -65,7 +65,7 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 swiftformat = { version = "0.61.1", backend = "github:nicklockwood/SwiftFormat", no_app = true, rename_exe = "swiftformat" }
 
 # Other ecosystems
-"core:rust" = { version = "1.95.0", profile = "minimal", components = "rustfmt,clippy", targets = "aarch64-linux-android,x86_64-linux-android" }
+"core:rust" = { version = "1.95.0", profile = "minimal", components = "rustfmt,clippy", targets = "aarch64-linux-android,x86_64-linux-android,aarch64-unknown-linux-ohos" }
 "core:zig" = { version = "0.16.0", os = ["linux", "macos", "windows/x64"] }
 # Zig's native Windows ARM64 0.16.0 build crashes while loading build.zig, so
 # Windows ARM64 uses the x64 host compiler under emulation to cross-build ARM64.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enable the Rust binding to cross-compile for OpenHarmony arm64 by mirroring the Android pattern: OHOS mise env vars, generated cargo link flags, and CI build steps on both ohos-arm64 variants.

Fixes CI regressions by gating OHOS cargo link flags on `CARGO_BUILD_TARGET` (not merely `OHOS_SDK_NATIVE`, which is set globally via conf.d).

## Test plan

- [x] `mise -E ohos-arm64-egl run //bindings/rust:build` with the OpenHarmony SDK v6.1 from CI
- [x] Verified `native-metadata` omits OHOS link flags when `CARGO_BUILD_TARGET` is unset
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fec7c5f-fb3c-4696-8109-fe0c1209875b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fec7c5f-fb3c-4696-8109-fe0c1209875b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

