### PR TITLE
Publish Dokka Javadoc JARs for Kotlin APIs

### DIFF
--- a/.mise/tasks/kotlin/verify-staging
+++ b/.mise/tasks/kotlin/verify-staging
@@ -27,6 +27,17 @@ MODULES = {
     "maplibre-native-ffi-runtime-vulkan-jvm",
 }
 
+# Modules with public Kotlin API. Their javadoc jars must carry the Dokka site,
+# not the manifest-only placeholders Maven Central tolerates for API-free modules.
+API_BEARING_MODULES = {
+    "maplibre-native-ffi",
+    "maplibre-native-ffi-android",
+    "maplibre-native-ffi-iosarm64",
+    "maplibre-native-ffi-iossimulatorarm64",
+    "maplibre-native-ffi-jvm",
+    "maplibre-native-ffi-macosarm64",
+}
+
 ROOT_TARGET_MODULES = {
     "maplibre-native-ffi": {
         "android": "maplibre-native-ffi-android",
@@ -123,6 +134,28 @@ def verify_metadata(root: pathlib.Path) -> None:
                 f"{metadata_path} references {referenced_targets}; "
                 f"expected {set(target_modules)}"
             )
+
+
+def verify_javadoc(root: pathlib.Path) -> None:
+    for module in API_BEARING_MODULES:
+        javadoc = one(
+            module_files(root, module, "-javadoc.jar"), f"{module} javadoc JAR"
+        )
+        with zipfile.ZipFile(javadoc) as jar:
+            names = set(jar.namelist())
+            if "index.html" not in names:
+                raise SystemExit(
+                    f"{javadoc} does not contain generated documentation"
+                )
+            if not any(
+                name.startswith("maplibre-native-ffi/org.maplibre.nativeffi")
+                and name.endswith(".html")
+                for name in names
+            ):
+                raise SystemExit(
+                    f"{javadoc} does not contain generated API pages"
+                )
+
 
 def verify_android(root: pathlib.Path) -> None:
     core = one(
@@ -235,6 +268,7 @@ def main() -> int:
         return 2
     root = pathlib.Path(sys.argv[1])
     verify_metadata(root)
+    verify_javadoc(root)
     verify_android(root)
     verify_jvm(root)
     verify_native(root)

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
   id("org.jetbrains.kotlin.multiplatform")
   id("com.android.kotlin.multiplatform.library")
   id("com.vanniktech.maven.publish")
+  alias(libs.plugins.dokka)
 }
 
 apply(from = rootProject.file("gradle/native-artifact.gradle.kts"))
@@ -137,6 +138,8 @@ mavenPublishing {
     description.set("Low-level Kotlin Multiplatform bindings for the MapLibre Native C API.")
   }
 }
+
+dokka { moduleName.set(mavenArtifact) }
 
 canonicalizeKmpRootMetadata(
   group = mavenGroup,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
   id("com.android.application") apply false
   id("com.android.kotlin.multiplatform.library") apply false
   id("com.vanniktech.maven.publish") apply false
+  alias(libs.plugins.dokka) apply false
 }
 
 allprojects {

--- a/docs/src/content/docs/development/kotlin-publishing.md
+++ b/docs/src/content/docs/development/kotlin-publishing.md
@@ -38,6 +38,11 @@ targets are all supported by one backend may depend on that runtime from
 `commonMain`. Applications using different backends select runtime publications
 from their platform source sets.
 
+Every `maplibre-native-ffi` module attaches Dokka-generated API documentation as
+its Maven javadoc artifact. The generated site covers the common API and each
+platform API. The runtime modules carry no public API, so their javadoc
+artifacts remain empty placeholders for the Central requirement.
+
 ```kotlin
 commonMain.dependencies {
   implementation("org.maplibre.nativeffi:maplibre-native-ffi:$version")
@@ -140,6 +145,7 @@ The initial snapshot workflow validates:
 - native archive presence in published KLIBs;
 - JNI library and Rustls helper presence in Android AARs;
 - native resource presence in JVM classifier JARs;
+- Dokka-generated API pages in every API-bearing javadoc JAR;
 - published JVM consumption through the Compose and LWJGL examples;
 - published Android consumption through the Android map example.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 kotlin = "2.4.10"
 compose = "1.11.1"
 agp = "9.1.1"
+dokka = "2.2.0"
 maven-publish = "0.37.0"
 javacpp = "1.5.11"
 lwjgl = "3.4.1"
@@ -26,3 +27,4 @@ lwjgl-shaderc = { module = "org.lwjgl:lwjgl-shaderc" }
 [plugins]
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }


### PR DESCRIPTION
## Summary

- Apply Dokka to Kotlin Maven publications and configure module names.
- Verify generated API pages in javadoc JARs during staging checks.
- Document Kotlin javadoc publishing and add the Dokka version catalog plugin.

## Testing

- Not run; changes were reviewed against the staging verification workflow.