### PR TITLE
Build Apple targets from Linux with xtool

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,6 +36,7 @@
       "name": "_macos-arm64",
       "hidden": true,
       "inherits": "_single-config",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/apple.cmake",
       "cacheVariables": {
         "CMAKE_OSX_ARCHITECTURES": "arm64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "14.3",
@@ -46,6 +47,7 @@
       "name": "_ios-arm64",
       "hidden": true,
       "inherits": "_single-config",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/apple.cmake",
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "iOS",
         "CMAKE_OSX_ARCHITECTURES": "arm64",

--- a/cmake/mln_target.cmake
+++ b/cmake/mln_target.cmake
@@ -66,25 +66,14 @@ function(mln_configure_complete_static_archive target)
   elseif(MLN_FFI_ARCHIVE_FORMAT STREQUAL "apple")
     get_target_property(MLN_FFI_ARCHIVE_TOOL mln_ffi_platform_dependencies
                         MLN_FFI_ARCHIVE_TOOL)
-    get_target_property(
-      MLN_FFI_RELOCATABLE_LINK_OPTIONS mln_ffi_platform_dependencies
-      MLN_FFI_RELOCATABLE_LINK_OPTIONS)
     add_custom_command(
       OUTPUT "${MLN_FFI_COMPLETE_STATIC_ARCHIVE}"
       COMMAND "${CMAKE_COMMAND}" -E rm -rf "${MLN_FFI_COMPLETE_STATIC_DIR}"
       COMMAND
         "${CMAKE_COMMAND}" -E make_directory "${MLN_FFI_COMPLETE_STATIC_DIR}"
       COMMAND
-        "${CMAKE_LINKER}"
-        -r
-        ${MLN_FFI_RELOCATABLE_LINK_OPTIONS}
-        -o
-        "${MLN_FFI_COMPLETE_STATIC_OBJECT}"
-        -all_load
-        ${MLN_FFI_INPUT_ARCHIVES}
-      COMMAND
         "${MLN_FFI_ARCHIVE_TOOL}" -static -o
-        "${MLN_FFI_COMPLETE_STATIC_ARCHIVE}" "${MLN_FFI_COMPLETE_STATIC_OBJECT}"
+        "${MLN_FFI_COMPLETE_STATIC_ARCHIVE}" ${MLN_FFI_INPUT_ARCHIVES}
       DEPENDS ${MLN_FFI_INPUT_TARGETS}
       VERBATIM)
   elseif(MLN_FFI_ARCHIVE_FORMAT STREQUAL "elf")

--- a/cmake/platform/apple.cmake
+++ b/cmake/platform/apple.cmake
@@ -80,27 +80,10 @@ function(mln_configure_platform_dependencies target)
   endif()
 
   find_program(MLN_FFI_LIBTOOL NAMES libtool REQUIRED)
-  list(GET CMAKE_OSX_ARCHITECTURES 0 MLN_FFI_OSX_ARCHITECTURE)
-  set(MLN_FFI_RELOCATABLE_LINK_OPTIONS -arch "${MLN_FFI_OSX_ARCHITECTURE}"
-      -syslibroot "${MLN_FFI_APPLE_SDK}")
-  if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
-    if(CMAKE_OSX_SYSROOT MATCHES "[iI][pP]hone[Ss]imulator")
-      set(MLN_FFI_APPLE_PLATFORM ios-simulator)
-    else()
-      set(MLN_FFI_APPLE_PLATFORM ios)
-    endif()
-  else()
-    set(MLN_FFI_APPLE_PLATFORM macos)
-  endif()
-  list(
-    APPEND MLN_FFI_RELOCATABLE_LINK_OPTIONS -platform_version
-    "${MLN_FFI_APPLE_PLATFORM}" "${CMAKE_OSX_DEPLOYMENT_TARGET}"
-    "${CMAKE_OSX_DEPLOYMENT_TARGET}")
   set_target_properties(
     ${target}
     PROPERTIES
-      MLN_FFI_ARCHIVE_FORMAT apple MLN_FFI_ARCHIVE_TOOL "${MLN_FFI_LIBTOOL}"
-      MLN_FFI_RELOCATABLE_LINK_OPTIONS "${MLN_FFI_RELOCATABLE_LINK_OPTIONS}")
+      MLN_FFI_ARCHIVE_FORMAT apple MLN_FFI_ARCHIVE_TOOL "${MLN_FFI_LIBTOOL}")
 endfunction()
 
 function(mln_configure_platform target)

