### PR TITLE
Scope pixi native library deps to Linux and Windows

### DIFF
--- a/.mise/config.linux-arm64-egl.toml
+++ b/.mise/config.linux-arm64-egl.toml
@@ -9,4 +9,3 @@ PKG_CONFIG_PATH = "{{env.MLN_FFI_BUILD_DIR}}:{{config_root}}/.pixi/envs/default/
 CMAKE_LIBRARY_PATH = "{{env.MLN_FFI_DEPENDENCY_LIBRARY_DIR}}"
 LIBRARY_PATH = "{{env.MLN_FFI_DEPENDENCY_LIBRARY_DIR}}"
 CARGO_BUILD_TARGET = "aarch64-unknown-linux-gnu"
-SSL_CERT_FILE = "{{config_root}}/.pixi/envs/default/ssl/cacert.pem"

--- a/.mise/config.linux-arm64-vulkan.toml
+++ b/.mise/config.linux-arm64-vulkan.toml
@@ -9,4 +9,3 @@ PKG_CONFIG_PATH = "{{env.MLN_FFI_BUILD_DIR}}:{{config_root}}/.pixi/envs/default/
 CMAKE_LIBRARY_PATH = "{{env.MLN_FFI_DEPENDENCY_LIBRARY_DIR}}"
 LIBRARY_PATH = "{{env.MLN_FFI_DEPENDENCY_LIBRARY_DIR}}"
 CARGO_BUILD_TARGET = "aarch64-unknown-linux-gnu"
-SSL_CERT_FILE = "{{config_root}}/.pixi/envs/default/ssl/cacert.pem"

--- a/.mise/config.linux-x64-egl.toml
+++ b/.mise/config.linux-x64-egl.toml
@@ -9,4 +9,3 @@ PKG_CONFIG_PATH = "{{env.MLN_FFI_BUILD_DIR}}:{{config_root}}/.pixi/envs/default/
 CMAKE_LIBRARY_PATH = "{{env.MLN_FFI_DEPENDENCY_LIBRARY_DIR}}"
 LIBRARY_PATH = "{{env.MLN_FFI_DEPENDENCY_LIBRARY_DIR}}"
 CARGO_BUILD_TARGET = "x86_64-unknown-linux-gnu"
-SSL_CERT_FILE = "{{config_root}}/.pixi/envs/default/ssl/cacert.pem"

--- a/.mise/config.linux-x64-vulkan.toml
+++ b/.mise/config.linux-x64-vulkan.toml
@@ -9,4 +9,3 @@ PKG_CONFIG_PATH = "{{env.MLN_FFI_BUILD_DIR}}:{{config_root}}/.pixi/envs/default/
 CMAKE_LIBRARY_PATH = "{{env.MLN_FFI_DEPENDENCY_LIBRARY_DIR}}"
 LIBRARY_PATH = "{{env.MLN_FFI_DEPENDENCY_LIBRARY_DIR}}"
 CARGO_BUILD_TARGET = "x86_64-unknown-linux-gnu"
-SSL_CERT_FILE = "{{config_root}}/.pixi/envs/default/ssl/cacert.pem"

--- a/cmake/render/vulkan.cmake
+++ b/cmake/render/vulkan.cmake
@@ -1,5 +1,16 @@
 function(mln_configure_vulkan_backend target)
-  find_library(MLN_VULKAN_LOADER_LIBRARY NAMES vulkan vulkan-1 REQUIRED)
+  set(_mln_vulkan_loader_names vulkan vulkan-1 vulkan.1)
+  set(_mln_vulkan_loader_hints)
+  if(DEFINED ENV{MLN_FFI_DEPENDENCY_LIBRARY_DIR} AND NOT
+                                       "$ENV{MLN_FFI_DEPENDENCY_LIBRARY_DIR}" STREQUAL "")
+    list(APPEND _mln_vulkan_loader_hints "$ENV{MLN_FFI_DEPENDENCY_LIBRARY_DIR}")
+  endif()
+
+  find_library(
+    MLN_VULKAN_LOADER_LIBRARY
+    NAMES ${_mln_vulkan_loader_names}
+    HINTS ${_mln_vulkan_loader_hints}
+    REQUIRED)
 
   set(MLN_FFI_VENDOR_VULKAN_SOURCES
       ${MLN_SOURCE_DIR}/platform/default/src/mbgl/vulkan/headless_backend.cpp)

--- a/cmake/render/vulkan.cmake
+++ b/cmake/render/vulkan.cmake
@@ -1,16 +1,13 @@
 function(mln_configure_vulkan_backend target)
