### PR TITLE
Suppress intentional mise deps stale warning

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,9 @@ min_version = "2026.7.10"
 
 [settings]
 lockfile = true
+# The submodules provider checks Git state directly and intentionally runs on
+# every dependency pass, so suppress its perpetual shell stale warning.
+status.show_deps_stale = false
 lockfile_platforms = [
   "linux-x64",
   "linux-arm64",


### PR DESCRIPTION
## Summary

Suppress the deps stale shell warning because submodule reconciliation intentionally has no mise freshness sources or outputs.

## Test plan

Ran `hk check mise.toml` and verified `mise settings get status.show_deps_stale` returns `false`.

## AI assistance

- **Tools:** Codex
- **Context:** Used to inspect mise behavior, make the scoped configuration change, and run validation.