### PR TITLE
Share Rust dependency artifacts across presets

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -29,6 +29,10 @@ runs:
           third_party/maplibre-native
           .git/modules/third_party/maplibre-native
         key: mln-src-v2-${{ hashFiles('.gitmodules', 'cmake/mln_version.cmake') }}
+        # sync-submodules re-syncs whatever it restores, so an older checkout
+        # turns a pin bump into an incremental fetch instead of a fresh clone.
+        restore-keys: |
+          mln-src-v2-
 
     - name: Install sccache
       uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/bindings/rust/mise.toml
+++ b/bindings/rust/mise.toml
@@ -25,10 +25,17 @@ depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
 run = '''
 native_install_dir="$MISE_MONOREPO_ROOT/build/$usage_preset/install"
-export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Wl,-rpath,$native_install_dir/lib"
+# The sys crate emits its own rpath, but cargo:rustc-link-arg only covers that
+# crate's link targets, so the core and umbrella test binaries need the library
+# located at run time. Resolving it here instead of through RUSTFLAGS keeps the
+# preset out of the compiler command line, which is what sccache keys on: every
+# preset would otherwise get its own copy of every dependency crate.
+lib_dirs="$native_install_dir/lib"
 if [[ -n "${MLN_FFI_VULKAN_LOADER_DIR:-}" ]]; then
-  export RUSTFLAGS="$RUSTFLAGS -C link-arg=-Wl,-rpath,$MLN_FFI_VULKAN_LOADER_DIR"
+  lib_dirs="$lib_dirs:$MLN_FFI_VULKAN_LOADER_DIR"
 fi
+export LD_LIBRARY_PATH="$lib_dirs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="$lib_dirs${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
 export MAPLIBRE_NATIVE_C_INSTALL_DIR="$native_install_dir"
 cargo test \
   -p maplibre-native-sys \


### PR DESCRIPTION
## Summary

Locate the native library through `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` in the Rust test task instead of baking a preset-specific rpath into `RUSTFLAGS`, so sccache stops keying every dependency crate to a single preset, and let the MapLibre Native source cache fall back to an older checkout on a pin bump.

## Test plan

CI on this PR, which exercises the Rust binding tests on Linux, macOS, and Windows.

## AI assistance

- **Tools:** Claude Code
- **Context:** Follow-up to #320 from a CI cache audit; sccache keying and rpath tradeoffs discussed in-session.