-  set(_mln_vulkan_loader_names vulkan vulkan-1 vulkan.1)
-  set(_mln_vulkan_loader_hints)
-  if(DEFINED ENV{MLN_FFI_DEPENDENCY_LIBRARY_DIR} AND NOT
-                                       "$ENV{MLN_FFI_DEPENDENCY_LIBRARY_DIR}" STREQUAL "")
-    list(APPEND _mln_vulkan_loader_hints "$ENV{MLN_FFI_DEPENDENCY_LIBRARY_DIR}")
+  if(APPLE)
+    find_library(
+      MLN_VULKAN_LOADER_LIBRARY
+      NAMES vulkan.1
+      PATHS "$ENV{MLN_FFI_DEPENDENCY_LIBRARY_DIR}" NO_DEFAULT_PATH
+      REQUIRED)
+  else()
+    find_library(MLN_VULKAN_LOADER_LIBRARY NAMES vulkan vulkan-1 REQUIRED)
   endif()
-
-  find_library(
-    MLN_VULKAN_LOADER_LIBRARY
-    NAMES ${_mln_vulkan_loader_names}
-    HINTS ${_mln_vulkan_loader_hints}
-    REQUIRED)
 
   set(MLN_FFI_VENDOR_VULKAN_SOURCES
       ${MLN_SOURCE_DIR}/platform/default/src/mbgl/vulkan/headless_backend.cpp)

--- a/cmake/render/vulkan.cmake
+++ b/cmake/render/vulkan.cmake
@@ -1,13 +1,8 @@
 function(mln_configure_vulkan_backend target)
-  if(APPLE)
-    find_library(
-      MLN_VULKAN_LOADER_LIBRARY
-      NAMES vulkan.1
-      PATHS "$ENV{MLN_FFI_DEPENDENCY_LIBRARY_DIR}" NO_DEFAULT_PATH
-      REQUIRED)
-  else()
-    find_library(MLN_VULKAN_LOADER_LIBRARY NAMES vulkan vulkan-1 REQUIRED)
-  endif()
+  find_library(
+    MLN_VULKAN_LOADER_LIBRARY
+    NAMES vulkan vulkan-1 vulkan.1
+    REQUIRED)
 
   set(MLN_FFI_VENDOR_VULKAN_SOURCES
       ${MLN_SOURCE_DIR}/platform/default/src/mbgl/vulkan/headless_backend.cpp)

--- a/pixi.lock
+++ b/pixi.lock
@@ -135,7 +135,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -150,7 +149,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/moltenvk-1.4.1-h407b865_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h637d24d_0.conda
@@ -1538,16 +1536,6 @@ packages:
   license_family: Other
   size: 59000
   timestamp: 1774073052242
-- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
-  sha256: 5dd728cebca2e96fa48d41661f1a35ed0ee3cb722669eee4e2d854c6745655eb
-  md5: 6276aa61ffc361cbf130d78cfb88a237
-  depends:
-  - __osx >=11.0
-  - libzlib 1.3.2 hbb4bfdb_2
-  license: Zlib
-  license_family: Other
-  size: 92411
-  timestamp: 1774073075482
 - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
   sha256: 47101a4055a70a4876ffc87b750ab2287b67eca793f21c8224be5e1ee6394d3f
   md5: 727109b184d680772e3122f40136d5ca
@@ -1703,16 +1691,6 @@ packages:
   license_family: APACHE
   size: 1380005
   timestamp: 1777643484676
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
-  sha256: 8dd2ac25f0ba714263aac5832d46985648f4bfb9b305b5021d702079badc08d2
-  md5: f1c0bce276210bed45a04949cfe8dc20
-  depends:
-  - __osx >=11.0
-  - libzlib 1.3.2 h8088a28_2
-  license: Zlib
-  license_family: Other
-  size: 81123
-  timestamp: 1774072974535
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
   sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
   md5: ab136e4c34e97f34fb621d2592a393d8

--- a/pixi.lock
+++ b/pixi.lock
@@ -61,7 +61,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_119.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_119.conda
@@ -117,7 +116,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2025.1-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-14.3.0-h25ba3ff_119.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_119.conda
@@ -1295,15 +1293,6 @@ packages:
   license_family: BSD
   size: 614429
   timestamp: 1764777145593
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-  md5: a9965dd99f683c5f444428f896635716
-  depends:
-  - __unix
-  license: ISC
-  run_exports: {}
-  size: 128866
-  timestamp: 1781708962055
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
   sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
   md5: 86d9cba083cd041bfbf242a01a7a1999

