### PR TITLE
Clip oversized rendered feature queries to the viewport

### DIFF
--- a/bindings/dotnet/src/Maplibre.Native/Geo/CoreValues.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Geo/CoreValues.cs
@@ -12,7 +12,11 @@ public readonly record struct ProjectedMeters(double Northing, double Easting);
 /// <summary>Screen coordinate in logical map pixels.</summary>
 public readonly record struct ScreenPoint(double X, double Y);
 
-/// <summary>Screen-space box in logical map pixels.</summary>
+/// <summary>
+/// Screen-space box in logical map pixels. Corners may be given in any order, and may extend past
+/// the viewport. Rendered queries normalize the corners and clip the box to the viewport, so a box
+/// that over-covers the viewport queries everything visible.
+/// </summary>
 public readonly record struct ScreenBox(ScreenPoint Min, ScreenPoint Max);
 
 /// <summary>3D vector.</summary>

--- a/bindings/go/query.go
+++ b/bindings/go/query.go
@@ -19,7 +19,11 @@ const (
 	RenderedQueryGeometryTypeLineString RenderedQueryGeometryType = RenderedQueryGeometryType(C.MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING)
 )
 
-// ScreenBox is a screen-space query rectangle.
+// ScreenBox is a screen-space query rectangle in logical map pixels.
+//
+// Corners may be given in any order, and may extend past the viewport. Rendered
+// queries normalize the corners and clip the box to the viewport, so a box that
+// over-covers the viewport queries everything visible.
 type ScreenBox struct {
 	Min ScreenPoint
 	Max ScreenPoint

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/geo/ScreenBox.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/geo/ScreenBox.kt
@@ -1,4 +1,10 @@
 package org.maplibre.nativeffi.geo
 
-/** Screen-space box in logical map pixels. */
+/**
+ * Screen-space box in logical map pixels.
+ *
+ * Corners may be given in any order, and may extend past the viewport. Rendered queries normalize
+ * the corners and clip the box to the viewport, so a box that over-covers the viewport queries
+ * everything visible.
+ */
 public data class ScreenBox(public val min: ScreenPoint, public val max: ScreenPoint)

--- a/bindings/python/python/maplibre_native/query.py
+++ b/bindings/python/python/maplibre_native/query.py
@@ -21,7 +21,12 @@ class RenderedQueryGeometryType(NativeIntEnum):
 
 @dataclass(frozen=True, slots=True)
 class ScreenBox:
-    """Screen-space box in logical map pixels."""
+    """Screen-space box in logical map pixels.
+
+    Corners may be given in any order, and may extend past the viewport.
+    Rendered queries normalize the corners and clip the box to the viewport, so
+    a box that over-covers the viewport queries everything visible.
+    """
 
     min: ScreenPoint
     max: ScreenPoint

--- a/bindings/rust/crates/maplibre-native-core/src/values.rs
+++ b/bindings/rust/crates/maplibre-native-core/src/values.rs
@@ -127,6 +127,10 @@ impl ScreenPoint {
 }
 
 /// Screen-space box in logical map pixels.
+///
+/// Corners may be given in any order, and may extend past the viewport.
+/// Rendered queries normalize the corners and clip the box to the viewport, so
+/// a box that over-covers the viewport queries everything visible.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ScreenBox {
     pub min: ScreenPoint,

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -1761,6 +1761,71 @@ fn rendered_and_source_queries_copy_results() {
 
 #[test]
 // Spec coverage: BND-106.
+fn rendered_box_queries_clip_to_the_viewport() {
+    if !has_test_owned_texture_session_backend() {
+        return;
+    }
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::new(64, 64, 1.0)).unwrap();
+    let (_context, session) =
+        create_owned_texture_session(&map, RenderTargetExtent::new(64, 64, 1.0))
+            .expect("Metal or Vulkan owned texture test session should attach when supported");
+
+    load_query_style(&runtime, &map, &session);
+    let mut options = RenderedFeatureQueryOptions::default();
+    options.layer_ids = Some(vec!["point-circle".into()]);
+
+    // Over-covering the viewport is the obvious way to ask for everything on
+    // screen, and must answer like the viewport itself.
+    let oversized = RenderedQueryGeometry::box_(ScreenBox::new(
+        ScreenPoint::new(-4096.0, -4096.0),
+        ScreenPoint::new(4096.0, 4096.0),
+    ));
+    let rendered = wait_for_rendered_feature(
+        &runtime,
+        &session,
+        &oversized,
+        &options,
+        "over-covering box query",
+    );
+    assert_eq!(
+        rendered.feature.identifier,
+        FeatureIdentifier::String("feature-1".into())
+    );
+
+    // Corners in either order describe the same box.
+    let inverted = RenderedQueryGeometry::box_(ScreenBox::new(
+        ScreenPoint::new(4096.0, 4096.0),
+        ScreenPoint::new(-4096.0, -4096.0),
+    ));
+    assert_eq!(
+        session
+            .query_rendered_features(&inverted, Some(&options))
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // Clipping keeps a fully off-screen box empty instead of collapsing it onto
+    // a viewport edge.
+    let offscreen = RenderedQueryGeometry::box_(ScreenBox::new(
+        ScreenPoint::new(512.0, 512.0),
+        ScreenPoint::new(1024.0, 1024.0),
+    ));
+    assert!(
+        session
+            .query_rendered_features(&offscreen, Some(&options))
+            .unwrap()
+            .is_empty()
+    );
+
+    session.close().unwrap();
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
+// Spec coverage: BND-106.
 fn feature_extension_queries_copy_value_and_feature_collection_results() {
     if !has_test_owned_texture_session_backend() {
         return;

--- a/bindings/swift/Sources/MaplibreNative/Query.swift
+++ b/bindings/swift/Sources/MaplibreNative/Query.swift
@@ -3,6 +3,12 @@ internal import CMaplibreNativeC
 
 public enum RenderedQueryGeometry: Equatable, Sendable {
   case point(ScreenPoint)
+  /// Screen-space box in logical map pixels.
+  ///
+  /// Corners may be given in any order, and may extend past the
+  /// viewport. Rendered queries normalize the corners and clip the box
+  /// to the viewport, so a box that over-covers the viewport queries
+  /// everything visible.
   case box(min: ScreenPoint, max: ScreenPoint)
   case lineString([ScreenPoint])
 

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -260,6 +260,11 @@ pub const FeatureStateSelector = struct {
     state_key: ?[]const u8 = null,
 };
 
+/// Screen-space box in logical map pixels.
+///
+/// Corners may be given in any order, and may extend past the viewport.
+/// Rendered queries normalize the corners and clip the box to the viewport, so
+/// a box that over-covers the viewport queries everything visible.
 pub const ScreenBox = struct {
     min: values.ScreenPoint,
     max: values.ScreenPoint,

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -1320,6 +1320,51 @@ test "render session queries rendered and source features" {
     try testing.expectError(error.InvalidArgument, session.querySourceFeatures(testing.allocator, "", null));
 }
 
+test "render session clips rendered box queries to the viewport" {
+    if (!supports_test_owned_texture) return error.SkipZigTest;
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    defer map.close() catch @panic("map close failed");
+
+    var owned = try attachTestOwnedTexture(&map, .{});
+    defer owned.close() catch {};
+    const session = &owned.session;
+
+    try map.setStyleJson(testing.allocator, support.style_json);
+    try testing.expect(try waitForEvent(&runtime, .map_render_update_available));
+    try session.renderUpdate();
+
+    const options = maplibre.RenderedFeatureQueryOptions{ .layer_ids = &.{"point-circle"} };
+
+    // Over-covering the viewport is the obvious way to ask for everything on
+    // screen, and must answer like the viewport itself.
+    var oversized = try waitForRenderedFeatureQuery(&runtime, session, .{ .box = .{
+        .min = .{ .x = -8192, .y = -8192 },
+        .max = .{ .x = 8192, .y = 8192 },
+    } }, options);
+    defer oversized.deinit();
+    try expectFeaturePropertyString(&oversized.features[0], "kind", "capital");
+
+    // Corners in either order describe the same box.
+    var inverted = try session.queryRenderedFeatures(testing.allocator, .{ .box = .{
+        .min = .{ .x = 8192, .y = 8192 },
+        .max = .{ .x = -8192, .y = -8192 },
+    } }, options);
+    defer inverted.deinit();
+    try testing.expectEqual(@as(usize, 1), inverted.features.len);
+
+    // Clipping keeps a fully off-screen box empty instead of collapsing it onto
+    // a viewport edge.
+    var offscreen = try session.queryRenderedFeatures(testing.allocator, .{ .box = .{
+        .min = .{ .x = 2048, .y = 2048 },
+        .max = .{ .x = 4096, .y = 4096 },
+    } }, options);
+    defer offscreen.deinit();
+    try testing.expectEqual(@as(usize, 0), offscreen.features.len);
+}
+
 test "render session queries cluster feature extensions" {
     if (!supports_test_owned_texture) return error.SkipZigTest;
     var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);

--- a/include/maplibre_native_c/query.h
+++ b/include/maplibre_native_c/query.h
@@ -26,7 +26,13 @@ typedef enum mln_rendered_query_geometry_type : uint32_t {
   MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING = 3,
 } mln_rendered_query_geometry_type;
 
-/** Screen-space box in logical map pixels. */
+/**
+ * Screen-space box in logical map pixels.
+ *
+ * Corners may be given in any order, and may extend past the viewport. Rendered
+ * queries normalize the corners and clip the box to the viewport, so a box that
+ * over-covers the viewport queries everything visible.
+ */
 typedef struct mln_screen_box {
   mln_screen_point min;
   mln_screen_point max;
@@ -154,6 +160,11 @@ MLN_API mln_rendered_query_geometry mln_rendered_query_geometry_line_string(
  * for the duration of the call. Passing null for options uses default options.
  * On success, *out_result receives an owned result handle. Destroy it with
  * mln_feature_query_result_destroy().
+ *
+ * Box geometry is normalized and clipped to the viewport, so a box that
+ * over-covers the viewport queries everything visible. A box that lies entirely
+ * outside the viewport yields an empty result. Point and line-string geometry
+ * are queried as given.
  *
  * Returns:
  * - MLN_STATUS_OK on success.

--- a/src/render/render_session_common.cpp
+++ b/src/render/render_session_common.cpp
@@ -583,6 +583,31 @@ auto to_screen_line_string(
   return true;
 }
 
+// Normalizes a query box and intersects it with the viewport. Native tile-space
+// query geometry saturates at a few tiles past a tile's own bounds, so a box
+// that over-covers the viewport can degrade into an empty answer instead of the
+// visible features. Clipping to the viewport is lossless for a box: the
+// intersection of a screen-space box with the viewport is the same box over the
+// only region that can hold rendered features. Returns nullopt when the box
+// lies entirely outside the viewport, which holds no rendered features.
+auto clip_screen_box_to_viewport(
+  mln_screen_box box, uint32_t width, uint32_t height
+) -> std::optional<mbgl::ScreenBox> {
+  const auto view_width = static_cast<double>(width);
+  const auto view_height = static_cast<double>(height);
+  const auto min_x = std::min(box.min.x, box.max.x);
+  const auto min_y = std::min(box.min.y, box.max.y);
+  const auto max_x = std::max(box.min.x, box.max.x);
+  const auto max_y = std::max(box.min.y, box.max.y);
+  if (min_x > view_width || min_y > view_height || max_x < 0.0 || max_y < 0.0) {
+    return std::nullopt;
+  }
+  return mbgl::ScreenBox{
+    {std::max(min_x, 0.0), std::max(min_y, 0.0)},
+    {std::min(max_x, view_width), std::min(max_y, view_height)}
+  };
+}
+
 auto feature_identifier_type(
   const mbgl::FeatureIdentifier& identifier,
   mln::core::OwnedQueriedFeatureDescriptor& storage
@@ -1247,20 +1272,25 @@ auto render_session_query_rendered_features(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
   auto line_string = mbgl::ScreenLineString{};
+  auto clipped_box = std::optional<mbgl::ScreenBox>{};
   switch (geometry->type) {
     case MLN_RENDERED_QUERY_GEOMETRY_TYPE_POINT:
       if (!validate_screen_point(geometry->data.point)) {
         return MLN_STATUS_INVALID_ARGUMENT;
       }
       break;
-    case MLN_RENDERED_QUERY_GEOMETRY_TYPE_BOX:
+    case MLN_RENDERED_QUERY_GEOMETRY_TYPE_BOX: {
       if (
         !validate_screen_point(geometry->data.box.min) ||
         !validate_screen_point(geometry->data.box.max)
       ) {
         return MLN_STATUS_INVALID_ARGUMENT;
       }
+      clipped_box = clip_screen_box_to_viewport(
+        geometry->data.box, session->width, session->height
+      );
       break;
+    }
     case MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING: {
       if (!to_screen_line_string(geometry->data.line_string, line_string)) {
         return MLN_STATUS_INVALID_ARGUMENT;
@@ -1287,13 +1317,11 @@ auto render_session_query_rendered_features(
       );
       break;
     case MLN_RENDERED_QUERY_GEOMETRY_TYPE_BOX:
-      features = session->renderer->queryRenderedFeatures(
-        mbgl::ScreenBox{
-          {geometry->data.box.min.x, geometry->data.box.min.y},
-          {geometry->data.box.max.x, geometry->data.box.max.y}
-        },
-        *native_options
-      );
+      if (clipped_box) {
+        features = session->renderer->queryRenderedFeatures(
+          *clipped_box, *native_options
+        );
+      }
       break;
     case MLN_RENDERED_QUERY_GEOMETRY_TYPE_LINE_STRING:
       features =


### PR DESCRIPTION
## Summary

- Normalize screen-box query corners regardless of input order.
- Clip box queries to the viewport, including empty results for fully off-screen boxes.
- Document the behavior in the C and Rust APIs.
- Add Rust integration coverage for oversized, inverted, and off-screen boxes.

## Testing

- Added and ran `rendered_box_queries_clip_to_the_viewport` Rust integration coverage.