### PR TITLE
fix Codeberg tag mirror and fetch zlib from GitHub

### DIFF
--- a/.github/workflows/mirror-codeberg.yml
+++ b/.github/workflows/mirror-codeberg.yml
@@ -33,4 +33,5 @@ jobs:
           git remote add mirror https://codeberg.org/maplibre/maplibre-native-ffi.git
           git fetch origin --tags
           git push mirror main
-          git push mirror --tags
+          # Floating tags (e.g. unstable-native-snapshot) are force-moved on origin.
+          git push mirror --tags --force

--- a/.mise/bin/sync-submodules
+++ b/.mise/bin/sync-submodules
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Git hooks export GIT_DIR / GIT_INDEX_FILE; clear them so submodule
+# operations resolve the worktree normally when mise deps runs from a hook.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR
+
 repo_root="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 mln_path="third_party/maplibre-native"
 

--- a/cmake/platform/windows.cmake
+++ b/cmake/platform/windows.cmake
@@ -6,7 +6,8 @@ function(mln_configure_platform_dependencies target)
   set(LIBUV_BUILD_BENCH OFF CACHE BOOL "" FORCE)
   fetchcontent_declare(
     mln_ffi_zlib_source
-    URL "https://zlib.net/fossils/zlib-1.3.1.tar.gz"
+    URL
+      "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"
     URL_HASH
       "SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
     EXCLUDE_FROM_ALL)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Force-push tags on the Codeberg mirror (floating `unstable-native-snapshot`) and fetch Windows zlib from the madler/zlib GitHub release instead of zlib.net.

## Test plan

Confirm mirror pushes tags without rejection and Windows CI configures past FetchContent zlib download.

## AI assistance

- **Tools:** Cursor
- **Models:** Cursor Grok 4.5
- **Context:** Explored recent main CI failures; implemented mirror tag force-push and zlib URL switch as discussed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30c6bc74-1963-4d89-b8b0-12d0d537152b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30c6bc74-1963-4d89-b8b0-12d0d537152b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

