### PR TITLE
Fix flaky Zig package fetches in CI

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -14,6 +14,19 @@ inputs:
     description: R2 S3 secret access key with Object Read & Write (push jobs only)
     required: false
     default: ""
+  zig:
+    description: Restore the Zig package cache and expose its key for a later save
+    required: false
+    default: "false"
+
+outputs:
+  zig-cache-key:
+    description: Key the job saves the Zig package cache under once its checks pass
+    value: ${{ steps.zig-cache-key.outputs.key }}
+  zig-cache-hit:
+    description: Whether the Zig package cache was restored from an exact key match
+    value: ${{ steps.zig-packages.outputs.cache-hit }}
+
 runs:
   using: composite
   steps:
@@ -102,13 +115,30 @@ runs:
     # Zig's global cache holds downloaded package tarballs, which keeps SDL's
     # source dependencies off the network. Windows resolves it under
     # LOCALAPPDATA; every other platform, including macOS, uses ~/.cache.
-    - name: Cache Zig packages
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    #
+    # Restore only. `actions/cache` saves in a post step even when the job
+    # failed, so a fetch that died partway published an incomplete cache under
+    # the exact key — and because a key is never overwritten, every later run
+    # restored the same gaps and retried the same downloads, turning one
+    # transient network error into a permanent one. The job saves this cache
+    # itself, after the checks that populate it pass.
+    - name: Compute Zig package cache key
+      if: ${{ inputs.zig == 'true' }}
+      id: zig-cache-key
+      shell: bash
+      run: >-
+        echo "key=${{ runner.os }}-${{ runner.arch }}-zig-packages-v1-${{ hashFiles('**/build.zig.zon') }}"
+        >> "$GITHUB_OUTPUT"
+
+    - name: Restore Zig packages
+      if: ${{ inputs.zig == 'true' }}
+      id: zig-packages
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cache/zig
           ~/AppData/Local/zig
-        key: ${{ runner.os }}-${{ runner.arch }}-zig-packages-v1-${{ hashFiles('**/build.zig.zon') }}
+        key: ${{ steps.zig-cache-key.outputs.key }}
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-zig-packages-v1-
 

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           path: pins
           key: pins
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: pins
+          key: pins
+      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: pins
+          key: pins
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test linux-x64-egl
             consumer_commands: >-
@@ -89,7 +88,6 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test linux-x64-vulkan
             consumer_commands: >-
@@ -110,7 +108,6 @@ jobs:
             runner: ubuntu-24.04-arm
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test linux-arm64-egl
             consumer_commands: >-
@@ -130,7 +127,6 @@ jobs:
             runner: ubuntu-24.04-arm
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test linux-arm64-vulkan
             consumer_commands: >-
@@ -150,7 +146,6 @@ jobs:
             runner: macos-26
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test macos-arm64-metal
             consumer_commands: >-
@@ -172,7 +167,6 @@ jobs:
             runner: macos-26
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test macos-arm64-vulkan
             consumer_commands: >-
@@ -193,7 +187,6 @@ jobs:
             runner: macos-26
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test macos-arm64-egl
             consumer_commands: >-
@@ -213,7 +206,6 @@ jobs:
             runner: macos-26
             package: true
             zig: false
-            zig_save: false
             native_commands: >-
               mise run build ios-arm64-metal
             consumer_commands: >-
@@ -223,8 +215,7 @@ jobs:
           - preset: ios-simulator-arm64-metal
             runner: macos-26
             package: true
-            zig: true
-            zig_save: false
+            zig: false
             native_commands: >-
               mise run test ios-simulator-arm64-metal
             consumer_commands: >-
@@ -237,7 +228,6 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: false
-            zig_save: false
             native_commands: >-
               mise run build android-arm64-egl
             consumer_commands: >-
@@ -247,7 +237,6 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: false
-            zig_save: false
             native_commands: >-
               mise run build android-arm64-vulkan
             consumer_commands: >-
@@ -256,7 +245,6 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: false
-            zig_save: false
             native_commands: >-
               mise run build android-x64-egl
             consumer_commands: >-
@@ -266,7 +254,6 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: false
-            zig_save: false
             native_commands: >-
               mise run build android-x64-vulkan
             consumer_commands: >-