--- a/cmake/toolchains/apple.cmake
+++ b/cmake/toolchains/apple.cmake
@@ -1,0 +1,57 @@
+if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+  return()
+endif()
+
+list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES MLN_FFI_XTOOL_SDK_BUNDLE
+     CMAKE_OSX_DEPLOYMENT_TARGET CMAKE_OSX_SYSROOT)
+
+set(MLN_FFI_XTOOL_SDK_BUNDLE
+    "$ENV{HOME}/.swiftpm/swift-sdks/darwin.artifactbundle"
+    CACHE PATH "Darwin Swift SDK artifact bundle installed by xtool")
+if(NOT EXISTS "${MLN_FFI_XTOOL_SDK_BUNDLE}/toolset/bin/ld64.lld")
+  message(
+    FATAL_ERROR "No xtool Darwin SDK found; run `xtool.AppImage sdk install`")
+endif()
+
+string(TOLOWER "${CMAKE_OSX_SYSROOT}" MLN_FFI_XTOOL_SYSROOT_NAME)
+if(MLN_FFI_XTOOL_SYSROOT_NAME MATCHES "iphonesimulator")
+  set(CMAKE_SYSTEM_NAME iOS)
+  set(MLN_FFI_XTOOL_TRIPLE
+      "arm64-apple-ios${CMAKE_OSX_DEPLOYMENT_TARGET}-simulator")
+  set(MLN_FFI_XTOOL_SYSROOT
+      "${MLN_FFI_XTOOL_SDK_BUNDLE}/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk")
+elseif(MLN_FFI_XTOOL_SYSROOT_NAME MATCHES "iphoneos")
+  set(CMAKE_SYSTEM_NAME iOS)
+  set(MLN_FFI_XTOOL_TRIPLE "arm64-apple-ios${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  set(MLN_FFI_XTOOL_SYSROOT
+      "${MLN_FFI_XTOOL_SDK_BUNDLE}/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk")
+elseif(MLN_FFI_XTOOL_SYSROOT_NAME MATCHES "macosx")
+  set(CMAKE_SYSTEM_NAME Darwin)
+  set(MLN_FFI_XTOOL_TRIPLE "arm64-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  set(MLN_FFI_XTOOL_SYSROOT
+      "${MLN_FFI_XTOOL_SDK_BUNDLE}/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
+else()
+  message(FATAL_ERROR "Unsupported Apple SDK: ${CMAKE_OSX_SYSROOT}")
+endif()
+
+find_program(MLN_FFI_XTOOL_CLANG NAMES clang REQUIRED)
+find_program(MLN_FFI_XTOOL_CLANGXX NAMES clang++ REQUIRED)
+set(CMAKE_C_COMPILER "${MLN_FFI_XTOOL_CLANG}")
+set(CMAKE_CXX_COMPILER "${MLN_FFI_XTOOL_CLANGXX}")
+set(CMAKE_OBJC_COMPILER "${MLN_FFI_XTOOL_CLANG}")
+set(CMAKE_OBJCXX_COMPILER "${MLN_FFI_XTOOL_CLANGXX}")
+foreach(MLN_FFI_XTOOL_LANGUAGE C CXX OBJC OBJCXX)
+  set(CMAKE_${MLN_FFI_XTOOL_LANGUAGE}_COMPILER_TARGET "${MLN_FFI_XTOOL_TRIPLE}")
+endforeach()
+
+set(CMAKE_SYSTEM_PROCESSOR arm64)
+set(CMAKE_OSX_SYSROOT "${MLN_FFI_XTOOL_SYSROOT}"
+    CACHE PATH "Apple SDK root" FORCE)
+set(MLN_FFI_XTOOL_LINKER_FLAGS
+    "-B${MLN_FFI_XTOOL_SDK_BUNDLE}/toolset/bin -fuse-ld=lld")
+foreach(MLN_FFI_XTOOL_LINKER_TYPE EXE SHARED MODULE)
+  set(CMAKE_${MLN_FFI_XTOOL_LINKER_TYPE}_LINKER_FLAGS_INIT
+      "${MLN_FFI_XTOOL_LINKER_FLAGS}")
+endforeach()
+set(MLN_FFI_LIBTOOL "${MLN_FFI_XTOOL_SDK_BUNDLE}/toolset/bin/libtool"
+    CACHE FILEPATH "Apple archive tool supplied by xtool")

--- a/examples/swift-map/.gitignore
+++ b/examples/swift-map/.gitignore
@@ -1,1 +1,2 @@
 .build/
+xtool/

--- a/examples/swift-map/Package.swift
+++ b/examples/swift-map/Package.swift
@@ -1,13 +1,37 @@
 // swift-tools-version: 6.0
 
+import Foundation
 import PackageDescription
+
+let xtoolBuild = ProcessInfo.processInfo.environment["MLN_FFI_XTOOL_BUILD"] == "1"
+let swiftMapIOSDependencies: [Target.Dependency] = [
+  .product(name: "MaplibreNative", package: "maplibre-native-swift"),
+]
+let swiftMapIOSLinkerSettings: [LinkerSetting] = [
+  .linkedFramework("Metal"),
+  .linkedFramework("QuartzCore"),
+  .linkedFramework("UIKit"),
+]
+let swiftMapIOSTarget: Target = xtoolBuild
+  ? .target(
+    name: "SwiftMapIOS",
+    dependencies: swiftMapIOSDependencies,
+    linkerSettings: swiftMapIOSLinkerSettings
+  )
+  : .executableTarget(
+    name: "SwiftMapIOS",
+    dependencies: swiftMapIOSDependencies,
+    linkerSettings: swiftMapIOSLinkerSettings
+  )
 
 let package = Package(
   name: "swift-map",
   platforms: [.macOS("14.3"), .iOS("14.3")],
   products: [
     .executable(name: "swift-map", targets: ["SwiftMap"]),
-    .executable(name: "swift-map-ios", targets: ["SwiftMapIOS"]),
+    xtoolBuild
+      ? .library(name: "swift-map-ios", targets: ["SwiftMapIOS"])
+      : .executable(name: "swift-map-ios", targets: ["SwiftMapIOS"]),
   ],
   dependencies: [
     .package(name: "maplibre-native-swift", path: "../../bindings/swift"),
@@ -24,16 +48,6 @@ let package = Package(
         .linkedFramework("QuartzCore"),
       ]
     ),
-    .executableTarget(
-      name: "SwiftMapIOS",
-      dependencies: [
-        .product(name: "MaplibreNative", package: "maplibre-native-swift"),
-      ],
-      linkerSettings: [
-        .linkedFramework("Metal"),
-        .linkedFramework("QuartzCore"),
-        .linkedFramework("UIKit"),
-      ]
-    ),
+    swiftMapIOSTarget,
   ]
 )

