### PR TITLE
Preserve unsigned JSON types in feature extension queries

### DIFF
--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -441,6 +441,21 @@ public sealed unsafe class RenderSessionHandle : IDisposable
         SourceFeatureQueryOptions? options
     ) => QuerySourceFeaturesCore(sourceId, options);
 
+    /// <summary>
+    /// Queries a feature extension from the latest render session state.
+    /// </summary>
+    /// <remarks>
+    /// The <c>supercluster</c> extension reads the <c>cluster_id</c> feature
+    /// property and the <c>limit</c> and <c>offset</c> arguments as
+    /// <c>JsonValue.UInt</c>. Other numeric types are treated as absent: a
+    /// <c>cluster_id</c> that is not <c>JsonValue.UInt</c> returns a
+    /// <c>FeatureExtensionResult.Value</c> holding <c>JsonValue.Null</c>
+    /// instead of a feature collection, and a <c>limit</c> or <c>offset</c>
+    /// that is not <c>JsonValue.UInt</c> leaves <c>leaves</c> at the native
+    /// defaults of ten leaves at offset zero. Queried feature properties keep
+    /// their JSON value type, so a queried cluster feature can be passed back
+    /// unmodified.
+    /// </remarks>
     public FeatureExtensionResult QueryFeatureExtension(
         string sourceId,
         Feature feature,

--- a/bindings/go/query.go
+++ b/bindings/go/query.go
@@ -581,6 +581,13 @@ func (session *RenderSessionHandle) QuerySourceFeatures(sourceID string, options
 }
 
 // QueryFeatureExtensions queries a feature extension from the latest render session state.
+//
+// The "supercluster" extension reads the "cluster_id" feature property and the "limit" and
+// "offset" arguments as JSONUint. Other numeric types are treated as absent: a "cluster_id"
+// that is not JSONUint returns a JSONValueTypeNull value result instead of a feature
+// collection, and a "limit" or "offset" that is not JSONUint leaves "leaves" at the native
+// defaults of ten leaves at offset zero. Queried feature properties keep their JSON value
+// type, so a queried cluster feature can be passed back unmodified.
 func (session *RenderSessionHandle) QueryFeatureExtensions(sourceID string, feature Feature, extension string, extensionField string, arguments *JSONValue) (FeatureExtensionResult, error) {
 	ptr, release, err := session.ptr()
 	if err != nil {

--- a/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
+++ b/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
@@ -24,11 +24,13 @@ import kotlinx.cinterop.rawValue
 import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.toLong
 import org.maplibre.nativeffi.Maplibre
+import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.error.InvalidArgumentException
 import org.maplibre.nativeffi.error.InvalidStateException
 import org.maplibre.nativeffi.error.MaplibreStatus
 import org.maplibre.nativeffi.error.UnsupportedFeatureException
 import org.maplibre.nativeffi.error.WrongThreadException
+import org.maplibre.nativeffi.geo.Feature
 import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.ScreenBox
 import org.maplibre.nativeffi.geo.ScreenPoint
@@ -37,6 +39,7 @@ import org.maplibre.nativeffi.log.LogCallback
 import org.maplibre.nativeffi.map.MapHandle
 import org.maplibre.nativeffi.map.MapMode
 import org.maplibre.nativeffi.map.MapOptions
+import org.maplibre.nativeffi.query.FeatureExtensionResult
 import org.maplibre.nativeffi.query.FeatureStateSelector
 import org.maplibre.nativeffi.query.QueriedFeature
 import org.maplibre.nativeffi.query.RenderedFeatureQueryOptions
@@ -421,6 +424,118 @@ class RenderSessionHandleTest {
     }
   }
 
+  // BND-107: an unsigned cluster_id survives the query round trip, and an
+  // unsigned leaves limit bounds the returned features.
+  @Test
+  fun clusterFeatureExtensionQueriesResolveUnsignedClusterIdAndLimit() {
+    if (!metalSupportedOrInapplicable()) return
+    val device =
+      MTLCreateSystemDefaultDevice() ?: error("MTLCreateSystemDefaultDevice returned nil")
+    Maplibre.setLogCallback(LogCallback { true })
+    Maplibre.setAsyncLogSeverities(emptySet())
+    try {
+      val runtime = RuntimeHandle.create(org.maplibre.nativeffi.runtime.RuntimeOptions())
+      val map =
+        MapHandle.create(
+          runtime,
+          MapOptions().apply {
+            width = 64
+            height = 64
+          },
+        )
+      try {
+        val session =
+          map.attachMetalOwnedTexture(
+            MetalOwnedTextureDescriptor(
+              extent = RenderTargetExtent(64, 64, 1.0),
+              context = MetalContextDescriptor(NativePointer.ofAddress(device.address())),
+            )
+          )
+        try {
+          map.jumpTo(
+            CameraOptions().apply {
+              center = LatLng(0.0, 0.0)
+              zoom = 0.0
+            }
+          )
+          map.setStyleJson(CLUSTER_STYLE_JSON)
+          assertTrue(waitForMapEvent(runtime, map, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE))
+          session.renderUpdate()
+
+          val queryPoint = map.pixelForLatLng(LatLng(0.0, 0.0))
+          val queryGeometry =
+            RenderedQueryGeometry.Box(
+              ScreenBox(
+                ScreenPoint(queryPoint.x - 30.0, queryPoint.y - 30.0),
+                ScreenPoint(queryPoint.x + 30.0, queryPoint.y + 30.0),
+              )
+            )
+          val cluster =
+            waitForQueriedFeature(runtime, map, session) {
+              session.queryRenderedFeatures(
+                queryGeometry,
+                RenderedFeatureQueryOptions().apply { layerIds = listOf("cluster-circle") },
+              )
+            }
+          // Native matches cluster_id by exact JSON value type, so the copied
+          // feature must keep the unsigned alternative to resolve on the way
+          // back in.
+          assertTrue(member(cluster, "cluster_id") is JsonValue.UInt)
+
+          val children =
+            featureCollectionResult(
+              session.queryFeatureExtension(
+                "cluster-source",
+                cluster.feature,
+                "supercluster",
+                "children",
+                null,
+              )
+            )
+          assertTrue(children.isNotEmpty())
+
+          val expansionZoom =
+            session.queryFeatureExtension(
+              "cluster-source",
+              cluster.feature,
+              "supercluster",
+              "expansion-zoom",
+              null,
+            )
+          val expansionZoomValue =
+            (expansionZoom as? FeatureExtensionResult.Value)?.value
+              ?: error("expected expansion-zoom value result")
+          assertTrue(expansionZoomValue is JsonValue.UInt)
+
+          val leaves =
+            featureCollectionResult(
+              session.queryFeatureExtension(
+                "cluster-source",
+                cluster.feature,
+                "supercluster",
+                "leaves",
+                JsonValue.ObjectValue(
+                  listOf(
+                    JsonValue.Member("limit", JsonValue.UInt(1)),
+                    JsonValue.Member("offset", JsonValue.UInt(0)),
+                  )
+                ),
+              )
+            )
+          assertEquals(1, leaves.size)
+        } finally {
+          session.close()
+        }
+      } finally {
+        map.close()
+        runtime.close()
+      }
+    } finally {
+      Maplibre.clearLogCallback()
+      Maplibre.restoreDefaultAsyncLogSeverities()
+    }
+  }
+
   private fun metalSupportedOrInapplicable(): Boolean {
     return RenderBackend.METAL in Maplibre.supportedRenderBackends()
   }
@@ -491,6 +606,10 @@ class RenderSessionHandleTest {
       }
     }
   }
