### PR TITLE
Drop the Kotlin/Native Linux targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
               mise run //examples/zig-map:build linux-x64-egl &&
               mise run //examples/zig-readback:run linux-x64-egl &&
               mise run //bindings/kotlin:jvmTest linux-x64-egl &&
-              mise run //bindings/kotlin:nativeTest linux-x64-egl &&
               mise run //examples/compose-map:build linux-x64-egl &&
               mise run //examples/lwjgl-map:build linux-x64-egl &&
               mise run //bindings/swift:test linux-x64-egl &&
@@ -95,7 +94,6 @@ jobs:
               mise run //examples/zig-map:build linux-x64-vulkan &&
               mise run //examples/zig-readback:run linux-x64-vulkan &&
               mise run //bindings/kotlin:jvmTest linux-x64-vulkan &&
-              mise run //bindings/kotlin:nativeTest linux-x64-vulkan &&
               mise run //examples/compose-map:build linux-x64-vulkan &&
               mise run //examples/lwjgl-map:build linux-x64-vulkan &&
               mise run //bindings/swift:test linux-x64-vulkan &&

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -30,14 +30,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - partition: linux-x64
+          - partition: android
             runner: ubuntu-latest
             target: linux-x64-vulkan
-            native_pattern: native-package-linux-x64-*
-          - partition: linux-arm64
-            runner: ubuntu-latest
-            target: linux-x64-vulkan
-            native_pattern: native-package-linux-arm64-*
+            native_pattern: native-package-android-*
           - partition: apple
             runner: macos-26
             target: macos-arm64-metal
@@ -59,13 +55,6 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
           pattern: ${{ matrix.native_pattern }}-${{ env.SNAPSHOT_SHA }}
