### PR TITLE
Pin the Linux CI runners and guard the glibc floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,11 @@ jobs:
       matrix:
         include:
           - preset: linux-x64-egl
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             package: true
             native_commands: >-
-              mise run test linux-x64-egl
+              mise run test linux-x64-egl &&
+              mise run check-glibc-floor linux-x64-egl
             consumer_commands: >-
               mise run //bindings/rust:test linux-x64-egl &&
               mise run //examples/rust-map:check linux-x64-egl &&
@@ -84,10 +85,11 @@ jobs:
               mise run //bindings/go:test linux-x64-egl &&
               mise run //bindings/python:test linux-x64-egl
           - preset: linux-x64-vulkan
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             package: true
             native_commands: >-
-              mise run test linux-x64-vulkan
+              mise run test linux-x64-vulkan &&
+              mise run check-glibc-floor linux-x64-vulkan
             consumer_commands: >-
               mise run //bindings/rust:test linux-x64-vulkan &&
               mise run //examples/rust-map:check linux-x64-vulkan &&
@@ -106,7 +108,8 @@ jobs:
             runner: ubuntu-24.04-arm
             package: true
             native_commands: >-
-              mise run test linux-arm64-egl
+              mise run test linux-arm64-egl &&
+              mise run check-glibc-floor linux-arm64-egl
             consumer_commands: >-
               mise run //bindings/rust:test linux-arm64-egl &&
               mise run //examples/rust-map:check linux-arm64-egl &&
@@ -124,7 +127,8 @@ jobs:
             runner: ubuntu-24.04-arm
             package: true
             native_commands: >-
-              mise run test linux-arm64-vulkan
+              mise run test linux-arm64-vulkan &&
+              mise run check-glibc-floor linux-arm64-vulkan
             consumer_commands: >-
               mise run //bindings/rust:test linux-arm64-vulkan &&
               mise run //examples/rust-map:check linux-arm64-vulkan &&

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -42,7 +42,10 @@ def runner(preset: str) -> str:
     target_platform = platform(preset)
     target_architecture = architecture(preset)
     if target_platform == "linux":
-        return "ubuntu-24.04-arm" if target_architecture == "arm64" else "ubuntu-latest"
+        # Linux runners are pinned because the runner image's glibc sets the
+        # minimum glibc our published natives require. See the glibc_floor
+        # variable in mise.linux.toml.
+        return "ubuntu-24.04-arm" if target_architecture == "arm64" else "ubuntu-24.04"
     if target_platform in {"macos", "ios", "ios-simulator"}:
         return "macos-26"
     if target_platform == "windows":
@@ -86,7 +89,10 @@ def native_commands(preset: str, tested: set[str]) -> list[str]:
     target_platform = platform(preset)
     if target_platform == "ohos":
         return [f"mise run //bindings/rust:build:ohos {preset}"]
-    return [f"mise run {'test' if preset in tested else 'build'} {preset}"]
+    commands = [f"mise run {'test' if preset in tested else 'build'} {preset}"]
+    if target_platform == "linux":
+        commands.append(f"mise run check-glibc-floor {preset}")
+    return commands
 
 
 def consumer_commands(source: dict[str, object], preset: str) -> list[str]:

--- a/mise.linux.toml
+++ b/mise.linux.toml
@@ -1,5 +1,9 @@
 [vars]
 host_native_preset = "linux-{{ arch() }}-vulkan"
+# Highest glibc release our published Linux natives may require. Raising this
+# drops support for distributions that ship an older glibc, so change it
+# together with the CI runner images in ci/workflow.py.
+glibc_floor = "2.39"
 
 [bootstrap.packages]
 "apt:build-essential" = "latest"
@@ -33,3 +37,36 @@ host_native_preset = "linux-{{ arch() }}-vulkan"
 "dnf:vulkan-loader-devel" = "latest"
 "dnf:zlib-ng-compat-devel" = "latest"
 "dnf:zlib-ng-compat-static" = "latest"
+
+[tasks.check-glibc-floor]
+description = "Verify a built Linux native requires no glibc newer than the floor."
+usage = 'arg "[preset]" default="{{vars.host_native_preset}}"'
+run = '''
+floor="{{vars.glibc_floor}}"
+library="$MISE_MONOREPO_ROOT/build/$usage_preset/install/lib/libmaplibre-native-c.so"
+
+if [[ ! -f "$library" ]]; then
+  echo "error: $library not found; build $usage_preset first" >&2
+  exit 1
+fi
+
+required="$(readelf --version-info "$library" |
+  grep -oE 'GLIBC_[0-9]+\.[0-9]+' |
+  sort -uV |
+  tail -1)"
+
+if [[ -z "$required" ]]; then
+  echo "error: $library declares no glibc version requirement" >&2
+  exit 1
+fi
+
+highest="$(printf '%s\nGLIBC_%s\n' "$required" "$floor" | sort -V | tail -1)"
+if [[ "$highest" != "GLIBC_$floor" ]]; then
+  echo "error: $usage_preset requires $required, above the GLIBC_$floor floor" >&2
+  echo "The build host's glibc sets this floor; build on an older image or" >&2
+  echo "raise glibc_floor in mise.linux.toml to accept the new requirement." >&2
+  exit 1
+fi
+
+echo "$usage_preset requires $required (floor GLIBC_$floor)"
+'''


### PR DESCRIPTION
## Summary

Pin the Linux CI runners to `ubuntu-24.04` and add a `check-glibc-floor` task that fails the build when a Linux native requires a glibc newer than the `glibc_floor` declared in `mise.linux.toml`.

## Test plan

Ran `mise run check-glibc-floor linux-x64-vulkan` against a local Fedora build, which correctly failed on its `GLIBC_2.43` requirement, and verified the version comparison across the `2.4`, `2.35`, `2.39`, `2.43`, and `2.100` cases.

## AI assistance

- **Tools:** Claude Code (Opus 5)
- **Context:** Follow-up to #319, where the published `natives-linux-*` jars turned out to require glibc 2.39. The floor was inherited from whatever `ubuntu-latest` resolved to rather than chosen, so this pins it and makes it enforced.
