### PR TITLE
Skip unchanged native build tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -102,6 +102,18 @@ run = 'cmake --preset "$usage_preset"'
 [tasks.build]
 description = "Configure, build, and install a native CMake preset."
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
+sources = [
+  "CMakeLists.txt",
+  "CMakePresets.json",
+  "Cargo.lock",
+  "Cargo.toml",
+  "LICENSE",
+  "cmake/**/*",
+  "include/**/*",
+  "src/**/*",
+  "third_party/**/*",
+]
+outputs = { auto = true }
 run = 'cmake --workflow --preset "$usage_preset"'
 
 [tasks.clean]


### PR DESCRIPTION
## Summary
Declare native build inputs and use mise's argument-aware automatic outputs so repeated builds of an unchanged preset are skipped.

## Test plan
Formatted the task config, inspected the resolved build task, and verified automatic freshness is tracked separately per task argument.