### PR TITLE
feat(map): add mln_map_render_still_blocking — synchronous render to completion

### DIFF
--- a/bindings/go/errors.go
+++ b/bindings/go/errors.go
@@ -26,6 +26,9 @@ var (
 	ErrUnsupported = errors.New("maplibre: unsupported")
 	// ErrNative reports a MapLibre Native error converted to a C status.
 	ErrNative = errors.New("maplibre: native error")
+	// ErrTimeout reports that a blocking call (e.g. RenderStillBlocking)
+	// exceeded its caller-supplied timeout.
+	ErrTimeout = errors.New("maplibre: timeout")
 	// ErrABIVersionMismatch reports that the loaded C ABI version is
 	// incompatible with this binding.
 	ErrABIVersionMismatch = errors.New("maplibre: ABI version mismatch")
@@ -121,6 +124,8 @@ func kindForStatus(status int32) error {
 		return ErrUnsupported
 	case int32(C.MLN_STATUS_NATIVE_ERROR):
 		return ErrNative
+	case int32(C.MLN_STATUS_TIMEOUT):
+		return ErrTimeout
 	default:
 		return ErrUnknownStatus
 	}

--- a/bindings/go/map.go
+++ b/bindings/go/map.go
@@ -116,6 +116,23 @@ func (m *MapHandle) RequestStillImage() error {
 	return checkNative(func() int32 { return int32(C.mln_map_request_still_image((*C.mln_map)(unsafe.Pointer(ptr)))) })
 }
 
+// RenderStillBlocking renders one still image to completion synchronously,
+// driving the runtime RunLoop in native code. No render-update events are
+// emitted and the caller does not pump during the call. timeoutMs == 0 blocks
+// until done; timeoutMs > 0 returns an error with status MLN_STATUS_TIMEOUT if
+// the deadline is exceeded.
+func (m *MapHandle) RenderStillBlocking(timeoutMs uint64) error {
+	ptr, release, err := m.ptr()
+	if err != nil {
+		return err
+	}
+	defer release()
+	defer m.state.KeepAlive()
+	return checkNative(func() int32 {
+		return int32(C.mln_map_render_still_blocking((*C.mln_map)(unsafe.Pointer(ptr)), C.uint64_t(timeoutMs)))
+	})
+}
+
 // SetStyleURL loads a style URL through MapLibre Native style APIs.
 func (m *MapHandle) SetStyleURL(url string) error {
 	if err := validateCStringArgument("style URL", url); err != nil {

--- a/include/maplibre_native_c/base.h
+++ b/include/maplibre_native_c/base.h
@@ -47,6 +47,8 @@ typedef enum mln_status : int32_t {
   MLN_STATUS_UNSUPPORTED = -4,
   /** A native MapLibre error or C++ exception was converted to status. */
   MLN_STATUS_NATIVE_ERROR = -5,
+  /** A blocking call exceeded its caller-supplied timeout. */
+  MLN_STATUS_TIMEOUT = -6,
 } mln_status;
 
 /** Render backend support flags reported by this native library build. */

--- a/include/maplibre_native_c/map.h
+++ b/include/maplibre_native_c/map.h
@@ -1063,6 +1063,49 @@ MLN_API mln_status mln_map_request_repaint(mln_map* map) MLN_NOEXCEPT;
 MLN_API mln_status mln_map_request_still_image(mln_map* map) MLN_NOEXCEPT;
 
 /**
+ * Renders one still image to completion synchronously.
+ *
+ * Unlike mln_map_request_still_image(), this drives the runtime's RunLoop
+ * internally (mirroring mbgl's HeadlessFrontend::render): the frontend
+ * self-draws the progressive frames into the attached render session, so NO
+ * MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE events are emitted and the
+ * caller does NOT pump, poll, or call mln_render_session_render_update() during
+ * this call. It blocks the runtime owner thread until the still image is
+ * complete, then leaves the finished frame in the attached render session for
+ * readback via the existing texture/surface API.
+ *
+ * Requires a render session attached to the map (see
+ * mln_render_session attach calls). timeout_ms == 0 blocks until the render
+ * completes; timeout_ms > 0 returns MLN_STATUS_TIMEOUT if the deadline is
+ * exceeded.
+ *
+ * On timeout the in-flight render is left pending — mbgl provides no
+ * still-render cancellation, and starting a second render while one is pending
+ * is rejected. It resolves (and frees the map for a new still request) only
+ * when the runtime RunLoop is next driven, e.g. by a subsequent
+ * mln_map_render_still_blocking() or mln_runtime_run_once() on the same
+ * runtime. A caller that stops driving the runtime after a timeout therefore
+ * leaves the still-image slot pending, and later still requests on that map
+ * return MLN_STATUS_INVALID_STATE until it resolves. For purely synchronous
+ * callers, prefer timeout_ms == 0 and treat any non-zero timeout as a
+ * deadlock backstop rather than routine cancellation.
+ *
+ * Returns:
+ * - MLN_STATUS_OK when the still image rendered successfully.
+ * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live.
+ * - MLN_STATUS_INVALID_STATE when map is not in MLN_MAP_MODE_STATIC or
+ *   MLN_MAP_MODE_TILE, when a still-image request is already pending, or when
+ * no render session is attached.
+ * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
+ *   thread.
+ * - MLN_STATUS_TIMEOUT when timeout_ms > 0 elapses before completion.
+ * - MLN_STATUS_NATIVE_ERROR when the render fails or an internal exception is
+ *   converted to status.
+ */
+MLN_API mln_status
+mln_map_render_still_blocking(mln_map* map, uint64_t timeout_ms) MLN_NOEXCEPT;
+
+/**
  * Destroys a map handle on its owner thread.
  *
  * The map must not have an attached render session.

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -7,6 +7,7 @@
 
 #include "c_api/boundary.hpp"
 #include "maplibre_native_c.h"
+#include "render/render_session_common.hpp"
 
 auto mln_map_options_default(void) noexcept -> mln_map_options {
   return mln::core::map_options_default();
@@ -91,6 +92,13 @@ auto mln_map_request_repaint(mln_map* map) noexcept -> mln_status {
 auto mln_map_request_still_image(mln_map* map) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
     return mln::core::map_request_still_image(map);
+  });
+}
+
+auto mln_map_render_still_blocking(mln_map* map, uint64_t timeout_ms) noexcept
+  -> mln_status {
+  return mln::c_api::status_boundary([&]() -> mln_status {
+    return mln::core::map_render_still_blocking(map, timeout_ms);
   });
 }
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1230,17 +1230,50 @@ class HeadlessFrontend final : public mbgl::RendererFrontend {
   }
 
   void update(std::shared_ptr<mbgl::UpdateParameters> update) override {
-    const std::scoped_lock lock(latest_update_mutex_);
-    latest_update_ = std::move(update);
-    mln::core::push_runtime_map_event(
-      runtime_, map_, MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE
-    );
+    bool self_draw = false;
+    {
+      const std::scoped_lock lock(latest_update_mutex_);
+      latest_update_ = std::move(update);
+      if (self_draw_) {
+        pending_self_draw_ = true;
+        self_draw = true;
+      }
+    }
+    // In self-draw mode (a blocking render is driving the loop in C++) we
+    // record a pending draw instead of queuing an event — no
+    // MAP_RENDER_UPDATE_AVAILABLE is emitted and the caller never pumps.
+    if (!self_draw) {
+      mln::core::push_runtime_map_event(
+        runtime_, map_, MLN_RUNTIME_EVENT_MAP_RENDER_UPDATE_AVAILABLE
+      );
+    }
   }
 
   [[nodiscard]] auto latest_update() const
     -> std::shared_ptr<mbgl::UpdateParameters> {
     const std::scoped_lock lock(latest_update_mutex_);
     return latest_update_;
+  }
+
+  // Enables/disables self-draw mode (see update()). Resets the pending-draw
+  // flag so the first draw of a blocking render happens only after a fresh
+  // update() — matching the event-driven path, where a render-update is
+  // serviced only after the frontend has produced parameters. Owner thread
+  // only.
+  auto set_self_draw(bool enabled) -> void {
+    const std::scoped_lock lock(latest_update_mutex_);
+    self_draw_ = enabled;
+    pending_self_draw_ = false;
+  }
+
+  // Returns whether a self-draw is pending and clears the flag, so multiple
+  // update() calls between pumps collapse into a single draw (the same
+  // coalescing the event path gets from the runtime queue).
+  [[nodiscard]] auto take_pending_self_draw() -> bool {
+    const std::scoped_lock lock(latest_update_mutex_);
+    const bool pending = pending_self_draw_;
+    pending_self_draw_ = false;
+    return pending;
   }
 
   auto run_render_jobs() -> void { thread_pool_.runRenderJobs(); }
@@ -1261,6 +1294,10 @@ class HeadlessFrontend final : public mbgl::RendererFrontend {
   mbgl::TaggedScheduler thread_pool_;
   mutable std::mutex latest_update_mutex_;
   std::shared_ptr<mbgl::UpdateParameters> latest_update_;
+  // Self-draw mode for mln_map_render_still_blocking. Guarded by
+  // latest_update_mutex_; only touched on the runtime owner thread.
+  bool self_draw_ = false;
+  bool pending_self_draw_ = false;
 };
 
 auto validate_map_options(const mln_map_options* options) -> mln_status {
@@ -2796,6 +2833,62 @@ auto map_renderer_observer(mln_map* map) -> mbgl::RendererObserver* {
 
 auto map_run_render_jobs(mln_map* map) -> void {
   map->frontend->run_render_jobs();
+}
+
+auto map_runtime(mln_map* map) -> mln_runtime* {
+  if (map == nullptr) {
+    return nullptr;
+  }
+  return map->runtime;
+}
+
+auto map_render_target_session(mln_map* map) -> void* {
+  if (map == nullptr) {
+    return nullptr;
+  }
+  return map->render_target_session;
+}
+
+auto map_set_self_draw(mln_map* map, bool enabled) -> void {
+  if (map == nullptr || map->frontend == nullptr) {
+    return;
+  }
+  map->frontend->set_self_draw(enabled);
+}
+
+auto map_take_pending_self_draw(mln_map* map) -> bool {
+  if (map == nullptr || map->frontend == nullptr) {
+    return false;
+  }
+  return map->frontend->take_pending_self_draw();
+}
+
+// Reserves the single still-image slot for a synchronous blocking render,
+// applying the same guards as map_request_still_image but without installing
+// the event-pushing completion callback. The caller drives renderStill itself
+// and must pair this with map_end_still_request.
+auto map_begin_still_request(mln_map* map) -> mln_status {
+  const auto status = validate_map(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+  if (!is_still_map_mode(map->map_mode)) {
+    set_thread_error("map is not in static or tile mode");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  if (map->still_image_request_pending) {
+    set_thread_error("map already has a pending still-image request");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  map->still_image_request_pending = true;
+  return MLN_STATUS_OK;
+}
+
+auto map_end_still_request(mln_map* map) -> void {
+  if (map == nullptr) {
+    return;
+  }
+  map->still_image_request_pending = false;
 }
 
 auto map_attach_render_target_session(mln_map* map, void* session)

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -364,6 +364,12 @@ auto map_native(mln_map* map) -> mbgl::Map*;
 auto map_latest_update(mln_map* map) -> std::shared_ptr<mbgl::UpdateParameters>;
 auto map_renderer_observer(mln_map* map) -> mbgl::RendererObserver*;
 auto map_run_render_jobs(mln_map* map) -> void;
+auto map_runtime(mln_map* map) -> mln_runtime*;
+auto map_render_target_session(mln_map* map) -> void*;
+auto map_set_self_draw(mln_map* map, bool enabled) -> void;
+auto map_take_pending_self_draw(mln_map* map) -> bool;
+auto map_begin_still_request(mln_map* map) -> mln_status;
+auto map_end_still_request(mln_map* map) -> void;
 auto map_attach_render_target_session(mln_map* map, void* session)
   -> mln_status;
 auto map_detach_render_target_session(mln_map* map, void* session)

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -23,7 +24,9 @@
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/geojson.hpp>
+#include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/size.hpp>
+#include <mbgl/util/timer.hpp>
 
 #include "render/render_session_common.hpp"
 
@@ -31,6 +34,7 @@
 #include "geojson/geojson.hpp"
 #include "map/map.hpp"
 #include "maplibre_native_c.h"
+#include "runtime/runtime.hpp"
 #include "style/style_value.hpp"
 
 namespace mln::core {
@@ -1029,6 +1033,167 @@ auto render_session_render_update(mln_render_session* session) -> mln_status {
     }
   }
   session->rendered_generation = session->generation;
+  return MLN_STATUS_OK;
+}
+
+namespace {
+
+struct BlockingRenderState {
+  bool done = false;
+  bool failed = false;
+  std::string message;
+};
+
+// Restores the frontend out of self-draw mode on every exit path — including a
+// synchronous exception from renderStill or the pump that the c_api
+// status_boundary catches above this frame, which would otherwise leave the map
+// stuck in self-draw and silently stop emitting MAP_RENDER_UPDATE_AVAILABLE for
+// ordinary rendering.
+struct SelfDrawGuard {
+  mln_map* map;
+  ~SelfDrawGuard() { map_set_self_draw(map, false); }
+};
+
+// Drives the runtime RunLoop until the still completes (state->done),
+// self-drawing each pending frame. When idle it blocks in runOnce() (waking on
+// the next tile/completion event, or on a one-shot Timer armed to the deadline)
+// so a cold render waits on tile IO without busy-spinning. Returns
+// MLN_STATUS_TIMEOUT on deadline, a draw error status if a self-draw fails, or
+// MLN_STATUS_OK once the render completes.
+auto pump_blocking_render(
+  mln_map* map, mln_render_session* session, mbgl::util::RunLoop& run_loop,
+  const std::shared_ptr<BlockingRenderState>& state, uint64_t timeout_ms
+) -> mln_status {
+  const bool has_timeout = timeout_ms > 0;
+  const auto deadline =
+    std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+
+  while (!state->done) {
+    const auto now = std::chrono::steady_clock::now();
+    if (has_timeout && now >= deadline) {
+      set_thread_error("render still blocking timed out");
+      return MLN_STATUS_TIMEOUT;
+    }
+
+    // Service pending self-draws BEFORE parking. renderStill -> Map::onUpdate
+    // -> frontend.update() sets the first pending draw synchronously, with no
+    // libuv event to wake runOnce; and a render can complete the still
+    // synchronously (onDidFinishRenderingFrame fires inside
+    // renderer->render()). If we blocked in runOnce first, the loop would park
+    // a full slice with a draw already pending — a fixed per-render stall.
+    // Draining first means a warm render returns in render-time without ever
+    // blocking.
+    if (map_take_pending_self_draw(map)) {
+      const auto draw_status = render_session_render_update(session);
+      if (draw_status != MLN_STATUS_OK) {
+        return draw_status;
+      }
+      continue;
+    }
+
+    // Idle: nothing to draw and not done. Block until the next event (a tile
+    // load completing, which mbgl posts to this loop, waking the run loop) so
+    // progressive cold renders advance without busy-spinning.
+    //
+    // mbgl::util::RunLoop::runOnce() takes no timeout, so for a bounded wait we
+    // arm a one-shot Timer to the remaining budget: when it fires it posts to
+    // this loop, waking runOnce() so we return to the top and re-check the
+    // deadline (bounding a stalled render that produces no tile events). A real
+    // tile/completion event wakes runOnce() earlier. With no timeout we block
+    // until the next event, matching "blocks until done".
+    mbgl::util::Timer wake_timer;
+    if (has_timeout) {
+      const auto remaining =
+        std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+      wake_timer.start(
+        remaining.count() < 1 ? std::chrono::milliseconds(1) : remaining,
+        mbgl::Duration::zero(),
+        [] {}
+      );
+    }
+    run_loop.runOnce();
+  }
+  return MLN_STATUS_OK;
+}
+
+}  // namespace
+
+auto map_render_still_blocking(mln_map* map, uint64_t timeout_ms)
+  -> mln_status {
+  // Reserve the still slot (validates the map, mode, owner thread, and that no
+  // request is already pending) before touching anything else.
+  auto status = map_begin_still_request(map);
+  if (status != MLN_STATUS_OK) {
+    return status;
+  }
+
+  auto* session =
+    static_cast<mln_render_session*>(map_render_target_session(map));
+  if (session == nullptr) {
+    map_end_still_request(map);
+    set_thread_error("map has no attached render session");
+    return MLN_STATUS_INVALID_STATE;
+  }
+  status = validate_live_attached_render_session(session);
+  if (status != MLN_STATUS_OK) {
+    map_end_still_request(map);
+    return status;
+  }
+  auto* runtime = map_runtime(map);
+  if (runtime == nullptr || runtime->run_loop == nullptr) {
+    map_end_still_request(map);
+    set_thread_error("map runtime is not available");
+    return MLN_STATUS_INVALID_STATE;
+  }
+
+  auto state = std::make_shared<BlockingRenderState>();
+
+  // Switch the frontend to self-draw: update() now records a pending draw
+  // instead of pushing MAP_RENDER_UPDATE_AVAILABLE events. The guard restores
+  // event mode on every exit, including the exception path (see SelfDrawGuard).
+  map_set_self_draw(map, true);
+  const SelfDrawGuard self_draw_guard{map};
+
+  // The completion callback captures `map` as a raw pointer, which is safe
+  // because mbgl owns the callback and never invokes it after the map dies:
+  // mbgl::Map::Impl holds the pending StillImageRequest, and ~Map destroys the
+  // Impl (dropping the request's unique_ptr) WITHOUT calling the callback — see
+  // mbgl src/mbgl/map/map.cpp. So on the timeout path, the callback either
+  // fires while the map is still alive (a later RunLoop pump resolves the
+  // render) or is dropped when the host destroys the map; it can never run
+  // against a freed `mln_map`. `state` is captured by shared_ptr so a
+  // completion arriving after a timeout return writes to live heap, never a
+  // dangling stack frame. Clearing the pending flag here is what lets a
+  // timed-out render self-heal: the map accepts a new still request once the
+  // in-flight render finally resolves on a subsequent pump.
+  map_native(map)->renderStill([map, state](std::exception_ptr error) -> void {
+    if (error) {
+      try {
+        std::rethrow_exception(error);
+      } catch (const std::exception& exception) {
+        state->message = exception.what();
+      } catch (...) {
+        state->message = "unknown render error";
+      }
+      state->failed = true;
+    }
+    state->done = true;
+    map_end_still_request(map);
+  });
+
+  const auto result =
+    pump_blocking_render(map, session, *runtime->run_loop, state, timeout_ms);
+
+  // self_draw_guard restores event mode on return. The pending still-image
+  // request is cleared by the completion callback — which has already fired on
+  // the success path, and fires later (resolving the slot) on timeout/abort.
+  if (result != MLN_STATUS_OK) {
+    return result;
+  }
+  if (state->failed) {
+    set_thread_error(state->message.c_str());
+    return MLN_STATUS_NATIVE_ERROR;
+  }
   return MLN_STATUS_OK;
 }
 

--- a/src/render/render_session_common.hpp
+++ b/src/render/render_session_common.hpp
@@ -247,6 +247,13 @@ auto render_session_resize(
   double scale_factor
 ) -> mln_status;
 auto render_session_render_update(mln_render_session* session) -> mln_status;
+// Renders a still image to completion synchronously by driving the runtime
+// RunLoop in C++ and self-drawing each progressive frame into the map's
+// attached render session — no MAP_RENDER_UPDATE_AVAILABLE events, no caller
+// pump. Implemented here because it bridges the map (renderStill, frontend)
+// and render (render_session_render_update) layers. See
+// mln_map_render_still_blocking.
+auto map_render_still_blocking(mln_map* map, uint64_t timeout_ms) -> mln_status;
 auto render_session_detach(mln_render_session* session) -> mln_status;
 auto render_session_destroy(mln_render_session* session) -> mln_status;
 auto render_session_reduce_memory_use(mln_render_session* session)


### PR DESCRIPTION
The headline item from #280: a synchronous render-to-completion primitive so non-libuv bindings don't have to pump the event loop frame-by-frame across the language boundary.

### What it does

`mln_map_render_still_blocking(map, timeout_ms)` runs the runtime RunLoop to completion in native code and self-draws each frame into the attached render session, returning only when the still is finished (or the timeout elapses). No `MAP_RENDER_UPDATE_AVAILABLE` events are emitted and the caller never pumps.

Today every non-libuv binding renders via `request_still_image` → loop { `run_once`/`poll_event` → `render_session_render_update` per `MAP_RENDER_UPDATE_AVAILABLE` } — the whole update→renderFrame loop crosses the boundary, ~15 round trips for a cold tile render. This collapses it to one call, the shape `mbgl::HeadlessFrontend::render` already uses internally.

### Implementation

- **`HeadlessFrontend` self-draw mode** — while a blocking render drives the loop, `update()` records a pending draw instead of queuing an event; multiple `update()`s between pumps coalesce into one draw.
- **`pump_blocking_render` services pending self-draws *before* parking** in `runOnce(slice)`. `renderStill` → `onUpdate` sets the first draw synchronously with no libuv event to wake the loop, and a still can complete synchronously inside `renderer->render()`; draining first means a warm render returns in render-time without ever blocking on a timer slice. Idle waits block in epoll (woken by tile-load posts), so cold progressive renders advance without busy-spinning. (We initially shipped this without the drain-before-park step and saw a fixed ~1–2 s/render stall — that's what this ordering avoids.)
- **`MLN_STATUS_TIMEOUT` (-6)**; `timeout_ms == 0` blocks indefinitely.
- `mln_c_version()` unchanged — the addition is backward-compatible.

### Why

Measured on a downstream in-process Go renderer (headless, Mesa/llvmpipe, production tile load): scale=1 p50 **~31 → ~24 ms** and p99 **~242 → ~136 ms** versus the event-driven pump, bringing it to parity with the legacy Node renderer. This is the change that closed the gap; it's been running in production.

### Scope / questions for you

- **Bindings:** I've added the C ABI + the **Go** binding (`MapHandle.RenderStillBlocking`, with an `ErrTimeout` mapping for the new status), since that's the one validated end-to-end. The other bindings (Rust/Zig/Kotlin/.NET/Swift/Python/Vala) aren't touched — happy to extend them in this PR or as follow-ups, whichever you prefer, and let me know if any are generated rather than hand-written so I do it the right way.
- **Tests:** I didn't add one yet — I'd rather put it where you'd want it (a C-ABI-level test under `src/c_api/tests/`, mirroring the existing still-render coverage, vs. a per-binding test). Point me at the preferred shape and I'll add it.
- The borrowed/owned synchronization concerns from #281 don't apply here — this path goes through `render_session_render_update` / the existing readback contract unchanged.

Refs #280. Companion to #281 (GL defaults).
