### PR TITLE
CI: replace Rust component repair with mise install --force rust

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -159,19 +159,9 @@ runs:
           echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
         } >> "$GITHUB_ENV"
 
-    # The mise action may restore Rust metadata without all rustup-managed
-    # component files. Repair the toolchain only when rustup cannot add the
-    # configured components or the component binaries still cannot run.
-    - name: Ensure Rust components
+    # The mise action may restore Rust install metadata without the rustup
+    # toolchain, components, or cross targets from mise.toml. Reinstall rust
+    # from mise config instead of redeclaring components/targets here.
+    - name: Ensure Rust toolchain
       shell: bash
-      run: |
-        ensure_rust_components() {
-          mise exec -- rustup component add rustfmt clippy &&
-            mise exec -- cargo fmt --version &&
-            mise exec -- cargo clippy --version
-        }
-
-        if ! ensure_rust_components; then
-          mise install --force rust
-          ensure_rust_components
-        fi
+      run: MISE_NO_HOOKS=1 mise install --force rust


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace the conditional `rustup component add` repair step with `MISE_NO_HOOKS=1 mise install --force rust` so CI reinstalls Rust components and cross targets from `mise.toml` after a partial mise-action cache restore.

## Test plan

Reproduced locally by deleting `RUSTUP_HOME/toolchains` while keeping the mise install marker: the old component repair passed but cross targets stayed missing until `mise install --force rust` restored them.

## AI assistance

- **Tools:** Cursor
- **Models:** Composer
- **Context:** Investigated CI flakes from missing Rust targets after mise-action cache restore; validated the fix locally before changing setup-ci-deps.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13b96f34-930b-4d34-bb02-f4a632d16608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13b96f34-930b-4d34-bb02-f4a632d16608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