-          path: build/packages/native/maven-input
-      - if: ${{ matrix.partition == 'linux-x64' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          pattern: native-package-android-*-${{ env.SNAPSHOT_SHA }}
           path: build/packages/native/maven-input
       - run: mise run //:kotlin:publish-snapshot stage ${{ matrix.partition }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -120,14 +109,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - partition: linux-x64
+          - partition: android
             runner: ubuntu-latest
             target: linux-x64-vulkan
-            native_pattern: native-package-linux-x64-*
-          - partition: linux-arm64
-            runner: ubuntu-latest
-            target: linux-x64-vulkan
-            native_pattern: native-package-linux-arm64-*
+            native_pattern: native-package-android-*
           - partition: apple
             runner: macos-26
             target: macos-arm64-metal
@@ -154,13 +139,6 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
           pattern: ${{ matrix.native_pattern }}-${{ env.SNAPSHOT_SHA }}
-          path: build/packages/native/maven-input
-      - if: ${{ matrix.partition == 'linux-x64' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          pattern: native-package-android-*-${{ env.SNAPSHOT_SHA }}
           path: build/packages/native/maven-input
       - run: mise run //:kotlin:publish-snapshot publish-leaves ${{ matrix.partition }}
 
@@ -198,12 +176,6 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
           pattern: native-package-*-metal-${{ env.SNAPSHOT_SHA }}
-          path: build/packages/native/maven-input
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          pattern: native-package-linux-*-${{ env.SNAPSHOT_SHA }}
           path: build/packages/native/maven-input
       - run: mise run //:kotlin:publish-snapshot publish-roots apple
 

--- a/.mise/tasks/kotlin/publish-snapshot
+++ b/.mise/tasks/kotlin/publish-snapshot
@@ -8,8 +8,8 @@ install_root="${MISE_MONOREPO_ROOT}/build/packages/kotlin/install"
 staging_base="${MISE_MONOREPO_ROOT}/build/packages/kotlin"
 
 usage() {
-  echo "usage: $(basename "$0") stage <linux-x64|linux-arm64|apple>" >&2
-  echo "       $(basename "$0") publish-leaves <linux-x64|linux-arm64|apple>" >&2
+  echo "usage: $(basename "$0") stage <android|apple>" >&2
+  echo "       $(basename "$0") publish-leaves <android|apple>" >&2
   echo "       $(basename "$0") publish-roots apple" >&2
   echo "       $(basename "$0") verify <maven-staging>" >&2
 }
@@ -33,20 +33,12 @@ prepare_native_inputs() {
   local presets=()
 
   case "$partition" in
-    linux-x64)
+    android)
       presets=(
-        linux-x64-egl
-        linux-x64-vulkan
         android-arm64-egl
         android-arm64-vulkan
         android-x64-egl
         android-x64-vulkan
-      )
-      ;;
-    linux-arm64)
-      presets=(
-        linux-arm64-egl
-        linux-arm64-vulkan
       )
       ;;
     apple)
@@ -80,10 +72,6 @@ prepare_native_inputs() {
 
 prepare_apple_root_inputs() {
   local presets=(
-    linux-x64-egl
-    linux-arm64-egl
-    linux-x64-vulkan
-    linux-arm64-vulkan
     macos-arm64-metal
     ios-arm64-metal
     ios-simulator-arm64-metal
@@ -110,69 +98,36 @@ publish_tasks() {
   ./gradlew "${tasks[@]}" "$@"
 }
 
-publish_linux_x64_leaves() {
+publish_android_leaves() {
   local repository="$1"
   shift
   local common=(
     -Pmaplibre.android.prebuiltInstallRoot="$install_root"
     "-Pmaplibre.android.abis=arm64-v8a,x86_64"
   )
-  local opengl=(
-    -Pmaplibre.android.backend=opengl
-    -Pmaplibre.runtime.opengl.linuxX64.installDir="$install_root/linux-x64-egl"
-  )
-  local vulkan=(
-    -Pmaplibre.android.backend=vulkan
-    -Pmaplibre.runtime.vulkan.linuxX64.installDir="$install_root/linux-x64-vulkan"
-  )
 
   publish_tasks \
     :bindings:kotlin \
     "$repository" \
-    LinuxX64 Android -- \
+    Android -- \
     "$@" \
     "${common[@]}"
 
   publish_tasks \
     :bindings:kotlin-runtime-opengl \
     "$repository" \
-    LinuxX64 Android -- \
+    Android -- \
     "$@" \
     "${common[@]}" \
-    "${opengl[@]}"
+    -Pmaplibre.android.backend=opengl
 
   publish_tasks \
     :bindings:kotlin-runtime-vulkan \
     "$repository" \
-    LinuxX64 Android -- \
+    Android -- \
     "$@" \
     "${common[@]}" \
-    "${vulkan[@]}"
-}
-
-publish_linux_arm64_leaves() {
-  local repository="$1"
-  shift
-
-  publish_tasks \
-    :bindings:kotlin \
-    "$repository" \
-    LinuxArm64 -- \
-    "$@"
-
-  publish_tasks \
-    :bindings:kotlin-runtime-opengl \
-    "$repository" \
-    LinuxArm64 -- \
-    "$@" \
-    -Pmaplibre.runtime.opengl.linuxArm64.installDir="$install_root/linux-arm64-egl"
-
-  publish_tasks \
-    :bindings:kotlin-runtime-vulkan \
-    "$repository" \
-    LinuxArm64 -- \
-    "$@" \
-    -Pmaplibre.runtime.vulkan.linuxArm64.installDir="$install_root/linux-arm64-vulkan"
+    -Pmaplibre.android.backend=vulkan
 }
 
 publish_apple_leaves() {
@@ -230,14 +185,6 @@ publish_apple_leaves() {
 publish_apple_roots() {
   local repository="$1"
   shift
-  local opengl=(
-    -Pmaplibre.runtime.opengl.linuxX64.installDir="$install_root/linux-x64-egl"
-    -Pmaplibre.runtime.opengl.linuxArm64.installDir="$install_root/linux-arm64-egl"
-  )
-  local vulkan=(
-    -Pmaplibre.runtime.vulkan.linuxX64.installDir="$install_root/linux-x64-vulkan"
-    -Pmaplibre.runtime.vulkan.linuxArm64.installDir="$install_root/linux-arm64-vulkan"
-  )
   local metal=(
     -Pmaplibre.runtime.metal.iosArm64.installDir="$install_root/ios-arm64-metal"
     -Pmaplibre.runtime.metal.iosSimulatorArm64.installDir="$install_root/ios-simulator-arm64-metal"
@@ -254,15 +201,13 @@ publish_apple_roots() {
     :bindings:kotlin-runtime-opengl \
     "$repository" \
     KotlinMultiplatform -- \
-    "$@" \
-    "${opengl[@]}"
+    "$@"
 
   publish_tasks \
     :bindings:kotlin-runtime-vulkan \
     "$repository" \
     KotlinMultiplatform -- \
-    "$@" \
-    "${vulkan[@]}"
+    "$@"
 
   publish_tasks \
     :bindings:kotlin-runtime-metal \
@@ -278,11 +223,8 @@ publish_leaf_partition() {
   shift 2
 
   case "$partition" in
-    linux-x64)
-      publish_linux_x64_leaves "$repository" "$@"
-      ;;
-    linux-arm64)
-      publish_linux_arm64_leaves "$repository" "$@"
+    android)
+      publish_android_leaves "$repository" "$@"
       ;;
     apple)
       publish_apple_leaves "$repository" "$@"
@@ -311,7 +253,7 @@ partition="${2:-}"
 case "$operation" in
   stage)
     case "$partition" in
-      linux-x64 | linux-arm64 | apple) ;;
+      android | apple) ;;
       *)
         usage
         exit 2
@@ -327,7 +269,7 @@ case "$operation" in
     ;;
   publish-leaves)
     case "$partition" in
-      linux-x64 | linux-arm64 | apple) ;;
+      android | apple) ;;
       *)
         usage
         exit 2

