### PR TITLE
Put the Vulkan loader on PATH for Windows jobs

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -258,6 +258,30 @@ runs:
         # the tests linked against it fail in the loader at startup.
         install_runtime: true
 
+    # A machine with a Vulkan driver has the loader in System32, where every
+    # process finds it. A runner has it only inside the SDK, so put it on PATH
+    # for the whole job: each binding and example links the shared library that
+    # imports it, and a job-wide entry covers them the way a real machine does.
+    - name: Put the Vulkan loader on PATH
+      if: ${{ startsWith(inputs.target, 'windows-') && endsWith(inputs.target, '-vulkan') }}
+      shell: pwsh
+      run: |
+        # Where the loader sits differs by SDK: the x64 SDK groups it under
+        # runtime by architecture, while the ARM64 SDK carries it in Bin. Both
+        # folders belong to the SDK being installed, so neither can offer a
+        # loader built for another architecture. This is the search
+        # cmake/render/vulkan.cmake performs for the same file.
+        $architecture = if ($env:RUNNER_ARCH -eq "ARM64") { "arm64" } else { "x64" }
+        $candidates = @("runtime\$architecture", "Bin", "bin") |
+          ForEach-Object { Join-Path $env:VULKAN_SDK $_ }
+        $directory = $candidates |
+          Where-Object { Test-Path (Join-Path $_ "vulkan-1.dll") } |
+          Select-Object -First 1
+        if (-not $directory) {
+          throw "no vulkan-1.dll in $($candidates -join ', ')"
+        }
+        $directory | Out-File -FilePath $env:GITHUB_PATH -Append
+
     - name: Bootstrap repository
       uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       with:


### PR DESCRIPTION
## Summary

Add the SDK's `vulkan-1.dll` directory to `GITHUB_PATH` on Windows Vulkan jobs, so every consumer that links the shared library importing it can start, rather than each task plumbing the directory itself.

## Test plan

CI: `target / windows-x64-vulkan`, whose Rust binding test currently exits `0xC0000135` after the C API suite passes.

## Notes

#330 fixed the C API tests by requiring the loader when configuring and handing ctest the directory that holds it. That covers ctest and nothing else: on #338 the C API suite passes and the Rust test binary exits `0xC0000135` instead, because the Windows Rust task puts only `install/bin` on PATH. `MLN_FFI_VULKAN_LOADER_DIR`, which the Unix branch of that task consults, is set only in `mise.macos.toml`.

Every binding and example links the shared library that imports the loader, so patching one task at a time would repeat this for Zig, .NET and the rest. A machine with a Vulkan driver has the loader in System32 where any process finds it; a runner has it only in the SDK, so a job-wide PATH entry is the closest equivalent.

The step prefers the runner's architecture under `runtime/`, falls back to searching for the loader, and fails loudly if the SDK has none.

## AI assistance

- **Tools:** Claude Code
- **Context:** Diagnosed the CI failures and made the change.