--- a/pixi.lock
+++ b/pixi.lock
@@ -131,7 +131,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm22-22.1.8-hab754da_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libvulkan-loader-1.4.341.0-ha6bc089_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
@@ -144,7 +143,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm22-22.1.8-h89af1be_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvulkan-loader-1.4.341.0-h3feff0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
@@ -1484,18 +1482,6 @@ packages:
   license: 0BSD
   size: 105724
   timestamp: 1775826029494
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libvulkan-loader-1.4.341.0-ha6bc089_0.conda
-  sha256: ce9bc992ffffdefbde5f7977b0a3ad9036650f8323611e4024908755891674e0
-  md5: dcce6338514e65c2b7fdf172f1264561
-  depends:
-  - __osx >=10.13
-  - libcxx >=19
-  constrains:
-  - libvulkan-headers 1.4.341.0.*
-  license: Apache-2.0
-  license_family: APACHE
-  size: 182703
-  timestamp: 1770077140315
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
   sha256: 437f003e299d77403db42d17e532d686236f357ac5c3d6bf466558c697902597
   md5: c74ae93cd7876e3a9c4b5569d5e29e34
@@ -1629,18 +1615,6 @@ packages:
   license: 0BSD
   size: 92472
   timestamp: 1775825802659
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvulkan-loader-1.4.341.0-h3feff0a_0.conda
-  sha256: d2790dafc9149b1acd45b9033d02cfa3f3e9ee5af97bd61e0a5718c414a0a135
-  md5: 6b4c9a5b130759136a0dde0c373cb0ea
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  constrains:
-  - libvulkan-headers 1.4.341.0.*
-  license: Apache-2.0
-  license_family: APACHE
-  size: 180304
-  timestamp: 1770077143460
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
   sha256: ff75b84cdb9e8d123db2fa694a8ac2c2059516b6cbc98ac21fb68e235d0fd354
   md5: 19edaa53885fc8205614b03da2482282

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,15 +19,13 @@ macos = "14.0"
 # Native support library used by binding generators.
 libclang = ">=22,<23"
 
-# Native libraries linked across all desktop platforms.
-libvulkan-loader = ">=1.4,<2"
-
 [target.linux.dependencies]
 ca-certificates = ">=2024,<2027"
 c-compiler = ">=1,<2"
 cxx-compiler = ">=1,<2"
 libgles-devel = ">=1.7.0,<2"
 libuv = ">=1,<2"
+libvulkan-loader = ">=1.4,<2"
 zlib = ">=1.3,<2"
 
 [target.osx-arm64.dependencies]
@@ -35,4 +33,5 @@ moltenvk = ">=1.4.1,<2"
 
 [target.win.dependencies]
 libuv = ">=1,<2"
+libvulkan-loader = ">=1.4,<2"
 zlib = ">=1.3,<2"

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,6 @@ macos = "14.0"
 libclang = ">=22,<23"
 
 [target.linux.dependencies]
-ca-certificates = ">=2024,<2027"
 c-compiler = ">=1,<2"
 cxx-compiler = ">=1,<2"
 libgles-devel = ">=1.7.0,<2"

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,27 +21,18 @@ libclang = ">=22,<23"
 
 # Native libraries linked across all desktop platforms.
 libvulkan-loader = ">=1.4,<2"
+
+[target.linux.dependencies]
+ca-certificates = ">=2024,<2027"
+c-compiler = ">=1,<2"
+cxx-compiler = ">=1,<2"
+libgles-devel = ">=1.7.0,<2"
+libuv = ">=1,<2"
 zlib = ">=1.3,<2"
-
-[target.linux-64.dependencies]
-c-compiler = ">=1,<2"
-cxx-compiler = ">=1,<2"
-libuv = ">=1,<2"
-libgles-devel = ">=1.7.0,<2"
-ca-certificates = ">=2024,<2027"
-
-[target.linux-aarch64.dependencies]
-c-compiler = ">=1,<2"
-cxx-compiler = ">=1,<2"
-libuv = ">=1,<2"
-libgles-devel = ">=1.7.0,<2"
-ca-certificates = ">=2024,<2027"
 
 [target.osx-arm64.dependencies]
 moltenvk = ">=1.4.1,<2"
 
-[target.win-64.dependencies]
+[target.win.dependencies]
 libuv = ">=1,<2"
-
-[target.win-arm64.dependencies]
-libuv = ">=1,<2"
+zlib = ">=1.3,<2"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scope pixi native library deps to the platforms that link them, consolidate target tables, drop redundant Linux TLS cert pinning, and fix macOS Vulkan configure to find MoltenVK's `libvulkan.1.dylib`.

## Test plan

Ran `pixi lock`; CI should pass `variant-macos-arm64-vulkan` configure after the CMake loader lookup fix.

## AI assistance

- **Tools:** Cursor
- **Models:** Composer
- **Context:** Fixed macOS CI failure from scoping `libvulkan-loader` away from macOS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-833767ef-2171-46f9-a398-24fe440f0807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-833767ef-2171-46f9-a398-24fe440f0807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