+
+  private fun featureCollectionResult(result: FeatureExtensionResult): List<Feature> =
+    (result as? FeatureExtensionResult.FeatureCollection)?.features
+      ?: error("expected feature collection result")
 
   private fun member(feature: QueriedFeature, key: String): JsonValue? =
     feature.feature.properties.firstOrNull { it.key == key }?.value
@@ -607,6 +726,32 @@ class RenderSessionHandleTest {
         "layers": [
           {"id": "background", "type": "background", "paint": {"background-color": "#d8f1ff"}},
           {"id": "point-circle", "type": "circle", "source": "point", "paint": {"circle-color": "#f97316", "circle-radius": 12}}
+        ]
+      }
+      """
+
+    private const val CLUSTER_STYLE_JSON =
+      """
+      {
+        "version": 8,
+        "name": "kotlin-cluster-query-test",
+        "sources": {
+          "cluster-source": {
+            "type": "geojson",
+            "cluster": true,
+            "data": {
+              "type": "FeatureCollection",
+              "features": [
+                {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.0, 0.0]}, "properties": {"name": "one"}},
+                {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.001, 0.001]}, "properties": {"name": "two"}},
+                {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.002, 0.002]}, "properties": {"name": "three"}}
+              ]
+            }
+          }
+        },
+        "layers": [
+          {"id": "background", "type": "background", "paint": {"background-color": "#ffffff"}},
+          {"id": "cluster-circle", "type": "circle", "source": "cluster-source", "filter": ["has", "point_count"], "paint": {"circle-color": "#2563eb", "circle-radius": 20}}
         ]
       }
       """

--- a/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
+++ b/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
@@ -507,22 +507,13 @@ class RenderSessionHandleTest {
               ?: error("expected expansion-zoom value result")
           assertTrue(expansionZoomValue is JsonValue.UInt)
 
-          val leaves =
-            featureCollectionResult(
-              session.queryFeatureExtension(
-                "cluster-source",
-                cluster.feature,
-                "supercluster",
-                "leaves",
-                JsonValue.ObjectValue(
-                  listOf(
-                    JsonValue.Member("limit", JsonValue.UInt(1)),
-                    JsonValue.Member("offset", JsonValue.UInt(0)),
-                  )
-                ),
-              )
-            )
-          assertEquals(1, leaves.size)
+          // An unsigned limit bounds the collection, and an unsigned offset
+          // selects a later leaf. Native ignores arguments of another type and
+          // falls back to ten leaves at offset zero, so both bounds must move
+          // the observed result.
+          val first = singleClusterLeaf(session, cluster.feature, 0)
+          val second = singleClusterLeaf(session, cluster.feature, 1)
+          assertNotEquals(member(first, "name"), member(second, "name"))
         } finally {
           session.close()
         }
@@ -610,6 +601,34 @@ class RenderSessionHandleTest {
   private fun featureCollectionResult(result: FeatureExtensionResult): List<Feature> =
     (result as? FeatureExtensionResult.FeatureCollection)?.features
       ?: error("expected feature collection result")
+
+  /** Returns the one leaf at [offset] through a bounded supercluster query. */
+  private fun singleClusterLeaf(
+    session: RenderSessionHandle,
+    feature: Feature,
+    offset: Long,
+  ): Feature {
+    val leaves =
+      featureCollectionResult(
+        session.queryFeatureExtension(
+          "cluster-source",
+          feature,
+          "supercluster",
+          "leaves",
+          JsonValue.ObjectValue(
+            listOf(
+              JsonValue.Member("limit", JsonValue.UInt(1)),
+              JsonValue.Member("offset", JsonValue.UInt(offset)),
+            )
+          ),
+        )
+      )
+    assertEquals(1, leaves.size)
+    return leaves.first()
+  }
+
+  private fun member(feature: Feature, key: String): JsonValue? =
+    feature.properties.firstOrNull { it.key == key }?.value
 
   private fun member(feature: QueriedFeature, key: String): JsonValue? =
     feature.feature.properties.firstOrNull { it.key == key }?.value

--- a/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
+++ b/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
@@ -460,7 +460,7 @@ class RenderSessionHandleTest {
           )
           map.setStyleJson(CLUSTER_STYLE_JSON)
           assertTrue(waitForMapEvent(runtime, map, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE))
-          session.renderUpdate()
+          assertTrue(session.renderUpdate())
 
           val queryPoint = map.pixelForLatLng(LatLng(0.0, 0.0))
           val queryGeometry =

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -53,6 +53,17 @@ public expect class RenderSessionHandle : AutoCloseable {
     options: SourceFeatureQueryOptions?,
   ): List<QueriedFeature>
 
+  /**
+   * Queries a feature extension from the latest render session state.
+   *
+   * The `supercluster` extension reads the `cluster_id` feature property and the `limit` and
+   * `offset` arguments as [JsonValue.UInt]. Other numeric types are treated as absent: a
+   * `cluster_id` that is not [JsonValue.UInt] returns [FeatureExtensionResult.Value] holding
+   * [JsonValue.Null] instead of a feature collection, and a `limit` or `offset` that is not
+   * [JsonValue.UInt] leaves `leaves` at the native defaults of ten leaves at offset zero.
+   * [QueriedFeature] properties keep their JSON value type, so a queried cluster feature can be
+   * passed back unmodified.
+   */
   public fun queryFeatureExtension(
     sourceId: String,
     feature: Feature,

--- a/bindings/python/python/maplibre_native/render.py
+++ b/bindings/python/python/maplibre_native/render.py
@@ -528,7 +528,19 @@ class RenderSessionHandle(NativeHandleMixin):
         extension_field: str,
         arguments: JsonObject | None = None,
     ) -> FeatureExtensionResult:
-        """Query a feature extension from the latest render session state."""
+        """Query a feature extension from the latest render session state.
+
+        The `supercluster` extension reads the `cluster_id` feature property and
+        the `limit` and `offset` arguments as `JsonUInt`. Other numeric types are
+        treated as absent: a `cluster_id` that is not `JsonUInt` returns a
+        `FeatureExtensionResultType.VALUE` result holding `None` instead of a
+        `FeatureExtensionResultType.FEATURE_COLLECTION` result,
+        and a `limit` or `offset` that is not `JsonUInt` leaves `leaves` at the
+        native defaults of ten leaves at offset zero. Note that
+        `json.from_python` converts a Python `int` to `JsonInt`; build these
+        arguments with `JsonUInt`. Queried feature properties keep their JSON
+        value type, so a queried cluster feature can be passed back unmodified.
+        """
         from .query import FeatureExtensionResult
 
         raw = self._native.query_feature_extensions(

--- a/bindings/python/tests/render_backend_helpers/runtime.py
+++ b/bindings/python/tests/render_backend_helpers/runtime.py
@@ -5,9 +5,26 @@ import time
 import pytest
 
 import maplibre_native as mln
-from maplibre_native import render
+from maplibre_native import camera, geo, json, query, render
 
 EMPTY_STYLE_JSON = '{"version":8,"sources":{},"layers":[]}'
+
+CLUSTER_STYLE_JSON = (
+    '{"version":8,"name":"python-cluster-query-test",'
+    '"sources":{"cluster-source":{"type":"geojson","cluster":true,'
+    '"data":{"type":"FeatureCollection","features":['
+    '{"type":"Feature","geometry":{"type":"Point","coordinates":[0.0,0.0]},'
+    '"properties":{"name":"one"}},'
+    '{"type":"Feature","geometry":{"type":"Point","coordinates":[0.001,0.001]},'
+    '"properties":{"name":"two"}},'
+    '{"type":"Feature","geometry":{"type":"Point","coordinates":[0.002,0.002]},'
+    '"properties":{"name":"three"}}]}}},'
+    '"layers":[{"id":"background","type":"background",'
+    '"paint":{"background-color":"#ffffff"}},'
+    '{"id":"cluster-circle","type":"circle","source":"cluster-source",'
+    '"filter":["has","point_count"],'
+    '"paint":{"circle-color":"#2563eb","circle-radius":20}}]}'
+)
 
 
 def is_configured_render_backend(
@@ -71,3 +88,93 @@ def render_until_update(
     )
     assert event.event_type == mln.RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE
     assert session.render_update()
+
+
+def request_still_image_if_needed(map_handle: mln.MapHandle) -> None:
+    try:
+        map_handle.request_still_image()
+    except mln.InvalidStateError as error:
+        if "pending still-image request" not in error.diagnostic:
+            raise
+
+
+def wait_for_rendered_cluster(
+    runtime: mln.RuntimeHandle,
+    map_handle: mln.MapHandle,
+    session: render.RenderSessionHandle,
+    *,
+    iterations: int = 5000,
+) -> query.QueriedFeature:
+    """Load the cluster style and return the first rendered cluster feature."""
+    map_handle.jump_to(camera.CameraOptions(center=geo.LatLng(0.0, 0.0), zoom=0.0))
+    map_handle.set_style_json(CLUSTER_STYLE_JSON)
+    query_point = map_handle.pixel_for_lat_lng(geo.LatLng(0.0, 0.0))
+    geometry = query.RenderedQueryGeometry.box_geometry(
+        query.ScreenBox(
+            camera.ScreenPoint(query_point.x - 30.0, query_point.y - 30.0),
+            camera.ScreenPoint(query_point.x + 30.0, query_point.y + 30.0),
+        )
+    )
+    options = query.RenderedFeatureQueryOptions(layer_ids=("cluster-circle",))
+    for _ in range(iterations):
+        request_still_image_if_needed(map_handle)
+        runtime.run_once()
+        while event := runtime.poll_event():
+            if event.event_type == mln.RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE:
+                try:
+                    session.render_update()
+                except mln.InvalidStateError:
+                    pass
+        try:
+            features = session.query_rendered_features(geometry, options)
+        except mln.InvalidStateError:
+            features = ()
+        if features:
+            return features[0]
+        time.sleep(0.001)
+    raise AssertionError("cluster feature query returned no features")
+
+
+def assert_cluster_feature_extensions(
+    runtime: mln.RuntimeHandle,
+    map_handle: mln.MapHandle,
+    session: render.RenderSessionHandle,
+) -> None:
+    """Round-trip a rendered cluster feature through supercluster queries."""
+    cluster = wait_for_rendered_cluster(runtime, map_handle, session)
+    # Native matches cluster_id by exact JSON value type, so the copied feature
+    # must keep the unsigned alternative to resolve on the way back in.
+    cluster_id = next(
+        member.value
+        for member in cluster.feature.properties
+        if member.key == "cluster_id"
+    )
+    assert isinstance(cluster_id, json.JsonUInt)
+
+    children = session.query_feature_extensions(
+        "cluster-source", cluster.feature, "supercluster", "children", None
+    )
+    assert children.type == query.FeatureExtensionResultType.FEATURE_COLLECTION
+    assert children.feature_collection
+
+    expansion_zoom = session.query_feature_extensions(
+        "cluster-source", cluster.feature, "supercluster", "expansion-zoom", None
+    )
+    assert expansion_zoom.type == query.FeatureExtensionResultType.VALUE
+    assert isinstance(expansion_zoom.value, json.JsonUInt)
+
+    leaves = session.query_feature_extensions(
+        "cluster-source",
+        cluster.feature,
+        "supercluster",
+        "leaves",
+        json.JsonObject(
+            (
+                json.JsonMember("limit", json.JsonUInt(1)),
+                json.JsonMember("offset", json.JsonUInt(0)),
+            )
+        ),
+    )
+    assert leaves.type == query.FeatureExtensionResultType.FEATURE_COLLECTION
+    assert leaves.feature_collection is not None
+    assert len(leaves.feature_collection) == 1

--- a/bindings/python/tests/render_backend_helpers/runtime.py
+++ b/bindings/python/tests/render_backend_helpers/runtime.py
@@ -135,6 +135,35 @@ def wait_for_rendered_cluster(
     raise AssertionError("cluster feature query returned no features")
 
 
+def feature_member(feature: geo.Feature, key: str) -> json.JsonValue:
+    return next(member.value for member in feature.properties if member.key == key)
+
+
+def single_cluster_leaf(
+    session: render.RenderSessionHandle,
+    feature: geo.Feature,
+    *,
+    offset: int,
+) -> geo.Feature:
+    """Return the one leaf at `offset` through a bounded supercluster query."""
+    leaves = session.query_feature_extensions(
+        "cluster-source",
+        feature,
+        "supercluster",
+        "leaves",
+        json.JsonObject(
+            (
+                json.JsonMember("limit", json.JsonUInt(1)),
+                json.JsonMember("offset", json.JsonUInt(offset)),
+            )
+        ),
+    )
+    assert leaves.type == query.FeatureExtensionResultType.FEATURE_COLLECTION
+    assert leaves.feature_collection is not None
+    assert len(leaves.feature_collection) == 1
+    return leaves.feature_collection[0]
+
+
 def assert_cluster_feature_extensions(
     runtime: mln.RuntimeHandle,
     map_handle: mln.MapHandle,
@@ -144,12 +173,7 @@ def assert_cluster_feature_extensions(
     cluster = wait_for_rendered_cluster(runtime, map_handle, session)
     # Native matches cluster_id by exact JSON value type, so the copied feature
     # must keep the unsigned alternative to resolve on the way back in.
-    cluster_id = next(
-        member.value
-        for member in cluster.feature.properties
-        if member.key == "cluster_id"
-    )
-    assert isinstance(cluster_id, json.JsonUInt)
+    assert isinstance(feature_member(cluster.feature, "cluster_id"), json.JsonUInt)
 
     children = session.query_feature_extensions(
         "cluster-source", cluster.feature, "supercluster", "children", None
@@ -163,18 +187,9 @@ def assert_cluster_feature_extensions(
     assert expansion_zoom.type == query.FeatureExtensionResultType.VALUE
     assert isinstance(expansion_zoom.value, json.JsonUInt)
 
-    leaves = session.query_feature_extensions(
-        "cluster-source",
-        cluster.feature,
-        "supercluster",
-        "leaves",
-        json.JsonObject(
-            (
-                json.JsonMember("limit", json.JsonUInt(1)),
-                json.JsonMember("offset", json.JsonUInt(0)),
-            )
-        ),
-    )
-    assert leaves.type == query.FeatureExtensionResultType.FEATURE_COLLECTION
-    assert leaves.feature_collection is not None
-    assert len(leaves.feature_collection) == 1
+    # An unsigned limit bounds the collection, and an unsigned offset selects a
+    # later leaf. Native ignores arguments of another type and falls back to ten
+    # leaves at offset zero, so both bounds must move the observed result.
+    first = single_cluster_leaf(session, cluster.feature, offset=0)
+    second = single_cluster_leaf(session, cluster.feature, offset=1)
+    assert feature_member(first, "name") != feature_member(second, "name")

--- a/bindings/python/tests/test_package.py
+++ b/bindings/python/tests/test_package.py
@@ -720,7 +720,7 @@ def test_render_session_methods_propagate_wrong_thread_errors() -> None:
                 feature,
                 "supercluster",
                 "leaves",
-                json.JsonObject((json.JsonMember("limit", json.JsonInt(10)),)),
+                json.JsonObject((json.JsonMember("limit", json.JsonUInt(10)),)),
             )
         ),
         "set_feature_state": (
@@ -1585,12 +1585,15 @@ def test_render_session_query_public_api_uses_query_and_geojson_wire_values() ->
 
     rendered = session.query_rendered_features(geometry, rendered_options)
     source = session.query_source_features("points", source_options)
+    # Supercluster reads "limit" as an unsigned value; json.from_python would
+    # convert the Python int to JsonInt, which native treats as absent.
+    leaves_arguments = json.JsonObject((json.JsonMember("limit", json.JsonUInt(10)),))
     extension = session.query_feature_extensions(
         "points",
         feature,
         "supercluster",
         "leaves",
-        _json_object({"limit": 10}),
+        leaves_arguments,
     )
 
     assert fake_native.rendered_call == (
@@ -1607,7 +1610,7 @@ def test_render_session_query_public_api_uses_query_and_geojson_wire_values() ->
         feature,
         "supercluster",
         "leaves",
-        _json_object({"limit": 10}),
+        leaves_arguments,
     )
     assert extension == query.FeatureExtensionResult.value_result(json.JsonUInt(7))
 

--- a/bindings/python/tests/test_render_metal_owned.py
+++ b/bindings/python/tests/test_render_metal_owned.py
@@ -12,6 +12,7 @@ from maplibre_native import camera, geo, json, query, render
 
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
+    assert_cluster_feature_extensions,
     skip_or_fail_fixture_setup,
 )
 
@@ -413,3 +414,13 @@ def test_real_metal_render_session_reports_wrong_thread_errors(
         assert isinstance(observed[0], mln.WrongThreadError)
         assert observed[0].status == mln.MaplibreStatus.WRONG_THREAD
         assert not metal_owned_session.session.closed
+
+
+def test_cluster_feature_extension_queries_resolve_unsigned_cluster_id_and_limit(
+    metal_owned_session: MetalOwnedSession,
+) -> None:
+    assert_cluster_feature_extensions(
+        metal_owned_session.runtime,
+        metal_owned_session.map,
+        metal_owned_session.session,
+    )

--- a/bindings/python/tests/test_render_opengl_egl.py
+++ b/bindings/python/tests/test_render_opengl_egl.py
@@ -13,6 +13,7 @@ from maplibre_native import camera, geo, json, query, render
 
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
+    assert_cluster_feature_extensions,
     render_until_update,
     skip_or_fail_fixture_setup,
 )
@@ -567,3 +568,13 @@ def test_egl_borrowed_texture_session_close_preserves_caller_resources() -> None
             assert _borrowed_descriptor_snapshot(replacement_descriptor) == (
                 before_descriptor
             )
+
+
+def test_cluster_feature_extension_queries_resolve_unsigned_cluster_id_and_limit(
+    opengl_owned_session: OpenGLOwnedSession,
+) -> None:
+    assert_cluster_feature_extensions(
+        opengl_owned_session.runtime,
+        opengl_owned_session.map,
+        opengl_owned_session.session,
+    )

--- a/bindings/python/tests/test_render_vulkan_owned.py
+++ b/bindings/python/tests/test_render_vulkan_owned.py
@@ -12,6 +12,7 @@ from maplibre_native import camera, geo, json, query, render
 
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
+    assert_cluster_feature_extensions,
     skip_or_fail_fixture_setup,
 )
 
@@ -430,3 +431,13 @@ def test_real_vulkan_render_session_reports_wrong_thread_errors(
         assert isinstance(observed[0], mln.WrongThreadError)
         assert observed[0].status == mln.MaplibreStatus.WRONG_THREAD
         assert not vulkan_owned_session.session.closed
+
+
+def test_cluster_feature_extension_queries_resolve_unsigned_cluster_id_and_limit(
+    vulkan_owned_session: VulkanOwnedSession,
+) -> None:
+    assert_cluster_feature_extensions(
+        vulkan_owned_session.runtime,
+        vulkan_owned_session.map,
+        vulkan_owned_session.session,
+    )

--- a/bindings/rust/crates/maplibre-native/src/render/query.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/query.rs
@@ -137,6 +137,16 @@ impl super::RenderSessionHandle {
     }
 
     /// Queries a feature extension from the latest render session state.
+    ///
+    /// The `supercluster` extension reads the `cluster_id` feature property and
+    /// the `limit` and `offset` arguments as [`JsonValue::UInt`]. Other numeric
+    /// types are treated as absent: a `cluster_id` that is not
+    /// [`JsonValue::UInt`] returns [`FeatureExtensionResult::Value`] holding
+    /// [`JsonValue::Null`] instead of a feature collection, and a `limit` or
+    /// `offset` that is not [`JsonValue::UInt`] leaves `leaves` at the native
+    /// defaults of ten leaves at offset zero. Queried feature properties keep
+    /// their JSON value type, so a queried cluster feature can be passed back
+    /// unmodified.
     pub fn query_feature_extension(
         &self,
         source_id: &str,

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -1301,6 +1301,27 @@ fn wait_for_source_feature(
     panic!("timed out waiting for {description}");
 }
 
+fn single_cluster_leaf(session: &RenderSessionHandle, feature: &Feature, offset: u64) -> Feature {
+    let arguments = JsonValue::Object(vec![
+        JsonMember::new("limit", JsonValue::UInt(1)),
+        JsonMember::new("offset", JsonValue::UInt(offset)),
+    ]);
+    let result = session
+        .query_feature_extension(
+            "cluster-source",
+            feature,
+            "supercluster",
+            "leaves",
+            Some(&arguments),
+        )
+        .unwrap();
+    let FeatureExtensionResult::FeatureCollection(leaves) = result else {
+        panic!("expected leaves feature collection");
+    };
+    assert_eq!(leaves.len(), 1);
+    leaves.into_iter().next().unwrap()
+}
+
 fn feature_member<'a>(feature: &'a Feature, key: &str) -> Option<&'a JsonValue> {
     feature
         .properties
@@ -1868,23 +1889,15 @@ fn feature_extension_queries_copy_value_and_feature_collection_results() {
     };
     assert!(!children.is_empty());
 
-    let leaves_arguments = JsonValue::Object(vec![
-        JsonMember::new("limit", JsonValue::UInt(1)),
-        JsonMember::new("offset", JsonValue::UInt(0)),
-    ]);
-    let leaves = session
-        .query_feature_extension(
-            "cluster-source",
-            &cluster.feature,
-            "supercluster",
-            "leaves",
-            Some(&leaves_arguments),
-        )
-        .unwrap();
-    let FeatureExtensionResult::FeatureCollection(leaves) = leaves else {
-        panic!("expected leaves feature collection");
-    };
-    assert_eq!(leaves.len(), 1);
+    // An unsigned limit bounds the collection, and an unsigned offset selects a
+    // later leaf. Native ignores arguments of another type and falls back to ten
+    // leaves at offset zero, so both bounds must move the observed result.
+    let first = single_cluster_leaf(&session, &cluster.feature, 0);
+    let second = single_cluster_leaf(&session, &cluster.feature, 1);
+    assert_ne!(
+        feature_member(&first, "name"),
+        feature_member(&second, "name")
+    );
 
     let expansion_zoom = session
         .query_feature_extension(

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -1825,7 +1825,7 @@ fn rendered_box_queries_clip_to_the_viewport() {
 }
 
 #[test]
-// Spec coverage: BND-106.
+// Spec coverage: BND-106 and BND-107.
 fn feature_extension_queries_copy_value_and_feature_collection_results() {
     if !has_test_owned_texture_session_backend() {
         return;
@@ -1847,6 +1847,13 @@ fn feature_extension_queries_copy_value_and_feature_collection_results() {
     let cluster =
         wait_for_rendered_feature(&runtime, &session, &geometry, &options, "rendered cluster");
 
+    // Native matches cluster_id by exact JSON value type, so the copied feature
+    // must keep the unsigned alternative to resolve on the way back in.
+    assert!(matches!(
+        feature_member(&cluster.feature, "cluster_id"),
+        Some(&JsonValue::UInt(_))
+    ));
+
     let children = session
         .query_feature_extension(
             "cluster-source",
@@ -1860,6 +1867,24 @@ fn feature_extension_queries_copy_value_and_feature_collection_results() {
         panic!("expected children feature collection");
     };
     assert!(!children.is_empty());
+
+    let leaves_arguments = JsonValue::Object(vec![
+        JsonMember::new("limit", JsonValue::UInt(1)),
+        JsonMember::new("offset", JsonValue::UInt(0)),
+    ]);
+    let leaves = session
+        .query_feature_extension(
+            "cluster-source",
+            &cluster.feature,
+            "supercluster",
+            "leaves",
+            Some(&leaves_arguments),
+        )
+        .unwrap();
+    let FeatureExtensionResult::FeatureCollection(leaves) = leaves else {
+        panic!("expected leaves feature collection");
+    };
+    assert_eq!(leaves.len(), 1);
 
     let expansion_zoom = session
         .query_feature_extension(

--- a/bindings/swift/Sources/MaplibreNative/Query.swift
+++ b/bindings/swift/Sources/MaplibreNative/Query.swift
@@ -215,6 +215,16 @@ public extension RenderSessionHandle {
     }
   }
 
+  /// Queries a feature extension from the latest render session state.
+  ///
+  /// The `supercluster` extension reads the `cluster_id` feature property
+  /// and the `limit` and `offset` arguments as `.uint`. Other numeric types
+  /// are treated as absent: a `cluster_id` that is not `.uint` returns a
+  /// `.value` result holding `.null` instead of a `.featureCollection`, and
+  /// a `limit` or `offset` that is not `.uint` leaves `leaves` at the native
+  /// defaults of ten leaves at offset zero. Queried feature properties keep
+  /// their JSON value type, so a queried cluster feature can be passed back
+  /// unmodified.
   func queryFeatureExtension(
     sourceId: String,
     feature: Feature,

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -547,6 +547,15 @@ pub const RenderSessionHandle = enum(u128) {
         return try copyFeatureQueryResult(allocator, result.?, lease.diagnostic_store);
     }
 
+    /// Queries a feature extension from the latest render session state.
+    ///
+    /// The `supercluster` extension reads the `cluster_id` feature property and
+    /// the `limit` and `offset` arguments as `.uint`. Other numeric types are
+    /// treated as absent: a `cluster_id` that is not `.uint` returns a `.value`
+    /// result holding `.null` instead of a `.feature_collection`, and a `limit`
+    /// or `offset` that is not `.uint` leaves `leaves` at the native defaults of
+    /// ten leaves at offset zero. Queried feature properties keep their JSON
+    /// value type, so a queried cluster feature can be passed back unmodified.
     pub fn queryFeatureExtension(
         self: *RenderSessionHandle,
         allocator: std.mem.Allocator,

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -1354,7 +1354,7 @@ test "render session clips rendered box queries to the viewport" {
 
     try map.setStyleJson(testing.allocator, support.style_json);
     try testing.expect(try waitForEvent(&runtime, .map_render_update_available));
-    try session.renderUpdate();
+    try testing.expect(try session.renderUpdate());
 
     const options = maplibre.RenderedFeatureQueryOptions{ .layer_ids = &.{"point-circle"} };
 

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -1430,17 +1430,39 @@ test "render session queries cluster feature extensions" {
     };
     try testing.expect(zoom_value == .uint);
 
-    const args_members = [_]maplibre.JsonMember{
+    // An unsigned limit bounds the collection, and an unsigned offset selects a
+    // later leaf. Native ignores arguments of another type and falls back to ten
+    // leaves at offset zero, so both bounds must move the observed result.
+    const first_args = [_]maplibre.JsonMember{
         .{ .key = "limit", .value = .{ .uint = 1 } },
         .{ .key = "offset", .value = .{ .uint = 0 } },
     };
-    var leaves = try session.queryFeatureExtension(testing.allocator, "cluster-source", borrowed.feature, "supercluster", "leaves", .{ .object = args_members[0..] });
-    defer leaves.deinit(testing.allocator);
-    const leaf_collection = switch (leaves) {
-        .feature_collection => |collection| collection,
+    var first = try session.queryFeatureExtension(testing.allocator, "cluster-source", borrowed.feature, "supercluster", "leaves", .{ .object = first_args[0..] });
+    defer first.deinit(testing.allocator);
+    const second_args = [_]maplibre.JsonMember{
+        .{ .key = "limit", .value = .{ .uint = 1 } },
+        .{ .key = "offset", .value = .{ .uint = 1 } },
+    };
+    var second = try session.queryFeatureExtension(testing.allocator, "cluster-source", borrowed.feature, "supercluster", "leaves", .{ .object = second_args[0..] });
+    defer second.deinit(testing.allocator);
+    try testing.expect(!std.mem.eql(u8, try singleLeafName(first), try singleLeafName(second)));
+}
+
+fn singleLeafName(result: maplibre.FeatureExtensionResult) ![]const u8 {
+    const collection = switch (result) {
+        .feature_collection => |value| value,
         else => return error.ExpectedFeatureCollection,
     };
-    try testing.expectEqual(@as(usize, 1), leaf_collection.features.len);
+    try testing.expectEqual(@as(usize, 1), collection.features.len);
+    for (collection.features[0].properties) |member| {
+        if (std.mem.eql(u8, member.key, "name")) {
+            return switch (member.value) {
+                .string => |value| value,
+                else => error.ExpectedStringProperty,
+            };
+        }
+    }
+    return error.MissingNameProperty;
 }
 
 test "unsupported backend owned texture attachment reports unsupported" {

--- a/docs/src/content/docs/development/binding-specification.md
+++ b/docs/src/content/docs/development/binding-specification.md
@@ -664,15 +664,16 @@ that a real native failure would expose.
 
 ### Map, camera, projection, style, and query
 
-| ID      | Test                                                                                                                                   |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| BND-100 | Map creation applies public map options, extent, and mode, then releases through the runtime parent relationship.                      |
-| BND-101 | Style URL and style JSON loading succeed through public map APIs and return copied style-loaded events through polling.                |
-| BND-102 | Camera set/get, animated camera commands, and transition cancellation produce the expected native camera state and statuses.           |
-| BND-103 | Projection helpers round-trip screen, lat/lng, and projected-meter values through copied public values within documented tolerance.    |
-| BND-104 | Representative invalid map and projection inputs propagate native invalid-argument diagnostics through the public error shape.         |
-| BND-105 | Style source, layer, image, and feature-state workflows add, update, query/list, and remove public input values and copied IDs.        |
-| BND-106 | Query workflows return copied feature geometry, properties, feature identifiers, feature state, and optional source/layer identifiers. |
+| ID      | Test                                                                                                                                                                |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BND-100 | Map creation applies public map options, extent, and mode, then releases through the runtime parent relationship.                                                   |
+| BND-101 | Style URL and style JSON loading succeed through public map APIs and return copied style-loaded events through polling.                                             |
+| BND-102 | Camera set/get, animated camera commands, and transition cancellation produce the expected native camera state and statuses.                                        |
+| BND-103 | Projection helpers round-trip screen, lat/lng, and projected-meter values through copied public values within documented tolerance.                                 |
+| BND-104 | Representative invalid map and projection inputs propagate native invalid-argument diagnostics through the public error shape.                                      |
+| BND-105 | Style source, layer, image, and feature-state workflows add, update, query/list, and remove public input values and copied IDs.                                     |
+| BND-106 | Query workflows return copied feature geometry, properties, feature identifiers, feature state, and optional source/layer identifiers.                              |
+| BND-107 | A queried cluster feature passed back to a feature-extension query resolves its unsigned `cluster_id`, and an unsigned `limit` argument bounds the returned leaves. |
 
 ### Logging and callbacks
 

--- a/docs/src/content/docs/development/binding-specification.md
+++ b/docs/src/content/docs/development/binding-specification.md
@@ -664,16 +664,15 @@ that a real native failure would expose.
 
 ### Map, camera, projection, style, and query
 
-| ID      | Test                                                                                                                                                                |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| BND-100 | Map creation applies public map options, extent, and mode, then releases through the runtime parent relationship.                                                   |
-| BND-101 | Style URL and style JSON loading succeed through public map APIs and return copied style-loaded events through polling.                                             |
-| BND-102 | Camera set/get, animated camera commands, and transition cancellation produce the expected native camera state and statuses.                                        |
-| BND-103 | Projection helpers round-trip screen, lat/lng, and projected-meter values through copied public values within documented tolerance.                                 |
-| BND-104 | Representative invalid map and projection inputs propagate native invalid-argument diagnostics through the public error shape.                                      |
-| BND-105 | Style source, layer, image, and feature-state workflows add, update, query/list, and remove public input values and copied IDs.                                     |
-| BND-106 | Query workflows return copied feature geometry, properties, feature identifiers, feature state, and optional source/layer identifiers.                              |
-| BND-107 | A queried cluster feature passed back to a feature-extension query resolves its unsigned `cluster_id`, and an unsigned `limit` argument bounds the returned leaves. |
+| ID      | Test                                                                                                                                   |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| BND-100 | Map creation applies public map options, extent, and mode, then releases through the runtime parent relationship.                      |
+| BND-101 | Style URL and style JSON loading succeed through public map APIs and return copied style-loaded events through polling.                |
+| BND-102 | Camera set/get, animated camera commands, and transition cancellation produce the expected native camera state and statuses.           |
+| BND-103 | Projection helpers round-trip screen, lat/lng, and projected-meter values through copied public values within documented tolerance.    |
+| BND-104 | Representative invalid map and projection inputs propagate native invalid-argument diagnostics through the public error shape.         |
+| BND-105 | Style source, layer, image, and feature-state workflows add, update, query/list, and remove public input values and copied IDs.        |
+| BND-106 | Query workflows return copied feature geometry, properties, feature identifiers, feature state, and optional source/layer identifiers. |
 
 ### Logging and callbacks
 
@@ -726,7 +725,7 @@ that a real native failure would expose.
 ### Conditional tests
 
 The following tests apply only when a binding has the named host-language
-mechanic or helper.
+mechanic, helper, or test fixture.
 
 #### Host cleanup hooks
 
@@ -747,6 +746,19 @@ thread or race release on the same owner-thread handle, include:
 | BND-046 | Concurrent releases call native release at most once and public calls fail while release is in progress. |
 | BND-190 | Owner-thread-affine calls from a different native thread report the binding's wrong-thread error.        |
 | BND-191 | Runtime wrong-thread errors include the copied native diagnostic.                                        |
+
+#### Live render session queries
+
+When the binding's test suite attaches a render session on a configured render
+backend, include:
+
+| ID      | Test                                                                                                                                                                                    |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BND-107 | A queried cluster feature passed back to a feature-extension query resolves its unsigned `cluster_id`, and unsigned `limit` and `offset` arguments bound and shift the returned leaves. |
+
+Bindings without live render-session fixtures cover the binding-owned half of
+this behavior through BND-067, which requires JSON values to preserve unsigned
+integer width across the boundary.
 
 #### Owner-thread execution adapters
 

--- a/docs/src/content/docs/development/c-conventions.md
+++ b/docs/src/content/docs/development/c-conventions.md
@@ -31,6 +31,15 @@ The public C header targets C23. ABI-crossing enum types use C23
 fixed-underlying enum syntax: `int32_t` for status values and `uint32_t` for
 non-negative domains and masks unless a native ABI field requires another width.
 
+`mln_json_value` carries the native value alternative, not just a number. Keep
+`MLN_JSON_VALUE_TYPE_UINT`, `MLN_JSON_VALUE_TYPE_INT`, and
+`MLN_JSON_VALUE_TYPE_DOUBLE` distinct in both directions, because native
+consumers match on the exact alternative. `mbgl` reads supercluster
+`cluster_id`, `limit`, and `offset` as unsigned and treats another alternative
+as absent, so a value that loses its tag produces an empty result with
+`MLN_STATUS_OK`. Document the required alternative on any function whose native
+behavior depends on it.
+
 Shape structs for future ABI stability. Option and output structs that may grow
 use `uint32_t size` fields. Default constructors populate them. Use field masks
 or presence booleans for optional values when zero is valid.

--- a/docs/src/content/docs/guides/query-map-data.md
+++ b/docs/src/content/docs/guides/query-map-data.md
@@ -6,4 +6,6 @@ sidebar:
 ---
 
 This planned guide will show how to query rendered features, source features,
-and feature extensions from the latest render session state.
+and feature extensions from the latest render session state, including passing a
+queried cluster feature back to the `supercluster` extension and supplying its
+`limit` and `offset` arguments as unsigned JSON values.

--- a/include/maplibre_native_c/query.h
+++ b/include/maplibre_native_c/query.h
@@ -217,6 +217,24 @@ MLN_API mln_status mln_render_session_query_source_features(
  * descriptor. On success, *out_result receives an owned result handle. Destroy
  * it with mln_feature_extension_result_destroy().
  *
+ * Native extensions match numeric inputs by exact JSON value type. The
+ * "supercluster" extension reads the "cluster_id" feature property and the
+ * "limit" and "offset" arguments as MLN_JSON_VALUE_TYPE_UINT. Other numeric
+ * types are treated as absent and produce MLN_STATUS_OK:
+ * - A "cluster_id" property that is missing or not
+ *   MLN_JSON_VALUE_TYPE_UINT yields a MLN_FEATURE_EXTENSION_RESULT_TYPE_VALUE
+ *   result holding MLN_JSON_VALUE_TYPE_NULL, for every extension field. A
+ *   cluster that resolves and has no matching features yields a
+ *   MLN_FEATURE_EXTENSION_RESULT_TYPE_FEATURE_COLLECTION result with zero
+ *   features instead.
+ * - A "limit" or "offset" argument that is not MLN_JSON_VALUE_TYPE_UINT is
+ *   ignored, and the "leaves" field falls back to the native defaults of ten
+ *   leaves at offset zero.
+ *
+ * Feature descriptors copied out of mln_feature_query_result preserve the JSON
+ * value type of every property, so a queried cluster feature can be passed back
+ * unmodified.
+ *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when session is null or not live, source_id,


### PR DESCRIPTION
## Summary

- Preserve unsigned JSON value types when copying queried feature properties.
- Require unsigned JSON values for supercluster `cluster_id`, `limit`, and `offset` inputs.
- Document behavior across the C API, bindings, and query guides.
- Add cluster feature-extension coverage for Rust, Kotlin, and Python render backends.

## Testing

- Added Rust coverage for unsigned cluster IDs and bounded leaves queries.
- Added Kotlin Metal coverage for cluster feature-extension round trips.
- Added Python Metal, OpenGL/EGL, and Vulkan coverage.
- Not run in this environment.