### PR TITLE
Pin the Swift Linux toolchain distro

### DIFF
--- a/mise.linux.toml
+++ b/mise.linux.toml
@@ -1,3 +1,9 @@
+[settings]
+# The Swift toolchain ships a separate tarball per Linux distro, while the
+# lockfile records one checksum per os-arch pair. Pin the distro so every Linux
+# machine downloads the artifact the lockfile describes.
+swift.platform = "ubuntu24.04"
+
 [vars]
 host_native_preset = "linux-{{ arch() }}-vulkan"
 


### PR DESCRIPTION
## Summary

Pin `swift.platform = "ubuntu24.04"` on Linux so every Linux host downloads the Swift tarball `mise.lock` describes, instead of a distro-detected one that fails the lock's checksum (Fedora resolved `fedora39` against the `ubuntu24.04` checksum).

## Test plan

`mise run //bindings/swift:test linux-x64-vulkan` passes 76/76 on Fedora 44; `mise.lock` is unchanged, so CI's Ubuntu runners keep the artifact they already had.

## AI assistance

- **Tools:** Claude Code
- **Context:** Diagnosed the checksum mismatch, confirmed the Ubuntu 24.04 toolchain matches the locked checksum and runs on Fedora 44, and evaluated `ubi9` as an alternative (rejected: `mise lock` ignores `swift.platform`, so its checksum can't be regenerated by any mise command).