### PR TITLE
Strip Android release artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Keep optimized release archives lean when toolchains add debug information.
+if(NOT MSVC)
+  add_compile_options("$<$<CONFIG:Release>:-g0>")
+endif()
+
 # This project uses C++20 language features, but not C++20 modules. Keep CMake
 # from generating compiler-specific module dependency scanner steps for every
 # C++ source file.
@@ -65,7 +70,7 @@ if(MLN_FFI_ARTIFACT_NAME)
   set(CPACK_PACKAGE_DIRECTORY "${PROJECT_SOURCE_DIR}/build/packages/native/dist")
   set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
   set(CPACK_MONOLITHIC_INSTALL ON)
-  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  if(CMAKE_SYSTEM_NAME MATCHES "^(Android|Linux)$")
     set(CPACK_STRIP_FILES ON)
   endif()
   include(CPack)


### PR DESCRIPTION
## Summary

Prevent NDK-injected debug information from bloating Release archives and strip packaged Android ELF libraries alongside Linux.

## Test plan

Built and packaged `android-arm64-egl`, verified the `.so` is stripped and the package shrank from 146.9 MB to 22.7 MB, and ran `hk check CMakeLists.txt`.

## AI assistance

- **Tools:** Codex
- **Context:** Used to investigate artifact sizes, implement the CMake change, and run local validation.