### PR TITLE
Cache Gradle with setup-gradle

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -121,15 +121,15 @@ runs:
 
         echo "OHOS_SDK_NATIVE=$sdk_root/linux/native" >> "$GITHUB_ENV"
 
-    - name: Cache Gradle
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    # Caches Gradle User Home and stops the daemons in its post-action, before
+    # the cache is saved. Daemons that outlive the job keep Windows file locks
+    # on `caches/*/**/*.lock`, which a plain archive step cannot read. The
+    # project uses the wrapper, so no `gradle-version` is requested and the
+    # mise-managed JDK stays in charge.
+    - name: Cache Gradle User Home
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-gradle-
+        add-job-summary: on-failure
 
     - name: Trim Windows PATH before mise activation
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           path: pins
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - uses: jakoch/install-vulkan-sdk-action@b394a1abed9cb019d8e637eeadac93d73e0853da # v1.5.5
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10


### PR DESCRIPTION
## Summary

Replace the hand-rolled `actions/cache` step for Gradle User Home with `gradle/actions/setup-gradle`, whose post-action stops the Gradle daemons before saving so Windows jobs stop failing to archive daemon-held `.lock` files.

## Test plan

CI on this PR.

## AI assistance

- **Tools:** Claude Code
- **Context:** Diagnosed the Windows `Device or resource busy` tar spam in post-run logs, compared cache-provider options, and made the swap.