@@ -275,21 +262,18 @@ jobs:
             runner: ubuntu-latest
             package: false
             zig: false
-            zig_save: false
             native_commands: >-
               mise run //bindings/rust:build:ohos ohos-arm64-egl
           - preset: ohos-arm64-vulkan
             runner: ubuntu-latest
             package: false
             zig: false
-            zig_save: false
             native_commands: >-
               mise run //bindings/rust:build:ohos ohos-arm64-vulkan
           - preset: windows-x64-wgl
             runner: windows-2022
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test windows-x64-wgl
             consumer_commands: >-
@@ -307,7 +291,6 @@ jobs:
             runner: windows-2022
             package: true
             zig: true
-            zig_save: true
             native_commands: >-
               mise run test windows-x64-vulkan
             consumer_commands: >-
@@ -325,7 +308,6 @@ jobs:
             runner: windows-11-arm
             package: true
             zig: false
-            zig_save: false
             native_commands: >-
               mise run test windows-arm64-wgl
             consumer_commands: >-
@@ -340,7 +322,6 @@ jobs:
             runner: windows-11-arm
             package: true
             zig: false
-            zig_save: false
             native_commands: >-
               mise run test windows-arm64-vulkan
             consumer_commands: >-
@@ -379,7 +360,7 @@ jobs:
           MISE_TASK_SKIP: "//:build"
         run: ${{ matrix.consumer_commands }}
       - name: Save Zig packages
