### PR TITLE
Preserve sccache CI overrides

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -77,10 +77,10 @@ MLN_FFI_ANDROID_NDK_VERSION = "28.2.13676358"
 # Public sccache reads via the R2 custom domain (no credentials). CI pushes
 # override these with write credentials in .github/actions/setup-ci-deps.
 SCCACHE_BUCKET = "maplibre-native-ffi-sccache"
-SCCACHE_ENDPOINT = "https://sccache.sargunv.dev"
+SCCACHE_ENDPOINT = { default = "https://sccache.sargunv.dev" }
 SCCACHE_REGION = "auto"
 SCCACHE_S3_USE_SSL = "true"
-SCCACHE_S3_NO_CREDENTIALS = "1"
+SCCACHE_S3_NO_CREDENTIALS = { default = "1" }
 CMAKE_C_COMPILER_LAUNCHER = "sccache"
 CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
 


### PR DESCRIPTION
## Summary

Allow CI-provided authenticated sccache settings to override the public-read defaults so docs and other push builds can write to R2.

## Test plan

Ran `mise exec -- hk check mise.toml` and verified both default and CI-overridden sccache values through `mise exec`.

## AI assistance

- **Tools:** Codex
- **Context:** Codex inspected the failing Actions logs, identified the mise environment precedence issue, applied the two-line configuration fix, and ran the validation above.