### PR TITLE
Switch sccache to Cloudflare R2 with public reads

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -195,6 +195,9 @@ runs:
           {
             echo "SCCACHE_ENDPOINT=${write_endpoint}"
             echo "SCCACHE_S3_KEY_PREFIX=${bucket}/"
+            # mise.toml exports SCCACHE_S3_NO_CREDENTIALS=1 for public reads;
+            # clear it so authenticated writes are not rejected by sccache.
+            echo "SCCACHE_S3_NO_CREDENTIALS=0"
             echo "AWS_ACCESS_KEY_ID=${SCCACHE_ACCESS_KEY_ID}"
             echo "AWS_SECRET_ACCESS_KEY=${SCCACHE_SECRET_ACCESS_KEY}"
           } >> "$GITHUB_ENV"

--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -6,6 +6,14 @@ inputs:
     description: Native target name
     required: false
     default: host
+  sccache-access-key-id:
+    description: R2 S3 access key ID with Object Read & Write (push jobs only)
+    required: false
+    default: ""
+  sccache-secret-access-key:
+    description: R2 S3 secret access key with Object Read & Write (push jobs only)
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -160,14 +168,41 @@ runs:
       shell: bash
       run: MISE_NO_HOOKS=1 mise install --force rust
 
+    # Public reads use the R2 custom domain (same defaults as mise.toml). Writes
+    # use the account S3 endpoint + key prefix so object URLs match OpenDAL's
+    # path-style public GETs: https://sccache.sargunv.dev/<bucket>/<key>
     - name: Wire sccache into CMake
       shell: bash
+      env:
+        SCCACHE_ACCESS_KEY_ID: ${{ inputs.sccache-access-key-id }}
+        SCCACHE_SECRET_ACCESS_KEY: ${{ inputs.sccache-secret-access-key }}
       run: |
+        bucket="maplibre-native-ffi-sccache"
+        account_id="6cda5be3bf367f2885f3696d3c9b2653"
+        public_endpoint="https://sccache.sargunv.dev"
+        write_endpoint="https://${account_id}.r2.cloudflarestorage.com"
+
         {
-          echo "SCCACHE_GHA_ENABLED=true"
-          echo "SCCACHE_GHA_VERSION=native-v1"
-          echo "SCCACHE_GHA_RW_MODE=${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}"
+          echo "SCCACHE_BUCKET=${bucket}"
+          echo "SCCACHE_REGION=auto"
+          echo "SCCACHE_S3_USE_SSL=true"
           echo "SCCACHE_BASEDIRS=${GITHUB_WORKSPACE}"
           echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
         } >> "$GITHUB_ENV"
+
+        if [[ "${GITHUB_EVENT_NAME}" != "pull_request" && -n "${SCCACHE_ACCESS_KEY_ID}" && -n "${SCCACHE_SECRET_ACCESS_KEY}" ]]; then
+          {
+            echo "SCCACHE_ENDPOINT=${write_endpoint}"
+            echo "SCCACHE_S3_KEY_PREFIX=${bucket}/"
+            echo "AWS_ACCESS_KEY_ID=${SCCACHE_ACCESS_KEY_ID}"
+            echo "AWS_SECRET_ACCESS_KEY=${SCCACHE_SECRET_ACCESS_KEY}"
+          } >> "$GITHUB_ENV"
+          echo "Configured sccache R2 backend (read-write)"
+        else
+          {
+            echo "SCCACHE_ENDPOINT=${public_endpoint}"
+            echo "SCCACHE_S3_NO_CREDENTIALS=1"
+          } >> "$GITHUB_ENV"
+          echo "Configured sccache R2 backend (public read-only)"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-ci-deps
+        with:
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - run: mise run ci:generate-workflow --check
       - run: mise run //docs:install
       - run: dprint output-resolved-config > /dev/null
@@ -45,6 +48,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-ci-deps
+        with:
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - run: mise run //docs:build
 
   target:
@@ -300,6 +306,8 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           target: ${{ matrix.preset }}
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - name: Run target checks
         run: ${{ matrix.commands }}
       - name: Package native artifact
