### PR TITLE
Cache Rust and package-manager downloads in CI

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -69,6 +69,36 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-cargo-registry-v1-
 
+    # uv, pnpm, NuGet, and Go each default to a different per-OS cache location,
+    # and some of those paths carry a tool-version suffix. Pinning them under
+    # one directory keeps a single cache entry accurate on every runner. Windows
+    # tools need a native path, so prefer USERPROFILE with forward slashes.
+    - name: Pin package download caches
+      shell: bash
+      run: |
+        if [[ -n "${USERPROFILE:-}" ]]; then
+          home="${USERPROFILE//\\//}"
+        else
+          home="$HOME"
+        fi
+        cache_root="$home/.ci-package-cache"
+        {
+          echo "UV_CACHE_DIR=$cache_root/uv"
+          echo "npm_config_store_dir=$cache_root/pnpm"
+          echo "NUGET_PACKAGES=$cache_root/nuget"
+          # bindings/go declares no module requirements, so only the build cache
+          # is worth carrying between jobs.
+          echo "GOCACHE=$cache_root/go-build"
+        } >> "$GITHUB_ENV"
+
+    - name: Cache package downloads
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.ci-package-cache
+        key: ${{ runner.os }}-${{ runner.arch }}-pkg-v1-${{ hashFiles('pnpm-lock.yaml', 'uv.lock', 'Directory.Packages.props', '**/dotnet-tools.json', '**/go.mod') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-pkg-v1-
+
     # Zig's global cache holds downloaded package tarballs, which keeps SDL's
     # source dependencies off the network. Windows resolves it under
     # LOCALAPPDATA; every other platform, including macOS, uses ~/.cache.

--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -66,6 +66,8 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
         key: ${{ runner.os }}-${{ runner.arch }}-cargo-registry-v1-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-cargo-registry-v1-
 
     # Zig's global cache holds downloaded package tarballs, which keeps SDL's
     # source dependencies off the network. Windows resolves it under
@@ -208,6 +210,10 @@ runs:
           echo "SCCACHE_IDLE_TIMEOUT=0"
           echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
           echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
+          echo "RUSTC_WRAPPER=sccache"
+          # sccache declines to cache incrementally compiled crates, which is
+          # the cargo default for the dev profile that `cargo test` uses.
+          echo "CARGO_INCREMENTAL=0"
         } >> "$GITHUB_ENV"
 
         if [[ "${GITHUB_EVENT_NAME}" != "pull_request" && -n "${SCCACHE_ACCESS_KEY_ID}" && -n "${SCCACHE_SECRET_ACCESS_KEY}" ]]; then

--- a/mise.toml
+++ b/mise.toml
@@ -84,6 +84,7 @@ SCCACHE_S3_USE_SSL = "true"
 SCCACHE_S3_NO_CREDENTIALS = { default = "1" }
 CMAKE_C_COMPILER_LAUNCHER = "sccache"
 CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
+RUSTC_WRAPPER = "sccache"
 
 [deps.uv]
 auto = true


### PR DESCRIPTION
## Summary

Route `rustc` through the existing sccache R2 bucket, give the Cargo registry cache a fallback key it was missing, and cache the uv, pnpm, NuGet, and Go download directories that were previously re-fetched in every job.

## Test plan

CI on this PR, plus a local probe confirming `RUSTC_WRAPPER=sccache` records cacheable Rust compiles against the R2 bucket.

## AI assistance

- **Tools:** Claude Code
- **Context:** Audited cache policy across every language ecosystem in CI; findings and priorities discussed in-session.