--- a/examples/swift-map/mise.toml
+++ b/examples/swift-map/mise.toml
@@ -34,24 +34,40 @@ run = [{ task = "run", args = ["native-surface"] }]
 depends = [{ task = "//:build", args = ["ios-simulator-arm64-metal"] }]
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/ios-simulator-arm64-metal/install"
-sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
-PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" \
-  swift build \
-    --product swift-map-ios \
-    --scratch-path .build/ios-simulator \
-    --sdk "$sdk" \
-    --triple arm64-apple-ios14.3-simulator
+export PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+swift build \
+  --product swift-map-ios \
+  --scratch-path .build/ios-simulator \
+  {{ "--swift-sdk arm64-apple-ios-simulator" if os() == "linux" else "--sdk \"$(xcrun --sdk iphonesimulator --show-sdk-path)\"" }} \
+  --triple arm64-apple-ios14.3-simulator
 '''
 
 [tasks."build:ios"]
 depends = [{ task = "//:build", args = ["ios-arm64-metal"] }]
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/ios-arm64-metal/install"
-sdk="$(xcrun --sdk iphoneos --show-sdk-path)"
-PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" \
-  swift build \
-    --product swift-map-ios \
-    --scratch-path .build/ios \
-    --sdk "$sdk" \
-    --triple arm64-apple-ios14.3
+export PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+{% if os() == "linux" %}
+MLN_FFI_XTOOL_BUILD=1 xtool.AppImage dev build
+{% elif os() == "macos" %}
+swift build \
+  --product swift-map-ios \
+  --scratch-path .build/ios \
+  --sdk "$(xcrun --sdk iphoneos --show-sdk-path)" \
+  --triple arm64-apple-ios14.3
+{% endif %}
+'''
+
+[tasks."run:ios"]
+depends = [{ task = "//:build", args = ["ios-arm64-metal"] }]
+run = '''
+{% if os() == "linux" %}
+native_install_dir="$MISE_MONOREPO_ROOT/build/ios-arm64-metal/install"
+export PKG_CONFIG_PATH="$native_install_dir/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+export MLN_FFI_XTOOL_BUILD=1
+exec xtool.AppImage dev run --usb
+{% else %}
+echo "run:ios is currently implemented by xtool on Linux" >&2
+exit 1
+{% endif %}
 '''

