### PR TITLE
Prefetch Zig package dependencies

### DIFF
--- a/bindings/zig/mise.toml
+++ b/bindings/zig/mise.toml
@@ -1,3 +1,11 @@
+[deps.zig]
+auto = true
+description = "Fetch Zig package dependencies."
+sources = ["build.zig", "build.zig.zon"]
+outputs = ["zig-pkg"]
+timeout = "10m"
+run = "zig build --fetch=needed"
+
 [tasks.build]
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,0 @@
-.{
-    .name = .maplibre_native_ffi,
-    .version = "0.16.0",
-    .dependencies = .{},
-    .paths = .{""},
-    .fingerprint = 0x4a5753fec41abf42,
-}

--- a/examples/zig-map/mise.toml
+++ b/examples/zig-map/mise.toml
@@ -1,3 +1,16 @@
+[deps.zig]
+auto = true
+description = "Fetch Zig package dependencies."
+sources = [
+  "build.zig",
+  "build.zig.zon",
+  "../../bindings/zig/build.zig",
+  "../../bindings/zig/build.zig.zon",
+]
+outputs = ["zig-pkg"]
+timeout = "10m"
+run = "zig build --fetch=needed"
+
 [tasks.build]
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]

--- a/examples/zig-readback/mise.toml
+++ b/examples/zig-readback/mise.toml
@@ -1,3 +1,16 @@
+[deps.zig]
+auto = true
+description = "Fetch Zig package dependencies."
+sources = [
+  "build.zig",
+  "build.zig.zon",
+  "../../bindings/zig/build.zig",
+  "../../bindings/zig/build.zig.zon",
+]
+outputs = ["zig-pkg"]
+timeout = "10m"
+run = "zig build --fetch=needed"
+
 [tasks.build]
 usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
 depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]


### PR DESCRIPTION
## Summary

Prefetch each Zig package graph through scoped mise dependency providers with a 10-minute timeout, use `zig-pkg` as the tracked output, and remove the orphan root manifest so dependency downloads are isolated from compilation.

## Test plan

Ran all three Zig dependency providers with `--force`, formatted the changed mise files with `hk fix`, and verified the staged diff with `git diff --check`.