@@ -326,6 +334,8 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           target: android-multi-vulkan
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - name: Download Android native artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     name: hygiene
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
         with:
@@ -43,6 +44,7 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
         with:
@@ -57,6 +59,7 @@ jobs:
     name: target / ${{ matrix.preset }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -325,6 +328,7 @@ jobs:
     name: Android multi-ABI packaging
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
     needs:
       - target
     steps:

--- a/.github/workflows/devcontainer-image.yml
+++ b/.github/workflows/devcontainer-image.yml
@@ -49,6 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-ci-deps
+        with:
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - name: Install image tooling
         run: sudo apt-get update && sudo apt-get install --no-install-recommends --yes skopeo
       - name: Build image
@@ -73,6 +76,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-ci-deps
+        with:
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - name: Install image tooling
         run: sudo apt-get update && sudo apt-get install --no-install-recommends --yes skopeo
       - name: Log in to GHCR

--- a/.github/workflows/devcontainer-image.yml
+++ b/.github/workflows/devcontainer-image.yml
@@ -60,6 +60,7 @@ jobs:
   release:
     name: release / ${{ matrix.arch }}
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    environment: sccache
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-ci-deps
+        with:
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - run: mise run //docs:build
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -19,6 +19,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    environment: sccache
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-ci-deps

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -51,6 +51,8 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           target: ${{ matrix.target }}
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}
@@ -93,6 +95,8 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           target: macos-arm64-metal
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: kotlin-maven-staging-*-${{ env.SNAPSHOT_SHA }}
@@ -157,6 +161,8 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           target: ${{ matrix.target }}
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}
@@ -212,6 +218,8 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         with:
           target: macos-arm64-metal
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 240
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment: sccache
     permissions:
       actions: read
       contents: read
@@ -80,6 +81,7 @@ jobs:
       - stage-kotlin
     runs-on: macos-26
     timeout-minutes: 60
+    environment: sccache
     permissions:
       actions: read
       contents: read

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -35,6 +35,13 @@ def matrix(rows: list[dict[str, object]], indent: int = 8) -> list[str]:
     return lines
 
 
+# Environment secrets for R2 writes live in the GitHub Environment `sccache`
+# (main only). PRs omit the environment and fall back to public read-only.
+SCCACHE_ENVIRONMENT = (
+    "    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}"
+)
+
+
 def setup(target: str | None = None) -> list[str]:
     lines = [
         f"      - uses: {CHECKOUT}",
@@ -81,6 +88,7 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "    name: hygiene",
         "    runs-on: ubuntu-latest",
         "    timeout-minutes: 30",
+        SCCACHE_ENVIRONMENT,
         "    steps:",
         *setup(),
         "      - run: mise run ci:generate-workflow --check",
@@ -97,6 +105,7 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "    name: docs",
         "    runs-on: ubuntu-latest",
         "    timeout-minutes: 60",
+        SCCACHE_ENVIRONMENT,
         "    steps:",
         *setup(),
         "      - run: mise run //docs:build",
@@ -105,6 +114,7 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "    name: target / ${{ matrix.preset }}",
         "    runs-on: ${{ matrix.runner }}",
         "    timeout-minutes: 120",
+        SCCACHE_ENVIRONMENT,
         "    strategy:",
         "      fail-fast: false",
         "      matrix:",
@@ -128,6 +138,7 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "    name: Android multi-ABI packaging",
         "    runs-on: ubuntu-latest",
         "    timeout-minutes: 30",
+        SCCACHE_ENVIRONMENT,
         "    needs:",
         "      - target",
         "    steps:",

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -41,13 +41,16 @@ def setup(target: str | None = None) -> list[str]:
         "        with:",
         "          persist-credentials: false",
         "      - uses: ./.github/actions/setup-ci-deps",
+        "        with:",
     ]
-    inputs = []
     if target:
-        inputs.append(f"          target: {target}")
-    if inputs:
-        lines.append("        with:")
-        lines.extend(inputs)
+        lines.append(f"          target: {target}")
+    lines.extend(
+        [
+            "          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}",
+            "          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}",
+        ]
+    )
     return lines
 
 

