### PR TITLE
Keep sccache stats alive in CI

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -187,6 +187,7 @@ runs:
           echo "SCCACHE_REGION=auto"
           echo "SCCACHE_S3_USE_SSL=true"
           echo "SCCACHE_BASEDIRS=${GITHUB_WORKSPACE}"
+          echo "SCCACHE_IDLE_TIMEOUT=0"
           echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
         } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Keep the sccache daemon alive for each CI job so post-job statistics include desktop compilations that precede extended packaging and consumer checks.

## Test plan

Ran `hk check .github/actions/setup-ci-deps/action.yml` and verified the staged diff with `git diff --check`.