--- a/examples/swift-map/xtool.yml
+++ b/examples/swift-map/xtool.yml
@@ -1,0 +1,3 @@
+version: 1
+bundleID: org.maplibre.nativeffi.examples.swift-map-ios
+product: swift-map-ios

--- a/mise.lock
+++ b/mise.lock
@@ -473,6 +473,35 @@ checksum = "sha256:adf29d4f9ff98b21492590d8887689093ea521792dbbbe80e032eb6ec3714
 url = "https://github.com/sargunv/jvl/releases/download/v2026.05.03/jvl-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/sargunv/jvl/releases/assets/411400578"
 
+[[tools."github:xtool-org/xtool"]]
+version = "1.17.0"
+backend = "github:xtool-org/xtool"
+
+[tools."github:xtool-org/xtool"."platforms.linux-arm64"]
+checksum = "sha256:9a8c47f7b2ee9b452bccee7ce723c0fc8746ac50d4a525a36da0358486bc375e"
+url = "https://github.com/xtool-org/xtool/releases/download/1.17.0/xtool-aarch64.AppImage"
+url_api = "https://api.github.com/repos/xtool-org/xtool/releases/assets/422189847"
+
+[tools."github:xtool-org/xtool"."platforms.linux-x64"]
+checksum = "sha256:7566d62b829a4deadb01b5389c94f45763d851f204c5d22fa36e9f9d1c88d57b"
+url = "https://github.com/xtool-org/xtool/releases/download/1.17.0/xtool-x86_64.AppImage"
+url_api = "https://api.github.com/repos/xtool-org/xtool/releases/assets/422189849"
+
+[tools."github:xtool-org/xtool"."platforms.macos-arm64"]
+checksum = "sha256:9a8c47f7b2ee9b452bccee7ce723c0fc8746ac50d4a525a36da0358486bc375e"
+url = "https://github.com/xtool-org/xtool/releases/download/1.17.0/xtool-aarch64.AppImage"
+url_api = "https://api.github.com/repos/xtool-org/xtool/releases/assets/422189847"
+
+[tools."github:xtool-org/xtool"."platforms.windows-arm64"]
+checksum = "sha256:9a8c47f7b2ee9b452bccee7ce723c0fc8746ac50d4a525a36da0358486bc375e"
+url = "https://github.com/xtool-org/xtool/releases/download/1.17.0/xtool-aarch64.AppImage"
+url_api = "https://api.github.com/repos/xtool-org/xtool/releases/assets/422189847"
+
+[tools."github:xtool-org/xtool"."platforms.windows-x64"]
+checksum = "sha256:7566d62b829a4deadb01b5389c94f45763d851f204c5d22fa36e9f9d1c88d57b"
+url = "https://github.com/xtool-org/xtool/releases/download/1.17.0/xtool-x86_64.AppImage"
+url_api = "https://api.github.com/repos/xtool-org/xtool/releases/assets/422189849"
+
 [[tools.go]]
 version = "1.26.3"
 backend = "core:go"

--- a/mise.toml
+++ b/mise.toml
@@ -54,6 +54,7 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 # Swift ecosystem
 "core:swift" = { version = "6.3.1", os = ["linux/x64"] }
 swiftformat = { version = "0.61.1", backend = "github:nicklockwood/SwiftFormat", no_app = true, rename_exe = "swiftformat" }
+"github:xtool-org/xtool" = { version = "1.17.0", os = ["linux"] }
 
 # Other ecosystems
 "core:rust" = { version = "1.95.0", profile = "minimal", components = "rustfmt,clippy", targets = "aarch64-linux-android,x86_64-linux-android,aarch64-unknown-linux-ohos,x86_64-pc-windows-msvc,aarch64-pc-windows-msvc" }


### PR DESCRIPTION
## Summary

Add a host-aware Apple CMake toolchain and Swift demo orchestration so the canonical iOS and macOS presets cross-build with xtool's Darwin SDK on Linux while retaining native behavior on macOS.

## Test plan

Built the iOS device, iOS Simulator, and macOS arm64 artifacts from Linux, verified their Mach-O outputs, packaged the macOS native artifact, and ran targeted `hk check`; USB deployment reached Apple provisioning but device registration was rejected with HTTP 403.

## AI assistance

- **Tools:** Codex
- **Models:** GPT-5.6
- **Context:** Used to explore xtool, implement the CMake and mise integration, and run the documented validation.
