### PR TITLE
Fix Kotlin snapshot staging

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -218,6 +218,12 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           pattern: native-package-*-metal-${{ env.SNAPSHOT_SHA }}
           path: build/packages/native/maven-input
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: native-package-linux-*-${{ env.SNAPSHOT_SHA }}
+          path: build/packages/native/maven-input
       - name: Check snapshot is still current
         id: current
         env:

--- a/.mise/tasks/kotlin/publish-snapshot
+++ b/.mise/tasks/kotlin/publish-snapshot
@@ -80,6 +80,10 @@ prepare_native_inputs() {
 
 prepare_apple_root_inputs() {
   local presets=(
+    linux-x64-egl
+    linux-arm64-egl
+    linux-x64-vulkan
+    linux-arm64-vulkan
     macos-arm64-metal
     ios-arm64-metal
     ios-simulator-arm64-metal
@@ -230,6 +234,14 @@ publish_apple_roots() {
   local repository="$1"
   shift
   local repository_args=("$@")
+  local opengl=(
+    -Pmaplibre.runtime.opengl.linuxX64.installDir="$install_root/linux-x64-egl"
+    -Pmaplibre.runtime.opengl.linuxArm64.installDir="$install_root/linux-arm64-egl"
+  )
+  local vulkan=(
+    -Pmaplibre.runtime.vulkan.linuxX64.installDir="$install_root/linux-x64-vulkan"
+    -Pmaplibre.runtime.vulkan.linuxArm64.installDir="$install_root/linux-arm64-vulkan"
+  )
   local metal=(
     -Pmaplibre.runtime.metal.iosArm64.installDir="$install_root/ios-arm64-metal"
     -Pmaplibre.runtime.metal.iosSimulatorArm64.installDir="$install_root/ios-simulator-arm64-metal"
@@ -242,13 +254,19 @@ publish_apple_roots() {
     KotlinMultiplatform -- \
     "${repository_args[@]}"
 
-  for backend in opengl vulkan; do
-    publish_tasks \
-      ":bindings:kotlin-runtime-${backend}" \
-      "$repository" \
-      KotlinMultiplatform -- \
-      "${repository_args[@]}"
-  done
+  publish_tasks \
+    :bindings:kotlin-runtime-opengl \
+    "$repository" \
+    KotlinMultiplatform -- \
+    "${repository_args[@]}" \
+    "${opengl[@]}"
+
+  publish_tasks \
+    :bindings:kotlin-runtime-vulkan \
+    "$repository" \
+    KotlinMultiplatform -- \
+    "${repository_args[@]}" \
+    "${vulkan[@]}"
 
   publish_tasks \
     :bindings:kotlin-runtime-metal \

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -188,6 +188,7 @@ androidComponents {
 
 tasks.configureEach {
   when (name) {
+    "androidSourcesJar",
     "compileAndroidMainJavaWithJavac",
     "compileAndroidMain",
     "extractAndroidMainAnnotations" -> dependsOn("generateAndroidJavaCppBindings")


### PR DESCRIPTION
## Summary

Fix Kotlin snapshot staging by declaring the generated Android source dependency and supplying Linux native archives to the existing macOS root-publication job.

## Test plan

Staged the complete Linux x64 partition from CI-produced native archives with a local Android SDK and ran shellcheck, actionlint, and repository formatting checks.

## AI assistance

- **Tools:** Codex
- **Context:** Used to inspect the failed snapshot logs, identify the missing Gradle dependency and root-publication inputs, implement the focused fixes, and validate Linux staging locally.