--- a/.mise/tasks/kotlin/verify-staging
+++ b/.mise/tasks/kotlin/verify-staging
@@ -13,8 +13,6 @@ MODULES = {
     "maplibre-native-ffi-iosarm64",
     "maplibre-native-ffi-iossimulatorarm64",
     "maplibre-native-ffi-jvm",
-    "maplibre-native-ffi-linuxarm64",
-    "maplibre-native-ffi-linuxx64",
     "maplibre-native-ffi-macosarm64",
     "maplibre-native-ffi-runtime-metal",
     "maplibre-native-ffi-runtime-metal-iosarm64",
@@ -24,13 +22,9 @@ MODULES = {
     "maplibre-native-ffi-runtime-opengl",
     "maplibre-native-ffi-runtime-opengl-android",
     "maplibre-native-ffi-runtime-opengl-jvm",
-    "maplibre-native-ffi-runtime-opengl-linuxarm64",
-    "maplibre-native-ffi-runtime-opengl-linuxx64",
     "maplibre-native-ffi-runtime-vulkan",
     "maplibre-native-ffi-runtime-vulkan-android",
     "maplibre-native-ffi-runtime-vulkan-jvm",
-    "maplibre-native-ffi-runtime-vulkan-linuxarm64",
-    "maplibre-native-ffi-runtime-vulkan-linuxx64",
 }
 
 ROOT_TARGET_MODULES = {
@@ -39,21 +33,15 @@ ROOT_TARGET_MODULES = {
         "iosArm64": "maplibre-native-ffi-iosarm64",
         "iosSimulatorArm64": "maplibre-native-ffi-iossimulatorarm64",
         "jvm": "maplibre-native-ffi-jvm",
-        "linuxArm64": "maplibre-native-ffi-linuxarm64",
-        "linuxX64": "maplibre-native-ffi-linuxx64",
         "macosArm64": "maplibre-native-ffi-macosarm64",
     },
     "maplibre-native-ffi-runtime-opengl": {
         "android": "maplibre-native-ffi-runtime-opengl-android",
         "jvm": "maplibre-native-ffi-runtime-opengl-jvm",
-        "linuxArm64": "maplibre-native-ffi-runtime-opengl-linuxarm64",
-        "linuxX64": "maplibre-native-ffi-runtime-opengl-linuxx64",
     },
     "maplibre-native-ffi-runtime-vulkan": {
         "android": "maplibre-native-ffi-runtime-vulkan-android",
         "jvm": "maplibre-native-ffi-runtime-vulkan-jvm",
-        "linuxArm64": "maplibre-native-ffi-runtime-vulkan-linuxarm64",
-        "linuxX64": "maplibre-native-ffi-runtime-vulkan-linuxx64",
     },
     "maplibre-native-ffi-runtime-metal": {
         "iosArm64": "maplibre-native-ffi-runtime-metal-iosarm64",
@@ -218,10 +206,6 @@ def verify_jvm(root: pathlib.Path) -> None:
 
 def verify_native(root: pathlib.Path) -> None:
     modules = {
-        "maplibre-native-ffi-runtime-opengl-linuxx64",
-        "maplibre-native-ffi-runtime-opengl-linuxarm64",
-        "maplibre-native-ffi-runtime-vulkan-linuxx64",
-        "maplibre-native-ffi-runtime-vulkan-linuxarm64",
         "maplibre-native-ffi-runtime-metal-macosarm64",
         "maplibre-native-ffi-runtime-metal-iosarm64",
         "maplibre-native-ffi-runtime-metal-iossimulatorarm64",

--- a/bindings/kotlin-runtime-common/linux-opengl.def
+++ b/bindings/kotlin-runtime-common/linux-opengl.def
@@ -1,4 +1,0 @@
-headers = maplibreNativeRuntime.h
-headerFilter = maplibreNativeRuntime.h
-package = org.maplibre.nativeffi.internal.runtime
-linkerOpts = -lEGL -lGLESv2 -ldl -lpthread -lm -lstdc++

--- a/bindings/kotlin-runtime-common/linux-vulkan.def
+++ b/bindings/kotlin-runtime-common/linux-vulkan.def
@@ -1,4 +1,0 @@
-headers = maplibreNativeRuntime.h
-headerFilter = maplibreNativeRuntime.h
-package = org.maplibre.nativeffi.internal.runtime
-linkerOpts = -lvulkan -ldl -lpthread -lm -lstdc++

--- a/bindings/kotlin-runtime-opengl/build.gradle.kts
+++ b/bindings/kotlin-runtime-opengl/build.gradle.kts
@@ -20,9 +20,6 @@ val packagedAndroidNativeLibs =
 kotlin {
   jvm { compilerOptions { jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.release.get())) } }
 
-  linuxX64()
-  linuxArm64()
-
   android {
     namespace = "org.maplibre.nativeffi.runtime.opengl"
     compileSdk = libs.versions.android.compileSdk.get().toInt()

--- a/bindings/kotlin-runtime-vulkan/build.gradle.kts
+++ b/bindings/kotlin-runtime-vulkan/build.gradle.kts
@@ -20,9 +20,6 @@ val packagedAndroidNativeLibs =
 kotlin {
   jvm { compilerOptions { jvmTarget.set(JvmTarget.fromTarget(libs.versions.java.release.get())) } }
 
-  linuxX64()
-  linuxArm64()
-
   android {
     namespace = "org.maplibre.nativeffi.runtime.vulkan"
     compileSdk = libs.versions.android.compileSdk.get().toInt()

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -55,8 +55,6 @@ val extractRustlsPlatformVerifierAndroidJar =
 kotlin {
   iosArm64()
   iosSimulatorArm64()
-  linuxX64()
-  linuxArm64()
   macosArm64()
 
   jvmToolchain(libs.versions.java.toolchain.get().toInt())
@@ -149,8 +147,6 @@ canonicalizeKmpRootMetadata(
       "iosArm64" to "$mavenArtifact-iosarm64",
       "iosSimulatorArm64" to "$mavenArtifact-iossimulatorarm64",
       "jvm" to "$mavenArtifact-jvm",
-      "linuxArm64" to "$mavenArtifact-linuxarm64",
-      "linuxX64" to "$mavenArtifact-linuxx64",
       "macosArm64" to "$mavenArtifact-macosarm64",
     ),
 )

--- a/bindings/kotlin/mise.toml
+++ b/bindings/kotlin/mise.toml
@@ -4,10 +4,8 @@ depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
 run = '''
 case "$usage_preset" in
-  linux-x64-*) kotlin_target=linuxX64 ;;
-  linux-arm64-*) kotlin_target=linuxArm64 ;;
   macos-arm64-*) kotlin_target=macosArm64 ;;
-  windows-*) kotlin_target= ;;
+  linux-*|windows-*) kotlin_target= ;;
   *)
     echo "Unsupported Kotlin build preset: $usage_preset" >&2
     exit 2
@@ -28,10 +26,8 @@ depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
 run = '''
 case "$usage_preset" in
-  linux-x64-*) kotlin_target=linuxX64 ;;
-  linux-arm64-*) kotlin_target=linuxArm64 ;;
   macos-arm64-*) kotlin_target=macosArm64 ;;
-  windows-*) kotlin_target= ;;
+  linux-*|windows-*) kotlin_target= ;;
   *)
     echo "Unsupported Kotlin test preset: $usage_preset" >&2
     exit 2
