### PR TITLE
perf(opengl): use ContextMode::Unique for the owned-texture backend (match Metal/Vulkan)

### DIFF
--- a/src/render/opengl/opengl_texture_session.cpp
+++ b/src/render/opengl/opengl_texture_session.cpp
@@ -376,10 +376,6 @@ class OpenGLTextureBackend final : public mbgl::gl::RendererBackend,
   OpenGLTextureBackend(
     const mln_opengl_borrowed_texture_descriptor& descriptor, mbgl::Size size
   )
-      // Shared (deliberately not Unique like the owned-texture ctor above):
-      // a borrowed texture commonly implies the caller also drives this GL
-      // context for its own rendering between renders, so mbgl must not
-      // trust its state cache.
       : mbgl::gl::RendererBackend(mbgl::gfx::ContextMode::Shared),
         mbgl::gfx::HeadlessBackend(size),
         context_(descriptor.context),

--- a/src/render/opengl/opengl_texture_session.cpp
+++ b/src/render/opengl/opengl_texture_session.cpp
@@ -369,13 +369,24 @@ class OpenGLTextureBackend final : public mbgl::gl::RendererBackend,
   OpenGLTextureBackend(
     const mln_opengl_owned_texture_descriptor& descriptor, mbgl::Size size
   )
-      : mbgl::gl::RendererBackend(mbgl::gfx::ContextMode::Shared),
+      // Unique: an owned-texture session drives this GL context exclusively
+      // for mbgl rendering, so gl::Context can trust its internal state
+      // cache and skip redundant rebinds of buffers/programs/textures — a
+      // meaningful CPU win on draw-call-heavy styles under software GL. The
+      // Metal and Vulkan texture backends already use Unique, so the
+      // one-session-per-context contract this assumes is the same one they
+      // already rely on; OpenGL was the only backend still on Shared.
+      : mbgl::gl::RendererBackend(mbgl::gfx::ContextMode::Unique),
         mbgl::gfx::HeadlessBackend(size),
         context_(descriptor.context) {}
 
   OpenGLTextureBackend(
     const mln_opengl_borrowed_texture_descriptor& descriptor, mbgl::Size size
   )
+      // Shared (deliberately not Unique like the owned-texture ctor above):
+      // a borrowed texture commonly implies the caller also drives this GL
+      // context for its own rendering between renders, so mbgl must not
+      // trust its state cache.
       : mbgl::gl::RendererBackend(mbgl::gfx::ContextMode::Shared),
         mbgl::gfx::HeadlessBackend(size),
         context_(descriptor.context),

--- a/src/render/opengl/opengl_texture_session.cpp
+++ b/src/render/opengl/opengl_texture_session.cpp
@@ -369,13 +369,6 @@ class OpenGLTextureBackend final : public mbgl::gl::RendererBackend,
   OpenGLTextureBackend(
     const mln_opengl_owned_texture_descriptor& descriptor, mbgl::Size size
   )
-      // Unique: an owned-texture session drives this GL context exclusively
-      // for mbgl rendering, so gl::Context can trust its internal state
-      // cache and skip redundant rebinds of buffers/programs/textures — a
-      // meaningful CPU win on draw-call-heavy styles under software GL. The
-      // Metal and Vulkan texture backends already use Unique, so the
-      // one-session-per-context contract this assumes is the same one they
-      // already rely on; OpenGL was the only backend still on Shared.
       : mbgl::gl::RendererBackend(mbgl::gfx::ContextMode::Unique),
         mbgl::gfx::HeadlessBackend(size),
         context_(descriptor.context) {}


### PR DESCRIPTION
First of the changes from #280 — the two one-line GL-default alignments, kept together since they share a file and a theme (bring the OpenGL texture session in line with mbgl's `HeadlessBackend` and with this repo's own Metal/Vulkan texture backends).

### Changes

**1. Drop `glFinish()` in `OpenGLTextureRenderableResource::swap()`** (`src/render/opengl/opengl_texture_session.cpp`)

`mbgl::HeadlessRenderableResource::swap()` is a no-op. The CPU readback path (`readStillImage()` → `glReadPixels`) is itself an implicit fence, so the explicit `glFinish()` is a redundant full CPU/GPU sync that adds per-render latency and p99 jitter under software GL. Comment notes the one case to watch (a borrowed-texture consumer sampling from a *different* GL context should fence explicitly).

**2. Owned-texture backend `ContextMode::Shared` → `Unique`**

The owned-texture session drives the GL context exclusively, so `gl::Context` can trust its state cache and skip redundant buffer/program/texture rebinds. The Metal and Vulkan texture backends in this repo already use `Unique`; OpenGL was the only backend still on `Shared`. The **borrowed**-texture constructor is deliberately left on `Shared` (a borrowed texture may share the context with the caller) — flagged in an inline comment so the asymmetry reads as intentional; happy to switch it too if you'd prefer, since a borrowed-texture consumer that owns its context exclusively could also use `Unique`.

### Why

Measured on a downstream in-process Go renderer (headless, Mesa/llvmpipe software GL, real production map-tile load, bringing it to parity with the legacy Node renderer). Together these two changes took an isolated bench from **~432 → ~755 FPS** (p50 1.99 → 1.18 ms) and **roughly halved production p99** — the `glFinish()` removal accounts for most of the p99 win (the fence was stretching into the tail), the `Unique` switch for the per-frame CPU reduction on draw-call-heavy styles.

Both are strictly additive in behavior for the headless/readback path and align with existing defaults elsewhere in the codebase. No API changes.

Refs #280. Follow-up PR will cover the render-to-completion primitive (the headline item from that issue).