--- a/docs/src/content/docs/development/overview.md
+++ b/docs/src/content/docs/development/overview.md
@@ -84,6 +84,14 @@ Pass another preset to select a different native target or backend:
 mise run build linux-x64-egl
 ```
 
+## Compiler Cache
+
+Native builds use [`sccache`](https://github.com/mozilla/sccache) through mise.
+`mise.toml` pins the tool and sets the public read-only R2 backend plus CMake
+compiler-launcher env, so `mise run build` and other mise tasks pick up the
+shared cache automatically. CI overrides those settings with write credentials
+when available.
+
 ## Common Commands
 
 ```bash

--- a/mise.lock
+++ b/mise.lock
@@ -636,6 +636,35 @@ components = "clippy,rustfmt"
 profile = "minimal"
 targets = "aarch64-linux-android,aarch64-pc-windows-msvc,aarch64-unknown-linux-ohos,x86_64-linux-android,x86_64-pc-windows-msvc"
 
+[[tools.sccache]]
+version = "0.16.0"
+backend = "aqua:mozilla/sccache"
+
+[tools.sccache."platforms.linux-arm64"]
+checksum = "sha256:f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060468"
+
+[tools.sccache."platforms.linux-x64"]
+checksum = "sha256:aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060682"
+
+[tools.sccache."platforms.macos-arm64"]
+checksum = "sha256:ded590cae2c72042c61178632906bef62d635fa20d45f8b22110a2241f430960"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060416"
+
+[tools.sccache."platforms.windows-arm64"]
+checksum = "sha256:09ca24bf12288b4b7ff8a852d89e533aa67353f7b956e73a3d7c298256ededa7"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-aarch64-pc-windows-msvc.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060436"
+
+[tools.sccache."platforms.windows-x64"]
+checksum = "sha256:c82319cc392b693e9fc72e6567cce47e218308f00fbf1df942e39b62e30f98da"
+url = "https://github.com/mozilla/sccache/releases/download/v0.16.0/sccache-v0.16.0-x86_64-pc-windows-msvc.tar.gz"
+url_api = "https://api.github.com/repos/mozilla/sccache/releases/assets/452060663"
+
 [[tools.swift]]
 version = "6.3.1"
 backend = "core:swift"

--- a/mise.toml
+++ b/mise.toml
@@ -37,6 +37,7 @@ config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 "aqua:koalaman/shellcheck" = "0.11.0" # Shell script linter (used by actionlint)
 "aqua:Kitware/CMake" = "4.3.3"
 "conda:doxygen" = { version = "1.13.2", os = ["linux", "macos", "windows/x64"] }
+sccache = "0.16.0"
 
 # Node.js ecosystem
 "core:node" = "24.11.0"
@@ -69,6 +70,16 @@ swiftformat = { version = "0.61.1", backend = "github:nicklockwood/SwiftFormat",
 [env]
 MLN_FFI_ANDROID_CMAKE_VERSION = "4.1.2"
 MLN_FFI_ANDROID_NDK_VERSION = "28.2.13676358"
+
+# Public sccache reads via the R2 custom domain (no credentials). CI pushes
+# override these with write credentials in .github/actions/setup-ci-deps.
+SCCACHE_BUCKET = "maplibre-native-ffi-sccache"
+SCCACHE_ENDPOINT = "https://sccache.sargunv.dev"
+SCCACHE_REGION = "auto"
+SCCACHE_S3_USE_SSL = "true"
+SCCACHE_S3_NO_CREDENTIALS = "1"
+CMAKE_C_COMPILER_LAUNCHER = "sccache"
+CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
 
 [deps.uv]
 auto = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Use a dedicated Cloudflare R2 bucket for sccache; CI writes via the GitHub Environment `sccache` (main-only secrets), and contributors get public reads through mise.

## AI assistance

- **Tools:** Cursor
- **Context:** Cloud agent implementation of R2-backed sccache, then wiring jobs to the `sccache` GitHub Environment for write secrets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03962e9d-8066-48bb-9d77-fb2bb8db33de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03962e9d-8066-48bb-9d77-fb2bb8db33de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