@@ -62,8 +58,6 @@ depends = [{ task = "//:build", args = ["{{usage.preset}}"] }]
 dir = "../.."
 run = '''
 case "$usage_preset" in
-  linux-x64-*) kotlin_target=linuxX64 ;;
-  linux-arm64-*) kotlin_target=linuxArm64 ;;
   macos-arm64-*) kotlin_target=macosArm64 ;;
   *)
     echo "Unsupported Kotlin/Native test preset: $usage_preset" >&2

--- a/ci/workflow.toml
+++ b/ci/workflow.toml
@@ -20,7 +20,7 @@ commands = [
 platforms = ["linux", "macos", "windows"]
 commands = [
   { task = "//bindings/kotlin:jvmTest" },
-  { task = "//bindings/kotlin:nativeTest", platforms = ["linux", "macos"], exclude = ["linux-arm64-egl", "linux-arm64-vulkan"] },
+  { task = "//bindings/kotlin:nativeTest", platforms = ["macos"] },
   { task = "//examples/compose-map:build" },
   { task = "//examples/lwjgl-map:build" },
 ]

--- a/docs/src/content/docs/development/kotlin-publishing.md
+++ b/docs/src/content/docs/development/kotlin-publishing.md
@@ -47,10 +47,6 @@ androidMain.dependencies {
   implementation("org.maplibre.nativeffi:maplibre-native-ffi-runtime-opengl:$version")
 }
 
-linuxMain.dependencies {
-  implementation("org.maplibre.nativeffi:maplibre-native-ffi-runtime-opengl:$version")
-}
-
 macosMain.dependencies {
   implementation("org.maplibre.nativeffi:maplibre-native-ffi-runtime-metal:$version")
 }
@@ -66,17 +62,21 @@ link requirements for that target and backend. The final application links the
 archive without acquiring a separate MapLibre Native FFI shared library or
 framework.
 
-The initial native runtime publications are OpenGL and Vulkan for Linux x64 and
-arm64, plus Metal for macOS arm64, iOS arm64, and the iOS arm64 simulator. Each
-published Kotlin/Native target has a matching runtime variant.
+The native runtime publications are Metal for macOS arm64, iOS arm64, and the
+iOS arm64 simulator. Each published Kotlin/Native target has a matching runtime
+variant.
+
+Linux reaches Kotlin through the JVM and Android publications rather than
+Kotlin/Native. Kotlin/Native links the runtime archive statically, and its Linux
+toolchain targets a far older glibc than the archive requires, so a published
+Linux KLIB could not be linked by consumers.
 
 Gradle registers this target set consistently on every host. Local and CI
 workflows invoke target-specific KLIB and test tasks, leaving targets
 unavailable on the current host idle.
 
-System graphics components remain platform dependencies. Examples include Metal
-frameworks from the Apple SDK and EGL, OpenGL, and Vulkan loaders supplied by
-the Linux system.
+System graphics components remain platform dependencies, such as the Metal
+frameworks supplied by the Apple SDK.
 
 ### Android
 
@@ -114,12 +114,10 @@ override.
 ## Snapshot publication
 
 Snapshot versions end in `-SNAPSHOT` and publish from the exact commit that
-passed the main CI workflow. A Linux x64 runner builds the Linux x64 publication
-and cross-compiles the Linux ARM64 publication, while macOS runners build the
-macOS and iOS publications. Each consumes native build artifacts produced by the
-platform and backend CI matrix. Android publication runs with the Linux x64
-partition; it reuses the matrix's CMake install archives and builds only the JNI
-bridge and final AARs.
+passed the main CI workflow. A Linux x64 runner builds the Android publications,
+reusing the matrix's CMake install archives to build only the JNI bridge and
+final AARs, while macOS runners build the JVM, macOS, and iOS publications. Each
+consumes native build artifacts produced by the platform and backend CI matrix.
 
 The Central Portal namespace covering `org.maplibre.nativeffi` must be
 registered with snapshot publishing enabled. The repository stores a Central
@@ -127,14 +125,14 @@ Portal user token in the `MAVEN_CENTRAL_USERNAME` and `MAVEN_CENTRAL_PASSWORD`
 GitHub Actions secrets. Snapshot publication does not require signing.
 
 Each host first stages its publications in a local Maven repository. CI merges
-the Linux x64, Linux ARM64, and Apple repositories, then inspects the published
-AAR, JAR, and KLIB payloads and compiles the example consumers against the
-merged repository. After every local check succeeds, each host publishes its own
-target artifacts to the Central Portal. Linux and Apple leaf modules publish
-first; the canonical multiplatform root modules publish last, after every leaf
-upload succeeds. Snapshot workflows are serialized so two commits cannot
-interleave those uploads. Publication jobs reuse the CI-produced native
-archives; they do not rebuild MapLibre Native.
+the Android and Apple repositories, then inspects the published AAR, JAR, and
+KLIB payloads and compiles the example consumers against the merged repository.
+After every local check succeeds, each host publishes its own target artifacts
+to the Central Portal. Android and Apple leaf modules publish first; the
+canonical multiplatform root modules publish last, after every leaf upload
+succeeds. Snapshot workflows are serialized so two commits cannot interleave
+those uploads. Publication jobs reuse the CI-produced native archives; they do
+not rebuild MapLibre Native.
 
 The initial snapshot workflow validates:
 

--- a/gradle/kotlin-runtime.gradle.kts
+++ b/gradle/kotlin-runtime.gradle.kts
@@ -44,14 +44,15 @@ fun nativeTargets(
   targetFamily: MaplibreRuntimeTargetFamily,
 ): Map<String, NativeTargetConfiguration> =
   when (targetFamily) {
+    // The OpenGL and Vulkan runtimes reach Linux through the JVM and Android
+    // artifacts. Kotlin/Native links the runtime archive statically, and its
+    // Linux toolchain targets a far older glibc than the archive requires, so
+    // these backends register no Kotlin/Native targets.
     MaplibreRuntimeTargetFamily.LINUX -> {
       require(backend != MaplibreRuntimeBackend.METAL) {
-        "Metal does not support Linux Kotlin/Native targets"
+        "Metal does not support the Linux runtime target family"
       }
-      mapOf(
-        "linuxX64" to NativeTargetConfiguration("linux-${backend.id}.def", "linux-x64"),
-        "linuxArm64" to NativeTargetConfiguration("linux-${backend.id}.def", "linux-arm64"),
-      )
+      emptyMap()
     }
     MaplibreRuntimeTargetFamily.APPLE -> {
       require(backend == MaplibreRuntimeBackend.METAL) {
@@ -330,12 +331,7 @@ canonicalizeKmpRootMetadata(
   targetModules =
     when (targetFamily) {
       MaplibreRuntimeTargetFamily.LINUX ->
-        mapOf(
-          "android" to "$mavenArtifact-android",
-          "jvm" to "$mavenArtifact-jvm",
-          "linuxArm64" to "$mavenArtifact-linuxarm64",
-          "linuxX64" to "$mavenArtifact-linuxx64",
-        )
+        mapOf("android" to "$mavenArtifact-android", "jvm" to "$mavenArtifact-jvm")
       MaplibreRuntimeTargetFamily.APPLE ->
         mapOf(
           "iosArm64" to "$mavenArtifact-iosarm64",


### PR DESCRIPTION
## Summary

Drop the `linuxX64` and `linuxArm64` Kotlin/Native targets from the binding and the OpenGL and Vulkan runtimes, since Kotlin/Native's Linux toolchain links against a glibc far older than the runtime archive requires, and rename the publish partitions to `android` and `apple` now that no partition builds Linux KLIBs.

## Test plan

Configured `:bindings:kotlin` and the three runtime projects with `./gradlew <project>:tasks`, which succeeds with no `linuxX64` or `linuxArm64` tasks remaining and the Apple targets, JVM jar, and Android publication intact; CI covers the rest.

## AI assistance

- **Tools:** Claude Code (Opus 5)
- **Context:** Follows the first finding in #319. The published Linux KLIBs fail to link for consumers: Kotlin/Native's linuxX64 sysroot is glibc 2.19, while the embedded `libmaplibre-native-c.a` needs glibc 2.32+ and GCC 11+ libstdc++ symbols. Claude verified the failure against the published snapshot, then made this change.

