### PR TITLE
Share sccache across native targets

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -165,7 +165,8 @@ runs:
       run: |
         {
           echo "SCCACHE_GHA_ENABLED=true"
-          echo "SCCACHE_GHA_VERSION=${{ inputs.target }}"
+          echo "SCCACHE_GHA_VERSION=native-v1"
+          echo "SCCACHE_GHA_RW_MODE=${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}"
           echo "SCCACHE_BASEDIRS=${GITHUB_WORKSPACE}"
           echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"


### PR DESCRIPTION
## Summary
Share one stable native sccache generation across targets, allow trusted workflows to write it, and keep pull requests read-only.

## Test plan
Ran the repository formatter and hooks for the composite action, then verified the staged diff.