-        if: ${{ matrix.zig_save && steps.setup.outputs.zig-cache-hit != 'true' }}
+        if: ${{ matrix.zig && steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,8 +318,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-ci-deps
+        id: setup
         with:
           target: ${{ matrix.preset }}
+          zig: "true"
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - name: Run native checks
@@ -338,6 +340,14 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
         run: ${{ matrix.consumer_commands }}
+      - name: Save Zig packages
+        if: ${{ matrix.package && steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
       - name: Upload native artifact
         if: ${{ matrix.package }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           - preset: linux-x64-egl
             runner: ubuntu-latest
             package: true
+            zig: true
             native_commands: >-
               mise run test linux-x64-egl
             consumer_commands: >-
@@ -86,6 +87,7 @@ jobs:
           - preset: linux-x64-vulkan
             runner: ubuntu-latest
             package: true
+            zig: true
             native_commands: >-
               mise run test linux-x64-vulkan
             consumer_commands: >-
@@ -105,6 +107,7 @@ jobs:
           - preset: linux-arm64-egl
             runner: ubuntu-24.04-arm
             package: true
+            zig: true
             native_commands: >-
               mise run test linux-arm64-egl
             consumer_commands: >-
@@ -123,6 +126,7 @@ jobs:
           - preset: linux-arm64-vulkan
             runner: ubuntu-24.04-arm
             package: true
+            zig: true
             native_commands: >-
               mise run test linux-arm64-vulkan
             consumer_commands: >-
@@ -141,6 +145,7 @@ jobs:
           - preset: macos-arm64-metal
             runner: macos-26
             package: true
+            zig: true
             native_commands: >-
               mise run test macos-arm64-metal
             consumer_commands: >-
@@ -161,6 +166,7 @@ jobs:
           - preset: macos-arm64-vulkan
             runner: macos-26
             package: true
+            zig: true
             native_commands: >-
               mise run test macos-arm64-vulkan
             consumer_commands: >-
@@ -180,6 +186,7 @@ jobs:
           - preset: macos-arm64-egl
             runner: macos-26
             package: true
+            zig: true
             native_commands: >-
               mise run test macos-arm64-egl
             consumer_commands: >-
@@ -198,6 +205,7 @@ jobs:
           - preset: ios-arm64-metal
             runner: macos-26
             package: true
+            zig: false
             native_commands: >-
               mise run build ios-arm64-metal
             consumer_commands: >-
@@ -207,6 +215,7 @@ jobs:
           - preset: ios-simulator-arm64-metal
             runner: macos-26
             package: true
+            zig: true
             native_commands: >-
               mise run test ios-simulator-arm64-metal
             consumer_commands: >-
@@ -218,6 +227,7 @@ jobs:
           - preset: android-arm64-egl
             runner: ubuntu-latest
             package: true
+            zig: false
             native_commands: >-
               mise run build android-arm64-egl
             consumer_commands: >-
@@ -226,6 +236,7 @@ jobs:
           - preset: android-arm64-vulkan
             runner: ubuntu-latest
             package: true
+            zig: false
             native_commands: >-
               mise run build android-arm64-vulkan
             consumer_commands: >-
@@ -233,6 +244,7 @@ jobs:
           - preset: android-x64-egl
             runner: ubuntu-latest
             package: true
+            zig: false
             native_commands: >-
               mise run build android-x64-egl
             consumer_commands: >-
@@ -241,6 +253,7 @@ jobs:
           - preset: android-x64-vulkan
             runner: ubuntu-latest
             package: true
+            zig: false
             native_commands: >-
               mise run build android-x64-vulkan
             consumer_commands: >-
@@ -248,16 +261,19 @@ jobs:
           - preset: ohos-arm64-egl
             runner: ubuntu-latest
             package: false
+            zig: false
             native_commands: >-
               mise run //bindings/rust:build:ohos ohos-arm64-egl
           - preset: ohos-arm64-vulkan
             runner: ubuntu-latest
             package: false
+            zig: false
             native_commands: >-
               mise run //bindings/rust:build:ohos ohos-arm64-vulkan
           - preset: windows-x64-wgl
             runner: windows-2022
             package: true
+            zig: true
             native_commands: >-
               mise run test windows-x64-wgl
             consumer_commands: >-
@@ -274,6 +290,7 @@ jobs:
           - preset: windows-x64-vulkan
             runner: windows-2022
             package: true
+            zig: true
             native_commands: >-
               mise run test windows-x64-vulkan
             consumer_commands: >-
@@ -290,6 +307,7 @@ jobs:
           - preset: windows-arm64-wgl
             runner: windows-11-arm
             package: true
+            zig: false
             native_commands: >-
               mise run test windows-arm64-wgl
             consumer_commands: >-
@@ -303,6 +321,7 @@ jobs:
           - preset: windows-arm64-vulkan
             runner: windows-11-arm
             package: true
+            zig: false
             native_commands: >-
               mise run test windows-arm64-vulkan
             consumer_commands: >-
@@ -321,7 +340,7 @@ jobs:
         id: setup
         with:
           target: ${{ matrix.preset }}
-          zig: "true"
+          zig: ${{ matrix.zig }}
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - name: Run native checks
@@ -341,7 +360,7 @@ jobs:
           MISE_TASK_SKIP: "//:build"
         run: ${{ matrix.consumer_commands }}
       - name: Save Zig packages
-        if: ${{ matrix.package && steps.setup.outputs.zig-cache-hit != 'true' }}
+        if: ${{ matrix.zig && steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test linux-x64-egl
             consumer_commands: >-
@@ -88,6 +89,7 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test linux-x64-vulkan
             consumer_commands: >-
@@ -108,6 +110,7 @@ jobs:
             runner: ubuntu-24.04-arm
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test linux-arm64-egl
             consumer_commands: >-
@@ -127,6 +130,7 @@ jobs:
             runner: ubuntu-24.04-arm
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test linux-arm64-vulkan
             consumer_commands: >-
@@ -146,6 +150,7 @@ jobs:
             runner: macos-26
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test macos-arm64-metal
             consumer_commands: >-
@@ -167,6 +172,7 @@ jobs:
             runner: macos-26
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test macos-arm64-vulkan
             consumer_commands: >-
@@ -187,6 +193,7 @@ jobs:
             runner: macos-26
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test macos-arm64-egl
             consumer_commands: >-
@@ -206,6 +213,7 @@ jobs:
             runner: macos-26
             package: true
             zig: false
+            zig_save: false
             native_commands: >-
               mise run build ios-arm64-metal
             consumer_commands: >-
@@ -216,6 +224,7 @@ jobs:
             runner: macos-26
             package: true
             zig: true
+            zig_save: false
             native_commands: >-
               mise run test ios-simulator-arm64-metal
             consumer_commands: >-
@@ -228,6 +237,7 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: false
+            zig_save: false
             native_commands: >-
               mise run build android-arm64-egl
             consumer_commands: >-
@@ -237,6 +247,7 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: false
+            zig_save: false
             native_commands: >-
               mise run build android-arm64-vulkan
             consumer_commands: >-
@@ -245,6 +256,7 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: false
+            zig_save: false
             native_commands: >-
               mise run build android-x64-egl
             consumer_commands: >-
@@ -254,6 +266,7 @@ jobs:
             runner: ubuntu-latest
             package: true
             zig: false
+            zig_save: false
             native_commands: >-
               mise run build android-x64-vulkan
             consumer_commands: >-
@@ -262,18 +275,21 @@ jobs:
             runner: ubuntu-latest
             package: false
             zig: false
+            zig_save: false
             native_commands: >-
               mise run //bindings/rust:build:ohos ohos-arm64-egl
           - preset: ohos-arm64-vulkan
             runner: ubuntu-latest
             package: false
             zig: false
+            zig_save: false
             native_commands: >-
               mise run //bindings/rust:build:ohos ohos-arm64-vulkan
           - preset: windows-x64-wgl
             runner: windows-2022
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test windows-x64-wgl
             consumer_commands: >-
@@ -291,6 +307,7 @@ jobs:
             runner: windows-2022
             package: true
             zig: true
+            zig_save: true
             native_commands: >-
               mise run test windows-x64-vulkan
             consumer_commands: >-
@@ -308,6 +325,7 @@ jobs:
             runner: windows-11-arm
             package: true
             zig: false
+            zig_save: false
             native_commands: >-
               mise run test windows-arm64-wgl
             consumer_commands: >-
@@ -322,6 +340,7 @@ jobs:
             runner: windows-11-arm
             package: true
             zig: false
+            zig_save: false
             native_commands: >-
               mise run test windows-arm64-vulkan
             consumer_commands: >-
@@ -360,7 +379,7 @@ jobs:
           MISE_TASK_SKIP: "//:build"
         run: ${{ matrix.consumer_commands }}
       - name: Save Zig packages
-        if: ${{ matrix.zig && steps.setup.outputs.zig-cache-hit != 'true' }}
+        if: ${{ matrix.zig_save && steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -60,7 +60,7 @@ def setup(target: str | None = None, zig: bool = False) -> list[str]:
     if target:
         lines.append(f"          target: {target}")
     if zig:
-        lines.append('          zig: "true"')
+        lines.append("          zig: ${{ matrix.zig }}")
     lines.extend(
         [
             "          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}",
@@ -146,11 +146,12 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "        env:",
         '          MISE_TASK_SKIP: "//:build"',
         "        run: ${{ matrix.consumer_commands }}",
-        # No status function in the `if`, so `success()` is implied: a job that
+        # Only rows that actually run Zig may claim the key; see `uses_zig`. No
+        # status function in the `if`, so `success()` is implied: a job that
         # fetched only part of its Zig packages before failing saves nothing,
         # leaving the key free for a later run that completes the fetch.
         "      - name: Save Zig packages",
-        "        if: ${{ matrix.package && steps.setup.outputs.zig-cache-hit != 'true' }}",
+        "        if: ${{ matrix.zig && steps.setup.outputs.zig-cache-hit != 'true' }}",
         f"        uses: {CACHE_SAVE}",
         "        with:",
         "          path: |",

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -17,6 +17,7 @@ from ci.workflow import load_configuration, target_rows  # noqa: E402
 # Pins come from `.github/workflows/action-pins.yml` so Dependabot updates them.
 PINS = load_pins(ROOT)
 CHECKOUT = PINS["actions/checkout"]
+CACHE_SAVE = PINS["actions/cache/save"]
 DOWNLOAD = PINS["actions/download-artifact"]
 UPLOAD = PINS["actions/upload-artifact"]
 
@@ -46,16 +47,20 @@ SCCACHE_ENVIRONMENT = (
 )
 
 
-def setup(target: str | None = None) -> list[str]:
+def setup(target: str | None = None, zig: bool = False) -> list[str]:
     lines = [
         f"      - uses: {CHECKOUT}",
         "        with:",
         "          persist-credentials: false",
         "      - uses: ./.github/actions/setup-ci-deps",
-        "        with:",
     ]
+    if zig:
+        lines.append("        id: setup")
+    lines.append("        with:")
     if target:
         lines.append(f"          target: {target}")
+    if zig:
+        lines.append('          zig: "true"')
     lines.extend(
         [
             "          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}",
@@ -124,7 +129,7 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "      matrix:",
         *matrix(rows),
         "    steps:",
-        *setup("${{ matrix.preset }}"),
+        *setup("${{ matrix.preset }}", zig=True),
         "      - name: Run native checks",
         "        run: ${{ matrix.native_commands }}",
         "      - name: Archive native artifact",
@@ -141,6 +146,17 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "        env:",
         '          MISE_TASK_SKIP: "//:build"',
         "        run: ${{ matrix.consumer_commands }}",
+        # No status function in the `if`, so `success()` is implied: a job that
+        # fetched only part of its Zig packages before failing saves nothing,
+        # leaving the key free for a later run that completes the fetch.
+        "      - name: Save Zig packages",
+        "        if: ${{ matrix.package && steps.setup.outputs.zig-cache-hit != 'true' }}",
+        f"        uses: {CACHE_SAVE}",
+        "        with:",
+        "          path: |",
+        "            ~/.cache/zig",
+        "            ~/AppData/Local/zig",
+        "          key: ${{ steps.setup.outputs.zig-cache-key }}",
         "      - name: Upload native artifact",
         "        if: ${{ matrix.package }}",
         f"        uses: {UPLOAD}",

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -147,12 +147,12 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         '          MISE_TASK_SKIP: "//:build"',
         "        run: ${{ matrix.consumer_commands }}",
         # Only rows that fetch every Zig project the key covers may claim it;
-        # see `fills_zig_cache`. No status function in the `if`, so `success()`
-        # is implied: a job that fetched only part of its Zig packages before
+        # see `uses_zig`. No status function in the `if`, so `success()` is
+        # implied: a job that fetched only part of its Zig packages before
         # failing saves nothing, leaving the key free for a later run that
         # completes the fetch.
         "      - name: Save Zig packages",
-        "        if: ${{ matrix.zig_save && steps.setup.outputs.zig-cache-hit != 'true' }}",
+        "        if: ${{ matrix.zig && steps.setup.outputs.zig-cache-hit != 'true' }}",
         f"        uses: {CACHE_SAVE}",
         "        with:",
         "          path: |",

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -146,12 +146,13 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         "        env:",
         '          MISE_TASK_SKIP: "//:build"',
         "        run: ${{ matrix.consumer_commands }}",
-        # Only rows that actually run Zig may claim the key; see `uses_zig`. No
-        # status function in the `if`, so `success()` is implied: a job that
-        # fetched only part of its Zig packages before failing saves nothing,
-        # leaving the key free for a later run that completes the fetch.
+        # Only rows that fetch every Zig project the key covers may claim it;
+        # see `fills_zig_cache`. No status function in the `if`, so `success()`
+        # is implied: a job that fetched only part of its Zig packages before
+        # failing saves nothing, leaving the key free for a later run that
+        # completes the fetch.
         "      - name: Save Zig packages",
-        "        if: ${{ matrix.zig && steps.setup.outputs.zig-cache-hit != 'true' }}",
+        "        if: ${{ matrix.zig_save && steps.setup.outputs.zig-cache-hit != 'true' }}",
         f"        uses: {CACHE_SAVE}",
         "        with:",
         "          path: |",

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -118,6 +118,20 @@ def consumer_commands(source: dict[str, object], preset: str) -> list[str]:
     return commands
 
 
+def uses_zig(commands: list[str]) -> bool:
+    """Whether a row runs Zig, and so populates the Zig package cache.
+
+    Rows that never fetch Zig packages must not restore or save that cache: the
+    key is shared by every row on the same runner OS and architecture, and cache
+    keys are immutable, so an empty save from an Android or iOS row would deny
+    the Zig rows a complete cache for as long as the key stays current.
+    """
+    return any(
+        command.startswith(("mise run //bindings/zig:", "mise run //examples/zig-"))
+        for command in commands
+    )
+
+
 def preset_sets(
     presets: dict[str, object],
 ) -> tuple[list[str], set[str], set[str], set[str]]:
@@ -153,6 +167,7 @@ def target_rows(
             "preset": preset,
             "runner": runner(preset),
             "package": preset in packaged,
+            "zig": uses_zig(native + consumers),
             "native_commands": native if preset in packaged else native + consumers,
         }
         if preset in packaged:

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -118,17 +118,35 @@ def consumer_commands(source: dict[str, object], preset: str) -> list[str]:
     return commands
 
 
+ZIG_PROJECTS = (
+    "mise run //bindings/zig:",
+    "mise run //examples/zig-map:",
+    "mise run //examples/zig-readback:",
+)
+
+
 def uses_zig(commands: list[str]) -> bool:
-    """Whether a row runs Zig, and so populates the Zig package cache.
+    """Whether a row runs Zig, and so benefits from the Zig package cache.
 
     Rows that never fetch Zig packages must not restore or save that cache: the
     key is shared by every row on the same runner OS and architecture, and cache
     keys are immutable, so an empty save from an Android or iOS row would deny
     the Zig rows a complete cache for as long as the key stays current.
     """
-    return any(
-        command.startswith(("mise run //bindings/zig:", "mise run //examples/zig-"))
-        for command in commands
+    return any(command.startswith(ZIG_PROJECTS) for command in commands)
+
+
+def fills_zig_cache(commands: list[str]) -> bool:
+    """Whether a row fetches every Zig project the cache key covers.
+
+    The key hashes every `build.zig.zon` in the repository, so a row that runs
+    only some of those projects would save a cache that is missing the rest.
+    Because the key is immutable, that partial save would win the shared key and
+    send the rows that do run the examples back to the network on every run.
+    """
+    return all(
+        any(command.startswith(project) for command in commands)
+        for project in ZIG_PROJECTS
     )
 
 
@@ -168,6 +186,7 @@ def target_rows(
             "runner": runner(preset),
             "package": preset in packaged,
             "zig": uses_zig(native + consumers),
+            "zig_save": fills_zig_cache(native + consumers),
             "native_commands": native if preset in packaged else native + consumers,
         }
         if preset in packaged:

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -126,23 +126,13 @@ ZIG_PROJECTS = (
 
 
 def uses_zig(commands: list[str]) -> bool:
-    """Whether a row runs Zig, and so benefits from the Zig package cache.
+    """Whether a row fetches every Zig project the package cache key covers.
 
-    Rows that never fetch Zig packages must not restore or save that cache: the
-    key is shared by every row on the same runner OS and architecture, and cache
-    keys are immutable, so an empty save from an Android or iOS row would deny
-    the Zig rows a complete cache for as long as the key stays current.
-    """
-    return any(command.startswith(ZIG_PROJECTS) for command in commands)
-
-
-def fills_zig_cache(commands: list[str]) -> bool:
-    """Whether a row fetches every Zig project the cache key covers.
-
-    The key hashes every `build.zig.zon` in the repository, so a row that runs
-    only some of those projects would save a cache that is missing the rest.
-    Because the key is immutable, that partial save would win the shared key and
-    send the rows that do run the examples back to the network on every run.
+    The key hashes every `build.zig.zon` in the repository and is shared by all
+    rows on the same runner OS and architecture. Cache keys are immutable, so a
+    row that runs only some of those projects would win the key with a cache
+    that is missing the rest, and Zig's fetcher has no retry: the rows that do
+    run the examples would then fail whenever an upstream host is unavailable.
     """
     return all(
         any(command.startswith(project) for command in commands)
@@ -186,7 +176,6 @@ def target_rows(
             "runner": runner(preset),
             "package": preset in packaged,
             "zig": uses_zig(native + consumers),
-            "zig_save": fills_zig_cache(native + consumers),
             "native_commands": native if preset in packaged else native + consumers,
         }
         if preset in packaged:

--- a/examples/zig-map/build.zig.zon
+++ b/examples/zig-map/build.zig.zon
@@ -12,8 +12,8 @@
             .hash = "zigglgen-0.5.0-ziggltzDLwA0Gk0Pj6QMij1j6Z_jkvGEtGKBM6-YlI_s",
         },
         .sdl = .{
-            .url = "git+https://github.com/allyourcodebase/SDL3.git#2112c226de02434111c8a7337fb83d5e5a270d76",
-            .hash = "sdl-1.0.1+3.4.4-i4QD0YeSqQCDkGoyRgfZH6_05GyutM6wfeECig3-STNj",
+            .url = "git+https://github.com/castholm/SDL.git#1b67d371a531ecb0499d4b80a865631c299f472a",
+            .hash = "sdl-0.5.2+3.4.12-SDL--qPKpwHc40bqAlYs7W9pXJVyLwsGDNa4shNXbOZr",
         },
     },
     .paths = .{""},

--- a/examples/zig-readback/build.zig.zon
+++ b/examples/zig-readback/build.zig.zon
@@ -4,8 +4,8 @@
     .dependencies = .{
         .maplibre_native = .{ .path = "../../bindings/zig" },
         .sdl = .{
-            .url = "git+https://github.com/allyourcodebase/SDL3.git#2112c226de02434111c8a7337fb83d5e5a270d76",
-            .hash = "sdl-1.0.1+3.4.4-i4QD0YeSqQCDkGoyRgfZH6_05GyutM6wfeECig3-STNj",
+            .url = "git+https://github.com/castholm/SDL.git#1b67d371a531ecb0499d4b80a865631c299f472a",
+            .hash = "sdl-0.5.2+3.4.12-SDL--qPKpwHc40bqAlYs7W9pXJVyLwsGDNa4shNXbOZr",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
## Summary

Switch the Zig examples from `allyourcodebase/SDL3` to `castholm/SDL` so package fetches hit one host instead of pulling 28 transitive tarballs from gitlab.freedesktop.org, and stop publishing partial Zig package caches.

## Test plan

Built and ran `zig-map` (Vulkan and OpenGL) and `zig-readback` locally on Linux, and A/B'd the old and new SDL builds for behavior differences; Windows msvc needs CI.

## Notes

The fetch step failed like this, on two different freedesktop.org URLs in the same run:

```
zig-pkg/sdl-1.0.1+3.4.4-.../build.zig.zon:36:20: error: unable to connect to server: TlsInitializationFailed
zig-pkg/sdl-1.0.1+3.4.4-.../build.zig.zon:48:20: error: invalid HTTP response: HttpConnectionClosing
```

`allyourcodebase/SDL3` declares 28 dependencies and marks only 2 lazy, so every job downloaded X11, wayland, alsa, pipewire, dbus and the rest regardless of platform — 14 of them from gitlab.freedesktop.org, whose `/-/archive/` endpoint throttles hard. Zig's fetcher has no retry and one failure kills the build.

`castholm/SDL` vendors the SDL source and bundles the Linux system headers into a single lazy package, so the tree is `sdl`, `sdl_linux_deps`, `zigglgen`, `zig_objc` — all github.com. No `build.zig` changes were needed; the `b.dependency("sdl", ...)` / `.artifact("SDL3")` shape is identical. `zig-readback` had the same dependency and is swapped too. SDL goes 3.4.4 -> 3.4.12.

The cache change is separate. `actions/cache` saves in a post step even when the job failed, so a fetch that died partway published an incomplete cache under the exact key — and since a key is never overwritten, every later run restored the same gaps and retried the same downloads. That is why this failed consistently rather than occasionally: in the run above the cache hit its exact key and still went to the network. Restore now happens in `setup-ci-deps` (behind a new `zig` input, so only the `target` job pays for it) and the save happens in the job after its checks pass.

Two things I could not verify locally:

- `castholm/SDL` lists `x86_64-windows-msvc` as second-class, and the Windows runners default to msvc. That is where I would expect this to break.
- The macOS `system_root` handling in `zig-map/build.zig`. The new package has `system_include_path` / `system_framework_path` / `library_path` options that would replace it, but I left that alone since I cannot test it.

Unrelated: I hit a `swift@6.3.1` checksum mismatch locally and ran everything with `MISE_DISABLE_TOOLS=swift,swiftformat`. Nothing here needs Swift.

## AI assistance

- **Tools:** Claude Code
- **Context:** Used to investigate the CI failures, survey GitHub mirror coverage for the freedesktop dependencies, and draft the change. I reviewed the diff and ran the local verification.