### PR TITLE
Add compose-map example to CI variant manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
@@ -73,6 +74,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
@@ -96,6 +98,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
@@ -119,6 +122,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
@@ -142,6 +146,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/swift-map:build
@@ -166,6 +171,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
@@ -189,6 +195,7 @@ jobs:
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/swift:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/zig-map:build
       - run: mise run //examples/zig-readback:run
@@ -326,6 +333,7 @@ jobs:
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
@@ -347,6 +355,7 @@ jobs:
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
@@ -368,6 +377,7 @@ jobs:
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build
@@ -389,6 +399,7 @@ jobs:
       - run: mise run //bindings/kotlin:jvmTest
       - run: mise run //bindings/rust:test
       - run: mise run //bindings/zig:test
+      - run: mise run //examples/compose-map:build
       - run: mise run //examples/lwjgl-map:build
       - run: mise run //examples/rust-map:check
       - run: mise run //examples/zig-map:build

--- a/ci/subprojects/examples-compose-map.toml
+++ b/ci/subprojects/examples-compose-map.toml
@@ -1,0 +1,2 @@
+[requires]
+os = ["linux", "macos", "windows"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Register `examples-compose-map` in the CI subproject manifests so Linux, macOS, and Windows desktop variants build the Compose Desktop example.

## Test plan

Regenerated `.github/workflows/ci.yml` with `uv run --script .mise/tasks/ci/generate-workflow --check`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e7ebfff-7470-49d1-b5ba-52c08de1d6d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e7ebfff-7470-49d1-b5ba-52c08de1d6d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

