### PR TITLE
Align binding option types with value semantics

### DIFF
--- a/bindings/dotnet/src/Maplibre.Native/Camera/CameraOptions.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Camera/CameraOptions.cs
@@ -3,7 +3,11 @@ using Maplibre.Native.Geo;
 namespace Maplibre.Native.Camera;
 
 /// <summary>Mutable camera descriptor used for camera snapshots and commands.</summary>
-public sealed class CameraOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record CameraOptions
 {
     public LatLng? Center { get; set; }
     public double? CenterAltitude { get; set; }
@@ -17,7 +21,11 @@ public sealed class CameraOptions
 }
 
 /// <summary>Camera animation descriptor.</summary>
-public sealed class AnimationOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record AnimationOptions
 {
     public double? Duration { get; set; }
     public UnitBezier? Easing { get; set; }
@@ -26,7 +34,11 @@ public sealed class AnimationOptions
 }
 
 /// <summary>Camera fitting descriptor.</summary>
-public sealed class CameraFitOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record CameraFitOptions
 {
     public EdgeInsets? Padding { get; set; }
     public double? Bearing { get; set; }
@@ -34,7 +46,11 @@ public sealed class CameraFitOptions
 }
 
 /// <summary>Camera bound constraint descriptor.</summary>
-public sealed class BoundOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record BoundOptions
 {
     public LatLngBounds? Bounds { get; set; }
     public double? MinimumZoom { get; set; }
@@ -44,7 +60,11 @@ public sealed class BoundOptions
 }
 
 /// <summary>Free camera descriptor.</summary>
-public sealed class FreeCameraOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record FreeCameraOptions
 {
     public Vec3? Position { get; set; }
     public Quaternion? Orientation { get; set; }

--- a/bindings/dotnet/src/Maplibre.Native/Geo/Feature.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Geo/Feature.cs
@@ -1,3 +1,4 @@
+using Maplibre.Native.Internal;
 using Maplibre.Native.Json;
 
 namespace Maplibre.Native.Geo;
@@ -24,11 +25,24 @@ public abstract record FeatureIdentifier
 }
 
 /// <summary>GeoJSON feature value.</summary>
+/// <remarks>
+/// <see cref="Properties"/> compares member by member, preserving order and repeated member names.
+/// </remarks>
 public sealed record Feature(
     Geometry Geometry,
     IReadOnlyList<JsonMember> Properties,
     FeatureIdentifier Identifier
-);
+)
+{
+    public bool Equals(Feature? other) =>
+        other is not null
+        && Equals(Geometry, other.Geometry)
+        && ValueEquality.SequenceEquals(Properties, other.Properties)
+        && Equals(Identifier, other.Identifier);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Geometry, ValueEquality.SequenceHashCode(Properties), Identifier);
+}
 
 /// <summary>GeoJSON value.</summary>
 public abstract record GeoJson
@@ -39,5 +53,11 @@ public abstract record GeoJson
 
     public sealed record FeatureValue(Feature Feature) : GeoJson;
 
-    public sealed record FeatureCollection(IReadOnlyList<Feature> Features) : GeoJson;
+    public sealed record FeatureCollection(IReadOnlyList<Feature> Features) : GeoJson
+    {
+        public bool Equals(FeatureCollection? other) =>
+            other is not null && ValueEquality.SequenceEquals(Features, other.Features);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(Features);
+    }
 }

--- a/bindings/dotnet/src/Maplibre.Native/Geo/Geometry.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Geo/Geometry.cs
@@ -1,6 +1,12 @@
+using Maplibre.Native.Internal;
+
 namespace Maplibre.Native.Geo;
 
 /// <summary>Immutable geometry tree used by Maplibre descriptors and copied results.</summary>
+/// <remarks>
+/// Coordinate lists compare element by element, so geometries built from distinct list instances
+/// holding the same coordinates compare equal.
+/// </remarks>
 public abstract record Geometry
 {
     public const int MaxCollectionDepth = 64;
@@ -16,16 +22,61 @@ public abstract record Geometry
 
     public sealed record Point(LatLng Coordinate) : Geometry;
 
-    public sealed record LineString(IReadOnlyList<LatLng> Coordinates) : Geometry;
+    public sealed record LineString(IReadOnlyList<LatLng> Coordinates) : Geometry
+    {
+        public bool Equals(LineString? other) =>
+            other is not null && ValueEquality.SequenceEquals(Coordinates, other.Coordinates);
 
-    public sealed record Polygon(IReadOnlyList<IReadOnlyList<LatLng>> Rings) : Geometry;
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(Coordinates);
+    }
 
-    public sealed record MultiPoint(IReadOnlyList<LatLng> Coordinates) : Geometry;
+    public sealed record Polygon(IReadOnlyList<IReadOnlyList<LatLng>> Rings) : Geometry
+    {
+        public bool Equals(Polygon? other) =>
+            other is not null && ValueEquality.NestedSequenceEquals(Rings, other.Rings);
 
-    public sealed record MultiLineString(IReadOnlyList<IReadOnlyList<LatLng>> Lines) : Geometry;
+        public override int GetHashCode() => ValueEquality.NestedSequenceHashCode(Rings);
+    }
+
+    public sealed record MultiPoint(IReadOnlyList<LatLng> Coordinates) : Geometry
+    {
+        public bool Equals(MultiPoint? other) =>
+            other is not null && ValueEquality.SequenceEquals(Coordinates, other.Coordinates);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(Coordinates);
+    }
+
+    public sealed record MultiLineString(IReadOnlyList<IReadOnlyList<LatLng>> Lines) : Geometry
+    {
+        public bool Equals(MultiLineString? other) =>
+            other is not null && ValueEquality.NestedSequenceEquals(Lines, other.Lines);
+
+        public override int GetHashCode() => ValueEquality.NestedSequenceHashCode(Lines);
+    }
 
     public sealed record MultiPolygon(IReadOnlyList<IReadOnlyList<IReadOnlyList<LatLng>>> Polygons)
-        : Geometry;
+        : Geometry
+    {
+        public bool Equals(MultiPolygon? other) =>
+            other is not null
+            && ValueEquality.SequenceEquals(
+                Polygons,
+                other.Polygons,
+                static (left, right) => ValueEquality.NestedSequenceEquals(left, right)
+            );
 
-    public sealed record Collection(IReadOnlyList<Geometry> Geometries) : Geometry;
+        public override int GetHashCode() =>
+            ValueEquality.SequenceHashCode(
+                Polygons,
+                static value => ValueEquality.NestedSequenceHashCode(value)
+            );
+    }
+
+    public sealed record Collection(IReadOnlyList<Geometry> Geometries) : Geometry
+    {
+        public bool Equals(Collection? other) =>
+            other is not null && ValueEquality.SequenceEquals(Geometries, other.Geometries);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(Geometries);
+    }
 }

--- a/bindings/dotnet/src/Maplibre.Native/Internal/ValueEquality.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Internal/ValueEquality.cs
@@ -1,0 +1,62 @@
+namespace Maplibre.Native.Internal;
+
+/// <summary>
+/// Structural comparison helpers for public value types that hold list-valued members. Record
+/// synthesis compares such members by reference, so types holding them supply their own
+/// <c>Equals</c> and <c>GetHashCode</c> built on these helpers.
+/// </summary>
+internal static class ValueEquality
+{
+    internal static bool SequenceEquals<T>(IReadOnlyList<T>? left, IReadOnlyList<T>? right) =>
+        SequenceEquals(left, right, static (a, b) => EqualityComparer<T>.Default.Equals(a, b));
+
+    internal static bool SequenceEquals<T>(
+        IReadOnlyList<T>? left,
+        IReadOnlyList<T>? right,
+        Func<T, T, bool> elementEquals
+    )
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+        if (left is null || right is null || left.Count != right.Count)
+        {
+            return false;
+        }
+        for (var index = 0; index < left.Count; index++)
+        {
+            if (!elementEquals(left[index], right[index]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    internal static bool NestedSequenceEquals<T>(
+        IReadOnlyList<IReadOnlyList<T>>? left,
+        IReadOnlyList<IReadOnlyList<T>>? right
+    ) => SequenceEquals(left, right, static (a, b) => SequenceEquals(a, b));
+
+    internal static int SequenceHashCode<T>(IReadOnlyList<T>? values) =>
+        SequenceHashCode(values, static value => value?.GetHashCode() ?? 0);
+
+    internal static int SequenceHashCode<T>(IReadOnlyList<T>? values, Func<T, int> elementHash)
+    {
+        if (values is null)
+        {
+            return 0;
+        }
+        var hash = new HashCode();
+        hash.Add(values.Count);
+        for (var index = 0; index < values.Count; index++)
+        {
+            hash.Add(elementHash(values[index]));
+        }
+        return hash.ToHashCode();
+    }
+
+    internal static int NestedSequenceHashCode<T>(IReadOnlyList<IReadOnlyList<T>>? values) =>
+        SequenceHashCode(values, static value => SequenceHashCode(value));
+}

--- a/bindings/dotnet/src/Maplibre.Native/Json/JsonValue.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Json/JsonValue.cs
@@ -1,3 +1,5 @@
+using Maplibre.Native.Internal;
+
 namespace Maplibre.Native.Json;
 
 /// <summary>JSON-like value tree that preserves integer width and object order.</summary>
@@ -24,9 +26,21 @@ public abstract record JsonValue
 
     public sealed record String(string Value) : JsonValue;
 
-    public sealed record Array(IReadOnlyList<JsonValue> Values) : JsonValue;
+    public sealed record Array(IReadOnlyList<JsonValue> Values) : JsonValue
+    {
+        public bool Equals(Array? other) =>
+            other is not null && ValueEquality.SequenceEquals(Values, other.Values);
 
-    public sealed record Object(IReadOnlyList<JsonMember> Members) : JsonValue;
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(Values);
+    }
+
+    public sealed record Object(IReadOnlyList<JsonMember> Members) : JsonValue
+    {
+        public bool Equals(Object? other) =>
+            other is not null && ValueEquality.SequenceEquals(Members, other.Members);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(Members);
+    }
 }
 
 /// <summary>JSON object member.</summary>

--- a/bindings/dotnet/src/Maplibre.Native/Map/MapDescriptors.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Map/MapDescriptors.cs
@@ -3,7 +3,11 @@ using Maplibre.Native.Camera;
 namespace Maplibre.Native.Map;
 
 /// <summary>Viewport options descriptor.</summary>
-public sealed class ViewportOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record ViewportOptions
 {
     public NorthOrientation? NorthOrientation { get; set; }
     public ConstrainMode? ConstrainMode { get; set; }
@@ -12,7 +16,11 @@ public sealed class ViewportOptions
 }
 
 /// <summary>Tile tuning options descriptor.</summary>
-public sealed class TileOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record TileOptions
 {
     public uint? PrefetchZoomDelta { get; set; }
     public double? LodMinimumRadius { get; set; }
@@ -23,7 +31,11 @@ public sealed class TileOptions
 }
 
 /// <summary>Projection mode options descriptor.</summary>
-public sealed class ProjectionModeOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record ProjectionModeOptions
 {
     public bool? Axonometric { get; set; }
     public double? XSkew { get; set; }

--- a/bindings/dotnet/src/Maplibre.Native/Map/MapOptions.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Map/MapOptions.cs
@@ -3,7 +3,11 @@ using Maplibre.Native.Internal.C;
 namespace Maplibre.Native.Map;
 
 /// <summary>Map creation options.</summary>
-public sealed class MapOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record MapOptions
 {
     /// <summary>Initial logical width in pixels.</summary>
     public uint? Width { get; set; }

--- a/bindings/dotnet/src/Maplibre.Native/Offline/OfflineTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Offline/OfflineTypes.cs
@@ -46,6 +46,21 @@ public sealed record OfflineRegionInfo
     public long Id { get; }
     public OfflineRegionDefinition Definition { get; }
     public byte[] Metadata => (byte[])metadata.Clone();
+
+    public bool Equals(OfflineRegionInfo? other) =>
+        other is not null
+        && Id == other.Id
+        && Equals(Definition, other.Definition)
+        && metadata.AsSpan().SequenceEqual(other.metadata);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Id);
+        hash.Add(Definition);
+        hash.AddBytes(metadata);
+        return hash.ToHashCode();
+    }
 }
 
 public sealed record OfflineRegionStatus(

--- a/bindings/dotnet/src/Maplibre.Native/Query/QueryTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Query/QueryTypes.cs
@@ -1,4 +1,5 @@
 using Maplibre.Native.Geo;
+using Maplibre.Native.Internal;
 using Maplibre.Native.Json;
 
 namespace Maplibre.Native.Query;
@@ -19,19 +20,51 @@ public abstract record RenderedQueryGeometry
 
     public sealed record Box(ScreenBox Value) : RenderedQueryGeometry;
 
-    public sealed record LineString(IReadOnlyList<ScreenPoint> Points) : RenderedQueryGeometry;
+    public sealed record LineString(IReadOnlyList<ScreenPoint> Points) : RenderedQueryGeometry
+    {
+        public bool Equals(LineString? other) =>
+            other is not null && ValueEquality.SequenceEquals(Points, other.Points);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(Points);
+    }
 }
 
-public sealed class RenderedFeatureQueryOptions
+/// <remarks>
+/// Compares and hashes by property value, comparing <see cref="LayerIds"/> element by element;
+/// <c>with</c> returns an independent instance. Keep an instance unmodified while it is a key in a
+/// hash-based collection.
+/// </remarks>
+public sealed record RenderedFeatureQueryOptions
 {
     public IReadOnlyList<string>? LayerIds { get; set; }
     public JsonValue? Filter { get; set; }
+
+    public bool Equals(RenderedFeatureQueryOptions? other) =>
+        other is not null
+        && ValueEquality.SequenceEquals(LayerIds, other.LayerIds)
+        && Equals(Filter, other.Filter);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(ValueEquality.SequenceHashCode(LayerIds), Filter);
 }
 
-public sealed class SourceFeatureQueryOptions
+/// <remarks>
+/// Compares and hashes by property value, comparing <see cref="SourceLayerIds"/> element by
+/// element; <c>with</c> returns an independent instance. Keep an instance unmodified while it is a
+/// key in a hash-based collection.
+/// </remarks>
+public sealed record SourceFeatureQueryOptions
 {
     public IReadOnlyList<string>? SourceLayerIds { get; set; }
     public JsonValue? Filter { get; set; }
+
+    public bool Equals(SourceFeatureQueryOptions? other) =>
+        other is not null
+        && ValueEquality.SequenceEquals(SourceLayerIds, other.SourceLayerIds)
+        && Equals(Filter, other.Filter);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(ValueEquality.SequenceHashCode(SourceLayerIds), Filter);
 }
 
 public sealed record QueriedFeature(
@@ -47,8 +80,13 @@ public abstract record FeatureExtensionResult
 
     public sealed record Value(JsonValue Json) : FeatureExtensionResult;
 
-    public sealed record FeatureCollection(IReadOnlyList<Feature> Features)
-        : FeatureExtensionResult;
+    public sealed record FeatureCollection(IReadOnlyList<Feature> Features) : FeatureExtensionResult
+    {
+        public bool Equals(FeatureCollection? other) =>
+            other is not null && ValueEquality.SequenceEquals(Features, other.Features);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(Features);
+    }
 
     public sealed record Unknown(uint RawType) : FeatureExtensionResult;
 }

--- a/bindings/dotnet/src/Maplibre.Native/Query/QueryTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Query/QueryTypes.cs
@@ -31,12 +31,20 @@ public abstract record RenderedQueryGeometry
 
 /// <remarks>
 /// Compares and hashes by property value, comparing <see cref="LayerIds"/> element by element;
-/// <c>with</c> returns an independent instance. Keep an instance unmodified while it is a key in a
-/// hash-based collection.
+/// <c>with</c> returns an independent instance. Assigning <see cref="LayerIds"/> snapshots the
+/// caller's list, so later caller mutation does not change this descriptor. Keep an instance
+/// unmodified while it is a key in a hash-based collection.
 /// </remarks>
 public sealed record RenderedFeatureQueryOptions
 {
-    public IReadOnlyList<string>? LayerIds { get; set; }
+    private IReadOnlyList<string>? layerIds;
+
+    public IReadOnlyList<string>? LayerIds
+    {
+        get => layerIds;
+        set => layerIds = value is null ? null : Array.AsReadOnly([.. value]);
+    }
+
     public JsonValue? Filter { get; set; }
 
     public bool Equals(RenderedFeatureQueryOptions? other) =>
@@ -50,12 +58,20 @@ public sealed record RenderedFeatureQueryOptions
 
 /// <remarks>
 /// Compares and hashes by property value, comparing <see cref="SourceLayerIds"/> element by
-/// element; <c>with</c> returns an independent instance. Keep an instance unmodified while it is a
-/// key in a hash-based collection.
+/// element; <c>with</c> returns an independent instance. Assigning <see cref="SourceLayerIds"/>
+/// snapshots the caller's list, so later caller mutation does not change this descriptor. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
 /// </remarks>
 public sealed record SourceFeatureQueryOptions
 {
-    public IReadOnlyList<string>? SourceLayerIds { get; set; }
+    private IReadOnlyList<string>? sourceLayerIds;
+
+    public IReadOnlyList<string>? SourceLayerIds
+    {
+        get => sourceLayerIds;
+        set => sourceLayerIds = value is null ? null : Array.AsReadOnly([.. value]);
+    }
+
     public JsonValue? Filter { get; set; }
 
     public bool Equals(SourceFeatureQueryOptions? other) =>

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderTypes.cs
@@ -47,6 +47,17 @@ public sealed record PremultipliedRgba8Image
     public byte[] Bytes => (byte[])bytes.Clone();
 
     public TextureImageInfo Info { get; }
+
+    public bool Equals(PremultipliedRgba8Image? other) =>
+        other is not null && Info == other.Info && bytes.AsSpan().SequenceEqual(other.bytes);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Info);
+        hash.AddBytes(bytes);
+        return hash.ToHashCode();
+    }
 }
 
 public sealed class MetalContextDescriptor

--- a/bindings/dotnet/src/Maplibre.Native/Runtime/RuntimeOptions.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Runtime/RuntimeOptions.cs
@@ -4,7 +4,11 @@ using Maplibre.Native.Internal.Memory;
 namespace Maplibre.Native.Runtime;
 
 /// <summary>Runtime creation options.</summary>
-public sealed class RuntimeOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record RuntimeOptions
 {
     /// <summary>Filesystem root for <c>asset://</c> URLs.</summary>
     public string? AssetPath { get; set; }

--- a/bindings/dotnet/src/Maplibre.Native/Runtime/RuntimeTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Runtime/RuntimeTypes.cs
@@ -150,5 +150,18 @@ public abstract record RuntimeEventPayload
 
         public uint RawPayloadType { get; }
         public byte[] PayloadBytes => (byte[])payloadBytes.Clone();
+
+        public bool Equals(Unknown? other) =>
+            other is not null
+            && RawPayloadType == other.RawPayloadType
+            && payloadBytes.AsSpan().SequenceEqual(other.payloadBytes);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(RawPayloadType);
+            hash.AddBytes(payloadBytes);
+            return hash.ToHashCode();
+        }
     }
 }

--- a/bindings/dotnet/src/Maplibre.Native/Style/StyleTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Style/StyleTypes.cs
@@ -49,7 +49,11 @@ public sealed record SourceInfo(
     string? Attribution
 );
 
-public sealed class TileSourceOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record TileSourceOptions
 {
     public TileScheme? Scheme { get; set; }
     public double? MinimumZoom { get; set; }
@@ -85,7 +89,11 @@ public sealed record StyleImageInfo(
     bool Sdf
 );
 
-public sealed class StyleImageOptions
+/// <remarks>
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record StyleImageOptions
 {
     public float? PixelRatio { get; set; }
     public bool? Sdf { get; set; }

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/BufferValueEqualityTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/BufferValueEqualityTests.cs
@@ -1,0 +1,77 @@
+using Maplibre.Native.Geo;
+using Maplibre.Native.Offline;
+using Maplibre.Native.Render;
+using Maplibre.Native.Runtime;
+using Xunit;
+
+namespace Maplibre.Native.Tests;
+
+/// <summary>
+/// BND-070: public values wrapping copied byte buffers compare buffer contents, matching the
+/// Kotlin binding's <c>contentEquals</c> behavior for the same types.
+/// </summary>
+public sealed class BufferValueEqualityTests
+{
+    private static readonly TextureImageInfo Info = new(2, 1, 8, 8);
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void ImagesComparePixelContents()
+    {
+        var left = new PremultipliedRgba8Image([1, 2, 3, 4, 5, 6, 7, 8], Info);
+        var right = new PremultipliedRgba8Image([1, 2, 3, 4, 5, 6, 7, 8], Info);
+
+        Assert.Equal(left, right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+        Assert.NotEqual(left, new PremultipliedRgba8Image([1, 2, 3, 4, 5, 6, 7, 9], Info));
+        Assert.NotEqual(left, new PremultipliedRgba8Image([1, 2, 3, 4], new(1, 1, 4, 4)));
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void OfflineRegionInfoComparesMetadataContents()
+    {
+        var definition = new OfflineRegionDefinition.TilePyramid(
+            "https://example.invalid/style.json",
+            new LatLngBounds(new LatLng(0, 0), new LatLng(1, 1)),
+            0,
+            10,
+            1,
+            false
+        );
+
+        var left = new OfflineRegionInfo(7, definition, [1, 2, 3]);
+        var right = new OfflineRegionInfo(7, definition, [1, 2, 3]);
+
+        Assert.Equal(left, right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+        Assert.NotEqual(left, new OfflineRegionInfo(7, definition, [1, 2, 4]));
+        Assert.NotEqual(left, new OfflineRegionInfo(8, definition, [1, 2, 3]));
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void UnknownEventPayloadComparesPayloadContents()
+    {
+        var left = new RuntimeEventPayload.Unknown(3, [9, 8, 7]);
+        var right = new RuntimeEventPayload.Unknown(3, [9, 8, 7]);
+
+        Assert.Equal(left, right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+        Assert.NotEqual(left, new RuntimeEventPayload.Unknown(3, [9, 8, 6]));
+        Assert.NotEqual(left, new RuntimeEventPayload.Unknown(4, [9, 8, 7]));
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void MutatingTheCallerBufferDoesNotChangeEquality()
+    {
+        // BND-069: the copied buffer is what participates in equality.
+        var pixels = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        var image = new PremultipliedRgba8Image(pixels, Info);
+
+        pixels[0] = 99;
+
+        Assert.Equal(new PremultipliedRgba8Image([1, 2, 3, 4, 5, 6, 7, 8], Info), image);
+    }
+}

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/GeometryValueEqualityTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/GeometryValueEqualityTests.cs
@@ -1,0 +1,128 @@
+using Maplibre.Native.Geo;
+using Maplibre.Native.Json;
+using Maplibre.Native.Query;
+using Xunit;
+
+namespace Maplibre.Native.Tests;
+
+/// <summary>
+/// BND-070: public value trees compare element by element rather than by list identity. Each case
+/// builds two trees from distinct list instances holding equal contents.
+/// </summary>
+public sealed class GeometryValueEqualityTests
+{
+    private static IReadOnlyList<LatLng> Ring(double offset) =>
+        [new LatLng(offset, offset), new LatLng(offset + 1, offset + 1)];
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void FlatCoordinateGeometriesCompareByValue()
+    {
+        Assert.Equal(new Geometry.LineString(Ring(0)), new Geometry.LineString(Ring(0)));
+        Assert.Equal(
+            new Geometry.LineString(Ring(0)).GetHashCode(),
+            new Geometry.LineString(Ring(0)).GetHashCode()
+        );
+        Assert.NotEqual(new Geometry.LineString(Ring(0)), new Geometry.LineString(Ring(5)));
+
+        Assert.Equal(new Geometry.MultiPoint(Ring(0)), new Geometry.MultiPoint(Ring(0)));
+        Assert.NotEqual(new Geometry.MultiPoint(Ring(0)), new Geometry.MultiPoint(Ring(5)));
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void NestedCoordinateGeometriesCompareByValue()
+    {
+        Assert.Equal(
+            new Geometry.Polygon([Ring(0), Ring(2)]),
+            new Geometry.Polygon([Ring(0), Ring(2)])
+        );
+        Assert.NotEqual(
+            new Geometry.Polygon([Ring(0), Ring(2)]),
+            new Geometry.Polygon([Ring(0), Ring(9)])
+        );
+
+        Assert.Equal(
+            new Geometry.MultiLineString([Ring(0)]),
+            new Geometry.MultiLineString([Ring(0)])
+        );
+
+        Assert.Equal(
+            new Geometry.MultiPolygon([
+                [Ring(0), Ring(2)],
+            ]),
+            new Geometry.MultiPolygon([
+                [Ring(0), Ring(2)],
+            ])
+        );
+        Assert.NotEqual(
+            new Geometry.MultiPolygon([
+                [Ring(0), Ring(2)],
+            ]),
+            new Geometry.MultiPolygon([
+                [Ring(0), Ring(9)],
+            ])
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void GeometryCollectionsCompareRecursively()
+    {
+        Assert.Equal(
+            new Geometry.Collection([new Geometry.LineString(Ring(0)), Geometry.Empty.Instance]),
+            new Geometry.Collection([new Geometry.LineString(Ring(0)), Geometry.Empty.Instance])
+        );
+        Assert.NotEqual(
+            new Geometry.Collection([new Geometry.LineString(Ring(0))]),
+            new Geometry.Collection([new Geometry.LineString(Ring(5))])
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void FeaturesCompareGeometryPropertiesAndIdentifier()
+    {
+        static Feature Build(long id, long propertyValue) =>
+            new(
+                new Geometry.LineString(Ring(0)),
+                [new JsonMember("k", new JsonValue.Int(propertyValue))],
+                new FeatureIdentifier.Int(id)
+            );
+
+        Assert.Equal(Build(1, 2), Build(1, 2));
+        Assert.Equal(Build(1, 2).GetHashCode(), Build(1, 2).GetHashCode());
+        Assert.NotEqual(Build(1, 2), Build(1, 3));
+        Assert.NotEqual(Build(1, 2), Build(9, 2));
+
+        Assert.Equal(
+            new GeoJson.FeatureCollection([Build(1, 2)]),
+            new GeoJson.FeatureCollection([Build(1, 2)])
+        );
+        Assert.NotEqual(
+            new GeoJson.FeatureCollection([Build(1, 2)]),
+            new GeoJson.FeatureCollection([Build(1, 3)])
+        );
+
+        Assert.Equal(
+            new FeatureExtensionResult.FeatureCollection([Build(1, 2)]),
+            new FeatureExtensionResult.FeatureCollection([Build(1, 2)])
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void RenderedQueryLineStringComparesByValue()
+    {
+        IReadOnlyList<ScreenPoint> Points() => [new ScreenPoint(1, 2), new ScreenPoint(3, 4)];
+
+        Assert.Equal(
+            new RenderedQueryGeometry.LineString(Points()),
+            new RenderedQueryGeometry.LineString(Points())
+        );
+        Assert.NotEqual(
+            new RenderedQueryGeometry.LineString(Points()),
+            new RenderedQueryGeometry.LineString([new ScreenPoint(1, 2)])
+        );
+    }
+}

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/MapCameraOptionsTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/MapCameraOptionsTests.cs
@@ -310,5 +310,8 @@ public sealed class MapCameraOptionsTests
         Assert.Equal(45, camera.Bearing.Value, 12);
         Assert.NotNull(camera.Pitch);
         Assert.Equal(30, camera.Pitch.Value, 12);
+
+        // BND-070: successive snapshots of an unchanged camera compare equal.
+        Assert.Equal(camera, map.GetCamera());
     }
 }

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/OptionsValueSemanticsTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/OptionsValueSemanticsTests.cs
@@ -1,0 +1,357 @@
+using Maplibre.Native.Camera;
+using Maplibre.Native.Geo;
+using Maplibre.Native.Json;
+using Maplibre.Native.Map;
+using Maplibre.Native.Query;
+using Maplibre.Native.Runtime;
+using Maplibre.Native.Style;
+using Xunit;
+
+namespace Maplibre.Native.Tests;
+
+/// <summary>
+/// BND-070: option descriptors compare and hash by property value, and <c>with</c> produces an
+/// independent instance. Each case lists one mutator per declared property, so a property left out
+/// of the record's equality fails its mutator assertion.
+/// </summary>
+public sealed class OptionsValueSemanticsTests
+{
+    private static void AssertValueSemantics<T>(Func<T> baseline, params Action<T>[] mutators)
+        where T : class
+    {
+        var left = baseline();
+        var right = baseline();
+        Assert.Equal(left, right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+        Assert.NotSame(left, right);
+
+        for (var index = 0; index < mutators.Length; index++)
+        {
+            var mutated = baseline();
+            mutators[index](mutated);
+            Assert.False(baseline().Equals(mutated), $"property {index} is missing from equality");
+        }
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void CameraOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new CameraOptions
+                {
+                    Center = new LatLng(1, 2),
+                    CenterAltitude = 3,
+                    Padding = new EdgeInsets(4, 5, 6, 7),
+                    Anchor = new ScreenPoint(8, 9),
+                    Zoom = 10,
+                    Bearing = 11,
+                    Pitch = 12,
+                    Roll = 13,
+                    FieldOfView = 14,
+                },
+            options => options.Center = new LatLng(90, 90),
+            options => options.CenterAltitude = 300,
+            options => options.Padding = new EdgeInsets(0, 0, 0, 0),
+            options => options.Anchor = new ScreenPoint(80, 90),
+            options => options.Zoom = 100,
+            options => options.Bearing = 110,
+            options => options.Pitch = 120,
+            options => options.Roll = 130,
+            options => options.FieldOfView = 140
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void AnimationOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new AnimationOptions
+                {
+                    Duration = 1,
+                    Easing = new UnitBezier(0.1, 0.2, 0.3, 0.4),
+                    MinimumZoom = 3,
+                    Velocity = 4,
+                },
+            options => options.Duration = 10,
+            options => options.Easing = new UnitBezier(0.9, 0.8, 0.7, 0.6),
+            options => options.MinimumZoom = 30,
+            options => options.Velocity = 40
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void CameraFitOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new CameraFitOptions
+                {
+                    Padding = new EdgeInsets(1, 2, 3, 4),
+                    Bearing = 5,
+                    Pitch = 6,
+                },
+            options => options.Padding = new EdgeInsets(0, 0, 0, 0),
+            options => options.Bearing = 50,
+            options => options.Pitch = 60
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void BoundOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new BoundOptions
+                {
+                    Bounds = new LatLngBounds(new LatLng(0, 0), new LatLng(1, 1)),
+                    MinimumZoom = 2,
+                    MaximumZoom = 3,
+                    MinimumPitch = 4,
+                    MaximumPitch = 5,
+                },
+            options => options.Bounds = new LatLngBounds(new LatLng(-1, -1), new LatLng(2, 2)),
+            options => options.MinimumZoom = 20,
+            options => options.MaximumZoom = 30,
+            options => options.MinimumPitch = 40,
+            options => options.MaximumPitch = 50
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void FreeCameraOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new FreeCameraOptions
+                {
+                    Position = new Vec3(1, 2, 3),
+                    Orientation = new Quaternion(0, 0, 0, 1),
+                },
+            options => options.Position = new Vec3(9, 9, 9),
+            options => options.Orientation = new Quaternion(1, 0, 0, 0)
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void ViewportOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new ViewportOptions
+                {
+                    NorthOrientation = NorthOrientation.Up,
+                    ConstrainMode = ConstrainMode.None,
+                    ViewportMode = ViewportMode.Default,
+                    FrustumOffset = new EdgeInsets(1, 2, 3, 4),
+                },
+            options => options.NorthOrientation = NorthOrientation.Down,
+            options => options.ConstrainMode = ConstrainMode.Screen,
+            options => options.ViewportMode = ViewportMode.FlippedY,
+            options => options.FrustumOffset = new EdgeInsets(0, 0, 0, 0)
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void TileOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new TileOptions
+                {
+                    PrefetchZoomDelta = 1,
+                    LodMinimumRadius = 2,
+                    LodScale = 3,
+                    LodPitchThreshold = 4,
+                    LodZoomShift = 5,
+                    LodMode = TileLodMode.Default,
+                },
+            options => options.PrefetchZoomDelta = 7,
+            options => options.LodMinimumRadius = 20,
+            options => options.LodScale = 30,
+            options => options.LodPitchThreshold = 40,
+            options => options.LodZoomShift = 50,
+            options => options.LodMode = TileLodMode.Distance
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void ProjectionModeOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new ProjectionModeOptions
+                {
+                    Axonometric = true,
+                    XSkew = 1,
+                    YSkew = 2,
+                },
+            options => options.Axonometric = false,
+            options => options.XSkew = 10,
+            options => options.YSkew = 20
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void MapOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new MapOptions
+                {
+                    Width = 100,
+                    Height = 200,
+                    ScaleFactor = 2,
+                    MapMode = MapMode.Continuous,
+                },
+            options => options.Width = 300,
+            options => options.Height = 400,
+            options => options.ScaleFactor = 3,
+            options => options.MapMode = MapMode.Static
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void RuntimeOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new RuntimeOptions
+                {
+                    AssetPath = "assets",
+                    CachePath = "cache",
+                    MaximumCacheSize = 1024,
+                },
+            options => options.AssetPath = "other-assets",
+            options => options.CachePath = "other-cache",
+            options => options.MaximumCacheSize = 2048
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void TileSourceOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new TileSourceOptions
+                {
+                    Scheme = TileScheme.Xyz,
+                    MinimumZoom = 1,
+                    MaximumZoom = 2,
+                    TileSize = 256,
+                    Attribution = "attribution",
+                    VectorEncoding = VectorTileEncoding.Mvt,
+                    RasterEncoding = RasterDemEncoding.Mapbox,
+                    Bounds = new LatLngBounds(new LatLng(0, 0), new LatLng(1, 1)),
+                },
+            options => options.Scheme = TileScheme.Tms,
+            options => options.MinimumZoom = 10,
+            options => options.MaximumZoom = 20,
+            options => options.TileSize = 512,
+            options => options.Attribution = "other",
+            options => options.VectorEncoding = VectorTileEncoding.Mlt,
+            options => options.RasterEncoding = RasterDemEncoding.Terrarium,
+            options => options.Bounds = new LatLngBounds(new LatLng(-1, -1), new LatLng(2, 2))
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void StyleImageOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () => new StyleImageOptions { PixelRatio = 2f, Sdf = true },
+            options => options.PixelRatio = 3f,
+            options => options.Sdf = false
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void QueryOptionsCompareLayerIdsElementByElement()
+    {
+        AssertValueSemantics(
+            () =>
+                new RenderedFeatureQueryOptions
+                {
+                    LayerIds = new[] { "a", "b" },
+                    Filter = new JsonValue.Bool(true),
+                },
+            options => options.LayerIds = new[] { "a" },
+            options => options.Filter = new JsonValue.String("filter")
+        );
+        AssertValueSemantics(
+            () =>
+                new SourceFeatureQueryOptions
+                {
+                    SourceLayerIds = new[] { "a", "b" },
+                    Filter = new JsonValue.Bool(true),
+                },
+            options => options.SourceLayerIds = new[] { "a" },
+            options => options.Filter = new JsonValue.String("filter")
+        );
+
+        // Distinct list instances holding the same elements compare equal.
+        Assert.Equal(
+            new RenderedFeatureQueryOptions { LayerIds = new[] { "a", "b" } },
+            new RenderedFeatureQueryOptions
+            {
+                LayerIds = new List<string> { "a", "b" },
+            }
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void AbsentLayerIdsDifferFromEmptyLayerIds()
+    {
+        // The native field mask distinguishes an absent layer filter from an empty one.
+        Assert.NotEqual(
+            new RenderedFeatureQueryOptions(),
+            new RenderedFeatureQueryOptions { LayerIds = Array.Empty<string>() }
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void WithProducesAnIndependentInstance()
+    {
+        var original = new CameraOptions { Zoom = 1 };
+        var derived = original with { Zoom = 2 };
+
+        Assert.Equal(1, original.Zoom);
+        Assert.Equal(2, derived.Zoom);
+        Assert.NotSame(original, derived);
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
+    public void JsonContainerValuesCompareStructurally()
+    {
+        // Query filters compare by value, so the JSON tree they hold has to as well.
+        Assert.Equal(
+            new JsonValue.Array(new JsonValue[] { new JsonValue.Int(1) }),
+            new JsonValue.Array(new JsonValue[] { new JsonValue.Int(1) })
+        );
+        Assert.Equal(
+            new JsonValue.Object(new[] { new JsonMember("k", new JsonValue.Int(1)) }),
+            new JsonValue.Object(new[] { new JsonMember("k", new JsonValue.Int(1)) })
+        );
+        Assert.NotEqual(
+            new JsonValue.Object(new[] { new JsonMember("k", new JsonValue.Int(1)) }),
+            new JsonValue.Object(new[] { new JsonMember("k", new JsonValue.Int(2)) })
+        );
+    }
+}

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/OptionsValueSemanticsTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/OptionsValueSemanticsTests.cs
@@ -313,6 +313,27 @@ public sealed class OptionsValueSemanticsTests
         );
     }
 
+    [BindingSpecTest("BND-069", "BND-070")]
+    [Fact]
+    public void QueryOptionsSnapshotCallerOwnedLayerIds()
+    {
+        var layerIds = new List<string> { "a" };
+        var options = new RenderedFeatureQueryOptions { LayerIds = layerIds };
+        var copy = options with { };
+
+        layerIds.Add("b");
+
+        Assert.Equal(["a"], options.LayerIds);
+        Assert.Equal(["a"], copy.LayerIds);
+
+        var sourceLayerIds = new List<string> { "a" };
+        var sourceOptions = new SourceFeatureQueryOptions { SourceLayerIds = sourceLayerIds };
+
+        sourceLayerIds.Add("b");
+
+        Assert.Equal(["a"], sourceOptions.SourceLayerIds);
+    }
+
     [BindingSpecTest("BND-070")]
     [Fact]
     public void AbsentLayerIdsDifferFromEmptyLayerIds()

--- a/bindings/go/camera.go
+++ b/bindings/go/camera.go
@@ -18,6 +18,20 @@ type CameraOptions struct {
 	FieldOfView    *float64
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options CameraOptions) Equal(other CameraOptions) bool {
+	return equalPointer(options.Center, other.Center) &&
+		equalPointer(options.CenterAltitude, other.CenterAltitude) &&
+		equalPointer(options.Padding, other.Padding) &&
+		equalPointer(options.Anchor, other.Anchor) &&
+		equalPointer(options.Zoom, other.Zoom) &&
+		equalPointer(options.Bearing, other.Bearing) &&
+		equalPointer(options.Pitch, other.Pitch) &&
+		equalPointer(options.Roll, other.Roll) &&
+		equalPointer(options.FieldOfView, other.FieldOfView)
+}
+
 // WithCenter returns a copy that sets the center coordinate.
 func (options CameraOptions) WithCenter(center LatLng) CameraOptions {
 	options.Center = new(LatLng)
@@ -145,6 +159,15 @@ type AnimationOptions struct {
 	Easing     *UnitBezier
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options AnimationOptions) Equal(other AnimationOptions) bool {
+	return equalPointer(options.DurationMS, other.DurationMS) &&
+		equalPointer(options.Velocity, other.Velocity) &&
+		equalPointer(options.MinZoom, other.MinZoom) &&
+		equalPointer(options.Easing, other.Easing)
+}
+
 // WithDurationMS returns a copy that sets the duration in milliseconds.
 func (options AnimationOptions) WithDurationMS(durationMS float64) AnimationOptions {
 	options.DurationMS = new(float64)
@@ -215,6 +238,14 @@ type CameraFitOptions struct {
 	Pitch   *float64
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options CameraFitOptions) Equal(other CameraFitOptions) bool {
+	return equalPointer(options.Padding, other.Padding) &&
+		equalPointer(options.Bearing, other.Bearing) &&
+		equalPointer(options.Pitch, other.Pitch)
+}
+
 // WithPadding returns a copy that sets fit padding.
 func (options CameraFitOptions) WithPadding(padding EdgeInsets) CameraFitOptions {
 	options.Padding = new(EdgeInsets)
@@ -268,6 +299,16 @@ type BoundOptions struct {
 	MaxZoom  *float64
 	MinPitch *float64
 	MaxPitch *float64
+}
+
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options BoundOptions) Equal(other BoundOptions) bool {
+	return equalPointer(options.Bounds, other.Bounds) &&
+		equalPointer(options.MinZoom, other.MinZoom) &&
+		equalPointer(options.MaxZoom, other.MaxZoom) &&
+		equalPointer(options.MinPitch, other.MinPitch) &&
+		equalPointer(options.MaxPitch, other.MaxPitch)
 }
 
 // WithBounds returns a copy that sets geographic camera constraints.
@@ -361,6 +402,13 @@ type FreeCameraOptions struct {
 	Orientation *Quaternion
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options FreeCameraOptions) Equal(other FreeCameraOptions) bool {
+	return equalPointer(options.Position, other.Position) &&
+		equalPointer(options.Orientation, other.Orientation)
+}
+
 // WithPosition returns a copy that sets free camera position.
 func (options FreeCameraOptions) WithPosition(position Vec3) FreeCameraOptions {
 	options.Position = new(Vec3)
@@ -445,6 +493,15 @@ type ViewportOptions struct {
 	FrustumOffset    *EdgeInsets
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options ViewportOptions) Equal(other ViewportOptions) bool {
+	return equalPointer(options.NorthOrientation, other.NorthOrientation) &&
+		equalPointer(options.ConstrainMode, other.ConstrainMode) &&
+		equalPointer(options.ViewportMode, other.ViewportMode) &&
+		equalPointer(options.FrustumOffset, other.FrustumOffset)
+}
+
 // WithNorthOrientation returns a copy that sets the north orientation field.
 func (options ViewportOptions) WithNorthOrientation(value NorthOrientation) ViewportOptions {
 	options.NorthOrientation = new(NorthOrientation)
@@ -525,6 +582,17 @@ type TileOptions struct {
 	LODMode           *TileLODMode
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options TileOptions) Equal(other TileOptions) bool {
+	return equalPointer(options.PrefetchZoomDelta, other.PrefetchZoomDelta) &&
+		equalPointer(options.LODMinRadius, other.LODMinRadius) &&
+		equalPointer(options.LODScale, other.LODScale) &&
+		equalPointer(options.LODPitchThreshold, other.LODPitchThreshold) &&
+		equalPointer(options.LODZoomShift, other.LODZoomShift) &&
+		equalPointer(options.LODMode, other.LODMode)
+}
+
 // WithPrefetchZoomDelta returns a copy that sets prefetch zoom delta.
 func (options TileOptions) WithPrefetchZoomDelta(value uint32) TileOptions {
 	options.PrefetchZoomDelta = new(uint32)
@@ -602,6 +670,14 @@ type ProjectionModeOptions struct {
 	Axonometric *bool
 	XSkew       *float64
 	YSkew       *float64
+}
+
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options ProjectionModeOptions) Equal(other ProjectionModeOptions) bool {
+	return equalPointer(options.Axonometric, other.Axonometric) &&
+		equalPointer(options.XSkew, other.XSkew) &&
+		equalPointer(options.YSkew, other.YSkew)
 }
 
 // WithAxonometric returns a copy that sets the axonometric field.

--- a/bindings/go/camera_test.go
+++ b/bindings/go/camera_test.go
@@ -41,6 +41,14 @@ func TestMapCameraCommandsUseNativeABI(t *testing.T) {
 	if gotCamera.Center == nil || gotCamera.Zoom == nil {
 		t.Fatalf("Camera() missing expected fields: %#v", gotCamera)
 	}
+	// BND-070: successive snapshots of an unchanged camera compare equal.
+	secondCamera, err := m.Camera()
+	if err != nil {
+		t.Fatalf("Camera(): %v", err)
+	}
+	if !gotCamera.Equal(secondCamera) {
+		t.Errorf("successive camera snapshots differ: %#v vs %#v", gotCamera, secondCamera)
+	}
 	if err := m.MoveBy(ScreenPoint{X: 1, Y: 2}); err != nil {
 		t.Fatalf("MoveBy(): %v", err)
 	}

--- a/bindings/go/equal.go
+++ b/bindings/go/equal.go
@@ -1,0 +1,36 @@
+package maplibre
+
+// Structural comparison helpers for the option structs. Optional fields are pointers, so the
+// built-in == operator compares pointer identity rather than the values behind them; the Equal
+// methods built on these helpers compare the values.
+
+// equalPointer reports whether two optional fields hold equal values. A nil pointer marks an
+// absent field and is equal only to another nil pointer.
+func equalPointer[T comparable](left, right *T) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+// equalStrings reports whether two optional string lists are equal. A nil list marks an absent
+// field and is never equal to an empty list, matching how the field masks are populated.
+func equalStrings(left, right []string) bool {
+	if (left == nil) != (right == nil) || len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// equalJSON reports whether two optional JSON filters are equal.
+func equalJSON(left, right *JSONValue) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Equal(*right)
+}

--- a/bindings/go/equal_test.go
+++ b/bindings/go/equal_test.go
@@ -1,0 +1,372 @@
+package maplibre
+
+import "testing"
+
+// BND-070: option descriptors compare by field value rather than pointer identity. Each case
+// lists one mutator per declared field, so a field left out of Equal fails its mutator assertion.
+
+func optionPtr[T any](value T) *T {
+	return &value
+}
+
+func assertValueSemantics[T any](
+	t *testing.T,
+	name string,
+	baseline func() T,
+	equal func(T, T) bool,
+	mutators []func(*T),
+) {
+	t.Helper()
+
+	if !equal(baseline(), baseline()) {
+		t.Fatalf("%s: descriptors with identical fields are not equal", name)
+	}
+	for index, mutate := range mutators {
+		mutated := baseline()
+		mutate(&mutated)
+		if equal(baseline(), mutated) {
+			t.Errorf("%s: field %d is missing from Equal", name, index)
+		}
+	}
+}
+
+func TestCameraOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"CameraOptions",
+		func() CameraOptions {
+			return CameraOptions{
+				Center:         optionPtr(LatLng{Latitude: 1, Longitude: 2}),
+				CenterAltitude: optionPtr(3.0),
+				Padding:        optionPtr(EdgeInsets{Top: 4, Left: 5, Bottom: 6, Right: 7}),
+				Anchor:         optionPtr(ScreenPoint{X: 8, Y: 9}),
+				Zoom:           optionPtr(10.0),
+				Bearing:        optionPtr(11.0),
+				Pitch:          optionPtr(12.0),
+				Roll:           optionPtr(13.0),
+				FieldOfView:    optionPtr(14.0),
+			}
+		},
+		CameraOptions.Equal,
+		[]func(*CameraOptions){
+			func(o *CameraOptions) { o.Center = optionPtr(LatLng{Latitude: 90, Longitude: 90}) },
+			func(o *CameraOptions) { o.CenterAltitude = optionPtr(300.0) },
+			func(o *CameraOptions) { o.Padding = optionPtr(EdgeInsets{}) },
+			func(o *CameraOptions) { o.Anchor = optionPtr(ScreenPoint{X: 80, Y: 90}) },
+			func(o *CameraOptions) { o.Zoom = optionPtr(100.0) },
+			func(o *CameraOptions) { o.Bearing = optionPtr(110.0) },
+			func(o *CameraOptions) { o.Pitch = optionPtr(120.0) },
+			func(o *CameraOptions) { o.Roll = optionPtr(130.0) },
+			func(o *CameraOptions) { o.FieldOfView = optionPtr(140.0) },
+		},
+	)
+}
+
+func TestAnimationOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"AnimationOptions",
+		func() AnimationOptions {
+			return AnimationOptions{
+				DurationMS: optionPtr(1.0),
+				Velocity:   optionPtr(2.0),
+				MinZoom:    optionPtr(3.0),
+				Easing:     optionPtr(UnitBezier{X1: 0.1, Y1: 0.2, X2: 0.3, Y2: 0.4}),
+			}
+		},
+		AnimationOptions.Equal,
+		[]func(*AnimationOptions){
+			func(o *AnimationOptions) { o.DurationMS = optionPtr(10.0) },
+			func(o *AnimationOptions) { o.Velocity = optionPtr(20.0) },
+			func(o *AnimationOptions) { o.MinZoom = optionPtr(30.0) },
+			func(o *AnimationOptions) {
+				o.Easing = optionPtr(UnitBezier{X1: 0.9, Y1: 0.8, X2: 0.7, Y2: 0.6})
+			},
+		},
+	)
+}
+
+func TestCameraFitOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"CameraFitOptions",
+		func() CameraFitOptions {
+			return CameraFitOptions{
+				Padding: optionPtr(EdgeInsets{Top: 1, Left: 2, Bottom: 3, Right: 4}),
+				Bearing: optionPtr(5.0),
+				Pitch:   optionPtr(6.0),
+			}
+		},
+		CameraFitOptions.Equal,
+		[]func(*CameraFitOptions){
+			func(o *CameraFitOptions) { o.Padding = optionPtr(EdgeInsets{}) },
+			func(o *CameraFitOptions) { o.Bearing = optionPtr(50.0) },
+			func(o *CameraFitOptions) { o.Pitch = optionPtr(60.0) },
+		},
+	)
+}
+
+func TestBoundOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"BoundOptions",
+		func() BoundOptions {
+			return BoundOptions{
+				Bounds: optionPtr(LatLngBounds{
+					Southwest: LatLng{Latitude: 0, Longitude: 0},
+					Northeast: LatLng{Latitude: 1, Longitude: 1},
+				}),
+				MinZoom:  optionPtr(2.0),
+				MaxZoom:  optionPtr(3.0),
+				MinPitch: optionPtr(4.0),
+				MaxPitch: optionPtr(5.0),
+			}
+		},
+		BoundOptions.Equal,
+		[]func(*BoundOptions){
+			func(o *BoundOptions) {
+				o.Bounds = optionPtr(LatLngBounds{
+					Southwest: LatLng{Latitude: -1, Longitude: -1},
+					Northeast: LatLng{Latitude: 2, Longitude: 2},
+				})
+			},
+			func(o *BoundOptions) { o.MinZoom = optionPtr(20.0) },
+			func(o *BoundOptions) { o.MaxZoom = optionPtr(30.0) },
+			func(o *BoundOptions) { o.MinPitch = optionPtr(40.0) },
+			func(o *BoundOptions) { o.MaxPitch = optionPtr(50.0) },
+		},
+	)
+}
+
+func TestFreeCameraOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"FreeCameraOptions",
+		func() FreeCameraOptions {
+			return FreeCameraOptions{
+				Position:    optionPtr(Vec3{X: 1, Y: 2, Z: 3}),
+				Orientation: optionPtr(Quaternion{X: 0, Y: 0, Z: 0, W: 1}),
+			}
+		},
+		FreeCameraOptions.Equal,
+		[]func(*FreeCameraOptions){
+			func(o *FreeCameraOptions) { o.Position = optionPtr(Vec3{X: 9, Y: 9, Z: 9}) },
+			func(o *FreeCameraOptions) {
+				o.Orientation = optionPtr(Quaternion{X: 1, Y: 0, Z: 0, W: 0})
+			},
+		},
+	)
+}
+
+func TestViewportOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"ViewportOptions",
+		func() ViewportOptions {
+			return ViewportOptions{
+				NorthOrientation: optionPtr(NorthOrientationUp),
+				ConstrainMode:    optionPtr(ConstrainModeNone),
+				ViewportMode:     optionPtr(ViewportModeDefault),
+				FrustumOffset:    optionPtr(EdgeInsets{Top: 1, Left: 2, Bottom: 3, Right: 4}),
+			}
+		},
+		ViewportOptions.Equal,
+		[]func(*ViewportOptions){
+			func(o *ViewportOptions) { o.NorthOrientation = optionPtr(NorthOrientationDown) },
+			func(o *ViewportOptions) { o.ConstrainMode = optionPtr(ConstrainModeScreen) },
+			func(o *ViewportOptions) { o.ViewportMode = optionPtr(ViewportModeFlippedY) },
+			func(o *ViewportOptions) { o.FrustumOffset = optionPtr(EdgeInsets{}) },
+		},
+	)
+}
+
+func TestTileOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"TileOptions",
+		func() TileOptions {
+			return TileOptions{
+				PrefetchZoomDelta: optionPtr(uint32(1)),
+				LODMinRadius:      optionPtr(2.0),
+				LODScale:          optionPtr(3.0),
+				LODPitchThreshold: optionPtr(4.0),
+				LODZoomShift:      optionPtr(5.0),
+				LODMode:           optionPtr(TileLODModeDefault),
+			}
+		},
+		TileOptions.Equal,
+		[]func(*TileOptions){
+			func(o *TileOptions) { o.PrefetchZoomDelta = optionPtr(uint32(7)) },
+			func(o *TileOptions) { o.LODMinRadius = optionPtr(20.0) },
+			func(o *TileOptions) { o.LODScale = optionPtr(30.0) },
+			func(o *TileOptions) { o.LODPitchThreshold = optionPtr(40.0) },
+			func(o *TileOptions) { o.LODZoomShift = optionPtr(50.0) },
+			func(o *TileOptions) { o.LODMode = optionPtr(TileLODModeDistance) },
+		},
+	)
+}
+
+func TestProjectionModeOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"ProjectionModeOptions",
+		func() ProjectionModeOptions {
+			return ProjectionModeOptions{
+				Axonometric: optionPtr(true),
+				XSkew:       optionPtr(1.0),
+				YSkew:       optionPtr(2.0),
+			}
+		},
+		ProjectionModeOptions.Equal,
+		[]func(*ProjectionModeOptions){
+			func(o *ProjectionModeOptions) { o.Axonometric = optionPtr(false) },
+			func(o *ProjectionModeOptions) { o.XSkew = optionPtr(10.0) },
+			func(o *ProjectionModeOptions) { o.YSkew = optionPtr(20.0) },
+		},
+	)
+}
+
+func TestRuntimeOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"RuntimeOptions",
+		func() RuntimeOptions {
+			return RuntimeOptions{
+				AssetPath:        "assets",
+				CachePath:        "cache",
+				MaximumCacheSize: optionPtr(uint64(1024)),
+			}
+		},
+		RuntimeOptions.Equal,
+		[]func(*RuntimeOptions){
+			func(o *RuntimeOptions) { o.AssetPath = "other-assets" },
+			func(o *RuntimeOptions) { o.CachePath = "other-cache" },
+			func(o *RuntimeOptions) { o.MaximumCacheSize = optionPtr(uint64(2048)) },
+		},
+	)
+}
+
+func TestStyleTileSourceOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"StyleTileSourceOptions",
+		func() StyleTileSourceOptions {
+			return StyleTileSourceOptions{
+				MinZoom:     optionPtr(1.0),
+				MaxZoom:     optionPtr(2.0),
+				Attribution: optionPtr("attribution"),
+				Scheme:      optionPtr(StyleTileSchemeXYZ),
+				Bounds: optionPtr(LatLngBounds{
+					Southwest: LatLng{Latitude: 0, Longitude: 0},
+					Northeast: LatLng{Latitude: 1, Longitude: 1},
+				}),
+				TileSize:       optionPtr(uint32(256)),
+				VectorEncoding: optionPtr(StyleVectorTileEncodingMVT),
+				RasterEncoding: optionPtr(StyleRasterDEMEncodingMapbox),
+			}
+		},
+		StyleTileSourceOptions.Equal,
+		[]func(*StyleTileSourceOptions){
+			func(o *StyleTileSourceOptions) { o.MinZoom = optionPtr(10.0) },
+			func(o *StyleTileSourceOptions) { o.MaxZoom = optionPtr(20.0) },
+			func(o *StyleTileSourceOptions) { o.Attribution = optionPtr("other") },
+			func(o *StyleTileSourceOptions) { o.Scheme = optionPtr(StyleTileSchemeTMS) },
+			func(o *StyleTileSourceOptions) {
+				o.Bounds = optionPtr(LatLngBounds{
+					Southwest: LatLng{Latitude: -1, Longitude: -1},
+					Northeast: LatLng{Latitude: 2, Longitude: 2},
+				})
+			},
+			func(o *StyleTileSourceOptions) { o.TileSize = optionPtr(uint32(512)) },
+			func(o *StyleTileSourceOptions) {
+				o.VectorEncoding = optionPtr(StyleVectorTileEncodingMLT)
+			},
+			func(o *StyleTileSourceOptions) {
+				o.RasterEncoding = optionPtr(StyleRasterDEMEncodingTerrarium)
+			},
+		},
+	)
+}
+
+func TestStyleImageOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"StyleImageOptions",
+		func() StyleImageOptions {
+			return StyleImageOptions{PixelRatio: optionPtr(float32(2)), SDF: optionPtr(true)}
+		},
+		StyleImageOptions.Equal,
+		[]func(*StyleImageOptions){
+			func(o *StyleImageOptions) { o.PixelRatio = optionPtr(float32(3)) },
+			func(o *StyleImageOptions) { o.SDF = optionPtr(false) },
+		},
+	)
+}
+
+func TestQueryOptionsEqualComparesLayerIDsElementByElement(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"RenderedFeatureQueryOptions",
+		func() RenderedFeatureQueryOptions {
+			return RenderedFeatureQueryOptions{
+				LayerIDs: []string{"a", "b"},
+				Filter:   optionPtr(JSONBool(true)),
+			}
+		},
+		RenderedFeatureQueryOptions.Equal,
+		[]func(*RenderedFeatureQueryOptions){
+			func(o *RenderedFeatureQueryOptions) { o.LayerIDs = []string{"a"} },
+			func(o *RenderedFeatureQueryOptions) { o.Filter = optionPtr(JSONString("filter")) },
+		},
+	)
+	assertValueSemantics(
+		t,
+		"SourceFeatureQueryOptions",
+		func() SourceFeatureQueryOptions {
+			return SourceFeatureQueryOptions{
+				SourceLayerIDs: []string{"a", "b"},
+				Filter:         optionPtr(JSONBool(true)),
+			}
+		},
+		SourceFeatureQueryOptions.Equal,
+		[]func(*SourceFeatureQueryOptions){
+			func(o *SourceFeatureQueryOptions) { o.SourceLayerIDs = []string{"a"} },
+			func(o *SourceFeatureQueryOptions) { o.Filter = optionPtr(JSONString("filter")) },
+		},
+	)
+}
+
+func TestQueryOptionsEqualSeparatesAbsentFromEmptyLayerIDs(t *testing.T) {
+	// The native field mask distinguishes an absent layer filter from an empty one.
+	absent := RenderedFeatureQueryOptions{}
+	empty := RenderedFeatureQueryOptions{LayerIDs: []string{}}
+
+	if absent.Equal(empty) {
+		t.Error("absent LayerIDs compares equal to an empty LayerIDs list")
+	}
+}
+
+func TestJSONValueEqualComparesNestedContainers(t *testing.T) {
+	// Query filters compare by value, so the JSON tree they hold has to as well.
+	left := JSONObject(
+		JSONMember{Name: "list", Value: JSONArray(JSONInt(1), JSONString("two"))},
+	)
+	right := JSONObject(
+		JSONMember{Name: "list", Value: JSONArray(JSONInt(1), JSONString("two"))},
+	)
+	if !left.Equal(right) {
+		t.Error("structurally identical JSON values are not equal")
+	}
+
+	differentOrder := JSONObject(
+		JSONMember{Name: "list", Value: JSONArray(JSONString("two"), JSONInt(1))},
+	)
+	if left.Equal(differentOrder) {
+		t.Error("JSON array element order is not compared")
+	}
+
+	// Integer width is part of the value, so a signed and unsigned 1 differ.
+	if JSONInt(1).Equal(JSONUint(1)) {
+		t.Error("signed and unsigned JSON integers compare equal")
+	}
+}

--- a/bindings/go/json.go
+++ b/bindings/go/json.go
@@ -37,6 +37,52 @@ type JSONValue struct {
 	Object JSONMembers
 }
 
+// Equal reports whether two JSON values are structurally equal, comparing only the field the type
+// selects and preserving array element order, object member order, and repeated member names. Use
+// this instead of ==, which does not compile for structs holding slices.
+func (v JSONValue) Equal(other JSONValue) bool {
+	if v.Type != other.Type {
+		return false
+	}
+	switch v.Type {
+	case JSONValueTypeNull:
+		return true
+	case JSONValueTypeBool:
+		return v.Bool == other.Bool
+	case JSONValueTypeString:
+		return v.String == other.String
+	case JSONValueTypeInt:
+		return v.Int == other.Int
+	case JSONValueTypeUint:
+		return v.Uint == other.Uint
+	case JSONValueTypeDouble:
+		return v.Double == other.Double
+	case JSONValueTypeArray:
+		if len(v.Array) != len(other.Array) {
+			return false
+		}
+		for index := range v.Array {
+			if !v.Array[index].Equal(other.Array[index]) {
+				return false
+			}
+		}
+		return true
+	case JSONValueTypeObject:
+		if len(v.Object) != len(other.Object) {
+			return false
+		}
+		for index := range v.Object {
+			if v.Object[index].Name != other.Object[index].Name ||
+				!v.Object[index].Value.Equal(other.Object[index].Value) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
 // JSONNull returns a null JSON value.
 func JSONNull() JSONValue {
 	return JSONValue{Type: JSONValueTypeNull}

--- a/bindings/go/map.go
+++ b/bindings/go/map.go
@@ -52,6 +52,12 @@ type MapOptions struct {
 	Mode        MapMode
 }
 
+// Equal reports whether two descriptors hold the same field values, matching the Equal methods on
+// the other option structs.
+func (options MapOptions) Equal(other MapOptions) bool {
+	return options == other
+}
+
 // NewMapOptions returns map creation options for a viewport size and scale.
 func NewMapOptions(width, height uint32, scaleFactor float64) MapOptions {
 	return MapOptions{Width: width, Height: height, ScaleFactor: scaleFactor, Mode: MapModeContinuous}

--- a/bindings/go/query.go
+++ b/bindings/go/query.go
@@ -54,10 +54,24 @@ type RenderedFeatureQueryOptions struct {
 	Filter   *JSONValue
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// does not compile for structs holding slices.
+func (options RenderedFeatureQueryOptions) Equal(other RenderedFeatureQueryOptions) bool {
+	return equalStrings(options.LayerIDs, other.LayerIDs) &&
+		equalJSON(options.Filter, other.Filter)
+}
+
 // SourceFeatureQueryOptions configures source feature queries.
 type SourceFeatureQueryOptions struct {
 	SourceLayerIDs []string
 	Filter         *JSONValue
+}
+
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// does not compile for structs holding slices.
+func (options SourceFeatureQueryOptions) Equal(other SourceFeatureQueryOptions) bool {
+	return equalStrings(options.SourceLayerIDs, other.SourceLayerIDs) &&
+		equalJSON(options.Filter, other.Filter)
 }
 
 // QueriedFeature contains one copied feature query result.

--- a/bindings/go/runtime.go
+++ b/bindings/go/runtime.go
@@ -158,6 +158,14 @@ type RuntimeOptions struct {
 	MaximumCacheSize *uint64
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options RuntimeOptions) Equal(other RuntimeOptions) bool {
+	return options.AssetPath == other.AssetPath &&
+		options.CachePath == other.CachePath &&
+		equalPointer(options.MaximumCacheSize, other.MaximumCacheSize)
+}
+
 // WithMaximumCacheSize returns a copy with an explicit maximum ambient cache
 // size.
 func (options RuntimeOptions) WithMaximumCacheSize(size uint64) RuntimeOptions {

--- a/bindings/go/style.go
+++ b/bindings/go/style.go
@@ -73,6 +73,19 @@ type StyleTileSourceOptions struct {
 	RasterEncoding *StyleRasterDEMEncoding
 }
 
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options StyleTileSourceOptions) Equal(other StyleTileSourceOptions) bool {
+	return equalPointer(options.MinZoom, other.MinZoom) &&
+		equalPointer(options.MaxZoom, other.MaxZoom) &&
+		equalPointer(options.Attribution, other.Attribution) &&
+		equalPointer(options.Scheme, other.Scheme) &&
+		equalPointer(options.Bounds, other.Bounds) &&
+		equalPointer(options.TileSize, other.TileSize) &&
+		equalPointer(options.VectorEncoding, other.VectorEncoding) &&
+		equalPointer(options.RasterEncoding, other.RasterEncoding)
+}
+
 // WithTileSize returns a copy that sets raster tile size.
 func (options StyleTileSourceOptions) WithTileSize(tileSize uint32) StyleTileSourceOptions {
 	options.TileSize = new(uint32)
@@ -229,6 +242,13 @@ type PremultipliedRGBA8Image struct {
 type StyleImageOptions struct {
 	PixelRatio *float32
 	SDF        *bool
+}
+
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// compares the optional fields by pointer identity.
+func (options StyleImageOptions) Equal(other StyleImageOptions) bool {
+	return equalPointer(options.PixelRatio, other.PixelRatio) &&
+		equalPointer(options.SDF, other.SDF)
 }
 
 func cStyleImageOptions(options StyleImageOptions) C.mln_style_image_options {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/AnimationOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/AnimationOptions.kt
@@ -1,6 +1,11 @@
 package org.maplibre.nativeffi.camera
 
-/** Mutable animation descriptor used for animated camera commands. */
+/**
+ * Mutable animation descriptor used for animated camera commands.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class AnimationOptions {
   public var durationMs: Double? = null
 
@@ -9,4 +14,22 @@ public class AnimationOptions {
   public var minZoom: Double? = null
 
   public var easing: UnitBezier? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: AnimationOptions.() -> Unit = {}): AnimationOptions =
+    AnimationOptions()
+      .also {
+        it.durationMs = durationMs
+        it.velocity = velocity
+        it.minZoom = minZoom
+        it.easing = easing
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(durationMs, velocity, minZoom, easing)
+
+  override fun equals(other: Any?): Boolean = other is AnimationOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/BoundOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/BoundOptions.kt
@@ -2,7 +2,12 @@ package org.maplibre.nativeffi.camera
 
 import org.maplibre.nativeffi.geo.LatLngBounds
 
-/** Mutable map bounds descriptor. */
+/**
+ * Mutable map bounds descriptor.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class BoundOptions {
   public var bounds: LatLngBounds? = null
 
@@ -13,4 +18,23 @@ public class BoundOptions {
   public var minPitch: Double? = null
 
   public var maxPitch: Double? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: BoundOptions.() -> Unit = {}): BoundOptions =
+    BoundOptions()
+      .also {
+        it.bounds = bounds
+        it.minZoom = minZoom
+        it.maxZoom = maxZoom
+        it.minPitch = minPitch
+        it.maxPitch = maxPitch
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(bounds, minZoom, maxZoom, minPitch, maxPitch)
+
+  override fun equals(other: Any?): Boolean = other is BoundOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/CameraFitOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/CameraFitOptions.kt
@@ -1,10 +1,32 @@
 package org.maplibre.nativeffi.camera
 
-/** Mutable camera fitting descriptor. */
+/**
+ * Mutable camera fitting descriptor.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class CameraFitOptions {
   public var padding: EdgeInsets? = null
 
   public var bearing: Double? = null
 
   public var pitch: Double? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: CameraFitOptions.() -> Unit = {}): CameraFitOptions =
+    CameraFitOptions()
+      .also {
+        it.padding = padding
+        it.bearing = bearing
+        it.pitch = pitch
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(padding, bearing, pitch)
+
+  override fun equals(other: Any?): Boolean = other is CameraFitOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/CameraOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/CameraOptions.kt
@@ -3,7 +3,12 @@ package org.maplibre.nativeffi.camera
 import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.ScreenPoint
 
-/** Mutable camera descriptor used for camera snapshots and commands. */
+/**
+ * Mutable camera descriptor used for camera snapshots and commands.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class CameraOptions {
   public var center: LatLng? = null
 
@@ -22,4 +27,27 @@ public class CameraOptions {
   public var roll: Double? = null
 
   public var fieldOfView: Double? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: CameraOptions.() -> Unit = {}): CameraOptions =
+    CameraOptions()
+      .also {
+        it.center = center
+        it.centerAltitude = centerAltitude
+        it.padding = padding
+        it.anchor = anchor
+        it.zoom = zoom
+        it.bearing = bearing
+        it.pitch = pitch
+        it.roll = roll
+        it.fieldOfView = fieldOfView
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(center, centerAltitude, padding, anchor, zoom, bearing, pitch, roll, fieldOfView)
+
+  override fun equals(other: Any?): Boolean = other is CameraOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/FreeCameraOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/FreeCameraOptions.kt
@@ -3,9 +3,30 @@ package org.maplibre.nativeffi.camera
 import org.maplibre.nativeffi.geo.Quaternion
 import org.maplibre.nativeffi.geo.Vec3
 
-/** Mutable free-camera descriptor. */
+/**
+ * Mutable free-camera descriptor.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class FreeCameraOptions {
   public var position: Vec3? = null
 
   public var orientation: Quaternion? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: FreeCameraOptions.() -> Unit = {}): FreeCameraOptions =
+    FreeCameraOptions()
+      .also {
+        it.position = position
+        it.orientation = orientation
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(position, orientation)
+
+  override fun equals(other: Any?): Boolean = other is FreeCameraOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapOptions.kt
@@ -2,7 +2,12 @@ package org.maplibre.nativeffi.map
 
 import org.maplibre.nativeffi.internal.status.Status
 
-/** Mutable descriptor used when creating a [MapHandle]. */
+/**
+ * Mutable descriptor used when creating a [MapHandle].
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class MapOptions {
   public var width: Int? = null
     set(value) {
@@ -19,4 +24,22 @@ public class MapOptions {
   public var scaleFactor: Double? = null
 
   public var mapMode: MapMode? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: MapOptions.() -> Unit = {}): MapOptions =
+    MapOptions()
+      .also {
+        it.width = width
+        it.height = height
+        it.scaleFactor = scaleFactor
+        it.mapMode = mapMode
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(width, height, scaleFactor, mapMode)
+
+  override fun equals(other: Any?): Boolean = other is MapOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/ProjectionModeOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/ProjectionModeOptions.kt
@@ -1,10 +1,33 @@
 package org.maplibre.nativeffi.map
 
-/** Mutable descriptor for axonometric map projection mode options. */
+/**
+ * Mutable descriptor for axonometric map projection mode options.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class ProjectionModeOptions {
   public var axonometric: Boolean? = null
 
   public var xSkew: Double? = null
 
   public var ySkew: Double? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: ProjectionModeOptions.() -> Unit = {}): ProjectionModeOptions =
+    ProjectionModeOptions()
+      .also {
+        it.axonometric = axonometric
+        it.xSkew = xSkew
+        it.ySkew = ySkew
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(axonometric, xSkew, ySkew)
+
+  override fun equals(other: Any?): Boolean =
+    other is ProjectionModeOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/TileOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/TileOptions.kt
@@ -2,7 +2,12 @@ package org.maplibre.nativeffi.map
 
 import org.maplibre.nativeffi.internal.status.Status
 
-/** Mutable descriptor for tile prefetch and level-of-detail controls. */
+/**
+ * Mutable descriptor for tile prefetch and level-of-detail controls.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class TileOptions {
   public var prefetchZoomDelta: Int? = null
     set(value) {
@@ -19,4 +24,25 @@ public class TileOptions {
   public var lodZoomShift: Double? = null
 
   public var lodMode: TileLodMode? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: TileOptions.() -> Unit = {}): TileOptions =
+    TileOptions()
+      .also {
+        it.prefetchZoomDelta = prefetchZoomDelta
+        it.lodMinRadius = lodMinRadius
+        it.lodScale = lodScale
+        it.lodPitchThreshold = lodPitchThreshold
+        it.lodZoomShift = lodZoomShift
+        it.lodMode = lodMode
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() =
+      listOf(prefetchZoomDelta, lodMinRadius, lodScale, lodPitchThreshold, lodZoomShift, lodMode)
+
+  override fun equals(other: Any?): Boolean = other is TileOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/ViewportOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/ViewportOptions.kt
@@ -2,7 +2,12 @@ package org.maplibre.nativeffi.map
 
 import org.maplibre.nativeffi.camera.EdgeInsets
 
-/** Mutable descriptor for live map viewport and render-transform controls. */
+/**
+ * Mutable descriptor for live map viewport and render-transform controls.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class ViewportOptions {
   public var northOrientation: NorthOrientation? = null
 
@@ -11,4 +16,22 @@ public class ViewportOptions {
   public var viewportMode: ViewportMode? = null
 
   public var frustumOffset: EdgeInsets? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: ViewportOptions.() -> Unit = {}): ViewportOptions =
+    ViewportOptions()
+      .also {
+        it.northOrientation = northOrientation
+        it.constrainMode = constrainMode
+        it.viewportMode = viewportMode
+        it.frustumOffset = frustumOffset
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(northOrientation, constrainMode, viewportMode, frustumOffset)
+
+  override fun equals(other: Any?): Boolean = other is ViewportOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/query/RenderedFeatureQueryOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/query/RenderedFeatureQueryOptions.kt
@@ -2,9 +2,31 @@ package org.maplibre.nativeffi.query
 
 import org.maplibre.nativeffi.json.JsonValue
 
-/** Mutable options for rendered feature queries. */
+/**
+ * Mutable options for rendered feature queries.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class RenderedFeatureQueryOptions {
   public var layerIds: List<String>? = null
 
   public var filter: JsonValue? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: RenderedFeatureQueryOptions.() -> Unit = {}): RenderedFeatureQueryOptions =
+    RenderedFeatureQueryOptions()
+      .also {
+        it.layerIds = layerIds?.toList()
+        it.filter = filter
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(layerIds, filter)
+
+  override fun equals(other: Any?): Boolean =
+    other is RenderedFeatureQueryOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/query/RenderedFeatureQueryOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/query/RenderedFeatureQueryOptions.kt
@@ -5,11 +5,15 @@ import org.maplibre.nativeffi.json.JsonValue
 /**
  * Mutable options for rendered feature queries.
  *
- * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
- * unmodified while it is a key in a hash-based collection.
+ * Compares and hashes by field value; [copy] returns an independent instance. Assigning [layerIds]
+ * snapshots the caller's list, so later caller mutation does not change this descriptor. Keep an
+ * instance unmodified while it is a key in a hash-based collection.
  */
 public class RenderedFeatureQueryOptions {
   public var layerIds: List<String>? = null
+    set(value) {
+      field = value?.toList()
+    }
 
   public var filter: JsonValue? = null
 
@@ -17,7 +21,7 @@ public class RenderedFeatureQueryOptions {
   public fun copy(block: RenderedFeatureQueryOptions.() -> Unit = {}): RenderedFeatureQueryOptions =
     RenderedFeatureQueryOptions()
       .also {
-        it.layerIds = layerIds?.toList()
+        it.layerIds = layerIds
         it.filter = filter
       }
       .apply(block)

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/query/SourceFeatureQueryOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/query/SourceFeatureQueryOptions.kt
@@ -5,11 +5,15 @@ import org.maplibre.nativeffi.json.JsonValue
 /**
  * Mutable options for source feature queries.
  *
- * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
- * unmodified while it is a key in a hash-based collection.
+ * Compares and hashes by field value; [copy] returns an independent instance. Assigning
+ * [sourceLayerIds] snapshots the caller's list, so later caller mutation does not change this
+ * descriptor. Keep an instance unmodified while it is a key in a hash-based collection.
  */
 public class SourceFeatureQueryOptions {
   public var sourceLayerIds: List<String>? = null
+    set(value) {
+      field = value?.toList()
+    }
 
   public var filter: JsonValue? = null
 
@@ -17,7 +21,7 @@ public class SourceFeatureQueryOptions {
   public fun copy(block: SourceFeatureQueryOptions.() -> Unit = {}): SourceFeatureQueryOptions =
     SourceFeatureQueryOptions()
       .also {
-        it.sourceLayerIds = sourceLayerIds?.toList()
+        it.sourceLayerIds = sourceLayerIds
         it.filter = filter
       }
       .apply(block)

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/query/SourceFeatureQueryOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/query/SourceFeatureQueryOptions.kt
@@ -2,9 +2,31 @@ package org.maplibre.nativeffi.query
 
 import org.maplibre.nativeffi.json.JsonValue
 
-/** Mutable options for source feature queries. */
+/**
+ * Mutable options for source feature queries.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class SourceFeatureQueryOptions {
   public var sourceLayerIds: List<String>? = null
 
   public var filter: JsonValue? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: SourceFeatureQueryOptions.() -> Unit = {}): SourceFeatureQueryOptions =
+    SourceFeatureQueryOptions()
+      .also {
+        it.sourceLayerIds = sourceLayerIds?.toList()
+        it.filter = filter
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(sourceLayerIds, filter)
+
+  override fun equals(other: Any?): Boolean =
+    other is SourceFeatureQueryOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeOptions.kt
@@ -2,7 +2,12 @@ package org.maplibre.nativeffi.runtime
 
 import org.maplibre.nativeffi.internal.status.Status
 
-/** Mutable descriptor used when creating a [RuntimeHandle]. */
+/**
+ * Mutable descriptor used when creating a [RuntimeHandle].
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class RuntimeOptions {
   public var assetPath: String? = null
 
@@ -13,4 +18,21 @@ public class RuntimeOptions {
       value?.let { Status.requireArgument(it >= 0) { "maximumCacheSize must be non-negative" } }
       field = value
     }
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: RuntimeOptions.() -> Unit = {}): RuntimeOptions =
+    RuntimeOptions()
+      .also {
+        it.assetPath = assetPath
+        it.cachePath = cachePath
+        it.maximumCacheSize = maximumCacheSize
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(assetPath, cachePath, maximumCacheSize)
+
+  override fun equals(other: Any?): Boolean = other is RuntimeOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/style/StyleImageOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/style/StyleImageOptions.kt
@@ -1,8 +1,29 @@
 package org.maplibre.nativeffi.style
 
-/** Mutable descriptor for runtime style image options. */
+/**
+ * Mutable descriptor for runtime style image options.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class StyleImageOptions {
   public var pixelRatio: Float? = null
 
   public var sdf: Boolean? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: StyleImageOptions.() -> Unit = {}): StyleImageOptions =
+    StyleImageOptions()
+      .also {
+        it.pixelRatio = pixelRatio
+        it.sdf = sdf
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() = listOf(pixelRatio, sdf)
+
+  override fun equals(other: Any?): Boolean = other is StyleImageOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/style/TileSourceOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/style/TileSourceOptions.kt
@@ -3,7 +3,12 @@ package org.maplibre.nativeffi.style
 import org.maplibre.nativeffi.geo.LatLngBounds
 import org.maplibre.nativeffi.internal.status.Status
 
-/** Mutable descriptor for vector, raster, and raster DEM style tile sources. */
+/**
+ * Mutable descriptor for vector, raster, and raster DEM style tile sources.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
 public class TileSourceOptions {
   public var minZoom: Double? = null
 
@@ -24,4 +29,36 @@ public class TileSourceOptions {
   public var vectorEncoding: VectorTileEncoding? = null
 
   public var rasterDemEncoding: RasterDemEncoding? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: TileSourceOptions.() -> Unit = {}): TileSourceOptions =
+    TileSourceOptions()
+      .also {
+        it.minZoom = minZoom
+        it.maxZoom = maxZoom
+        it.attribution = attribution
+        it.scheme = scheme
+        it.bounds = bounds
+        it.tileSize = tileSize
+        it.vectorEncoding = vectorEncoding
+        it.rasterDemEncoding = rasterDemEncoding
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() =
+      listOf(
+        minZoom,
+        maxZoom,
+        attribution,
+        scheme,
+        bounds,
+        tileSize,
+        vectorEncoding,
+        rasterDemEncoding,
+      )
+
+  override fun equals(other: Any?): Boolean = other is TileSourceOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
 }

--- a/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/OptionsValueSemanticsTest.kt
+++ b/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/OptionsValueSemanticsTest.kt
@@ -1,0 +1,375 @@
+package org.maplibre.nativeffi
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotSame
+import org.maplibre.nativeffi.camera.AnimationOptions
+import org.maplibre.nativeffi.camera.BoundOptions
+import org.maplibre.nativeffi.camera.CameraFitOptions
+import org.maplibre.nativeffi.camera.CameraOptions
+import org.maplibre.nativeffi.camera.EdgeInsets
+import org.maplibre.nativeffi.camera.FreeCameraOptions
+import org.maplibre.nativeffi.camera.UnitBezier
+import org.maplibre.nativeffi.geo.LatLng
+import org.maplibre.nativeffi.geo.LatLngBounds
+import org.maplibre.nativeffi.geo.Quaternion
+import org.maplibre.nativeffi.geo.ScreenPoint
+import org.maplibre.nativeffi.geo.Vec3
+import org.maplibre.nativeffi.json.JsonValue
+import org.maplibre.nativeffi.map.ConstrainMode
+import org.maplibre.nativeffi.map.MapMode
+import org.maplibre.nativeffi.map.MapOptions
+import org.maplibre.nativeffi.map.NorthOrientation
+import org.maplibre.nativeffi.map.ProjectionModeOptions
+import org.maplibre.nativeffi.map.TileLodMode
+import org.maplibre.nativeffi.map.TileOptions
+import org.maplibre.nativeffi.map.ViewportMode
+import org.maplibre.nativeffi.map.ViewportOptions
+import org.maplibre.nativeffi.query.RenderedFeatureQueryOptions
+import org.maplibre.nativeffi.query.SourceFeatureQueryOptions
+import org.maplibre.nativeffi.runtime.RuntimeOptions
+import org.maplibre.nativeffi.style.RasterDemEncoding
+import org.maplibre.nativeffi.style.StyleImageOptions
+import org.maplibre.nativeffi.style.TileScheme
+import org.maplibre.nativeffi.style.TileSourceOptions
+import org.maplibre.nativeffi.style.VectorTileEncoding
+
+/**
+ * BND-070: option descriptors compare and hash by field value, and copies are independent.
+ *
+ * Each case lists one mutator per declared field. A field left out of the descriptor's equality
+ * fails its mutator assertion, so adding a field without extending equality fails here.
+ */
+class OptionsValueSemanticsTest {
+  private fun <T : Any> assertValueSemantics(
+    baseline: () -> T,
+    copyOf: (T) -> T,
+    mutators: List<T.() -> Unit>,
+  ) {
+    val left = baseline()
+    val right = baseline()
+    assertEquals(left, right)
+    assertEquals(left.hashCode(), right.hashCode())
+
+    val copy = copyOf(left)
+    assertEquals(left, copy)
+    assertNotSame(left, copy)
+
+    mutators.forEachIndexed { index, mutate ->
+      val mutated = baseline().apply(mutate)
+      assertNotEquals(baseline(), mutated, "field $index is missing from equality")
+      assertEquals(mutated, copyOf(mutated), "field $index is missing from copy")
+    }
+  }
+
+  @Test
+  fun cameraOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        CameraOptions().apply {
+          center = LatLng(1.0, 2.0)
+          centerAltitude = 3.0
+          padding = EdgeInsets(4.0, 5.0, 6.0, 7.0)
+          anchor = ScreenPoint(8.0, 9.0)
+          zoom = 10.0
+          bearing = 11.0
+          pitch = 12.0
+          roll = 13.0
+          fieldOfView = 14.0
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf(
+          { center = LatLng(90.0, 90.0) },
+          { centerAltitude = 300.0 },
+          { padding = EdgeInsets.ZERO },
+          { anchor = ScreenPoint(80.0, 90.0) },
+          { zoom = 100.0 },
+          { bearing = 110.0 },
+          { pitch = 120.0 },
+          { roll = 130.0 },
+          { fieldOfView = 140.0 },
+        ),
+    )
+  }
+
+  @Test
+  fun animationOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        AnimationOptions().apply {
+          durationMs = 1.0
+          velocity = 2.0
+          minZoom = 3.0
+          easing = UnitBezier(0.1, 0.2, 0.3, 0.4)
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf(
+          { durationMs = 10.0 },
+          { velocity = 20.0 },
+          { minZoom = 30.0 },
+          { easing = UnitBezier(0.9, 0.8, 0.7, 0.6) },
+        ),
+    )
+  }
+
+  @Test
+  fun boundOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        BoundOptions().apply {
+          bounds = LatLngBounds(LatLng(0.0, 0.0), LatLng(1.0, 1.0))
+          minZoom = 2.0
+          maxZoom = 3.0
+          minPitch = 4.0
+          maxPitch = 5.0
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf(
+          { bounds = LatLngBounds(LatLng(-1.0, -1.0), LatLng(2.0, 2.0)) },
+          { minZoom = 20.0 },
+          { maxZoom = 30.0 },
+          { minPitch = 40.0 },
+          { maxPitch = 50.0 },
+        ),
+    )
+  }
+
+  @Test
+  fun cameraFitOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        CameraFitOptions().apply {
+          padding = EdgeInsets(1.0, 2.0, 3.0, 4.0)
+          bearing = 5.0
+          pitch = 6.0
+        }
+      },
+      copyOf = { it.copy() },
+      mutators = listOf({ padding = EdgeInsets.ZERO }, { bearing = 50.0 }, { pitch = 60.0 }),
+    )
+  }
+
+  @Test
+  fun freeCameraOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        FreeCameraOptions().apply {
+          position = Vec3(1.0, 2.0, 3.0)
+          orientation = Quaternion(0.0, 0.0, 0.0, 1.0)
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf({ position = Vec3(9.0, 9.0, 9.0) }, { orientation = Quaternion(1.0, 0.0, 0.0, 0.0) }),
+    )
+  }
+
+  @Test
+  fun viewportOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        ViewportOptions().apply {
+          northOrientation = NorthOrientation(0)
+          constrainMode = ConstrainMode(0)
+          viewportMode = ViewportMode(0)
+          frustumOffset = EdgeInsets(1.0, 2.0, 3.0, 4.0)
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf(
+          { northOrientation = NorthOrientation(2) },
+          { constrainMode = ConstrainMode(1) },
+          { viewportMode = ViewportMode(1) },
+          { frustumOffset = EdgeInsets.ZERO },
+        ),
+    )
+  }
+
+  @Test
+  fun tileOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        TileOptions().apply {
+          prefetchZoomDelta = 1
+          lodMinRadius = 2.0
+          lodScale = 3.0
+          lodPitchThreshold = 4.0
+          lodZoomShift = 5.0
+          lodMode = TileLodMode(0)
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf(
+          { prefetchZoomDelta = 7 },
+          { lodMinRadius = 20.0 },
+          { lodScale = 30.0 },
+          { lodPitchThreshold = 40.0 },
+          { lodZoomShift = 50.0 },
+          { lodMode = TileLodMode(1) },
+        ),
+    )
+  }
+
+  @Test
+  fun projectionModeOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        ProjectionModeOptions().apply {
+          axonometric = true
+          xSkew = 1.0
+          ySkew = 2.0
+        }
+      },
+      copyOf = { it.copy() },
+      mutators = listOf({ axonometric = false }, { xSkew = 10.0 }, { ySkew = 20.0 }),
+    )
+  }
+
+  @Test
+  fun mapOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        MapOptions().apply {
+          width = 100
+          height = 200
+          scaleFactor = 2.0
+          mapMode = MapMode(0)
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf({ width = 300 }, { height = 400 }, { scaleFactor = 3.0 }, { mapMode = MapMode(1) }),
+    )
+  }
+
+  @Test
+  fun runtimeOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        RuntimeOptions().apply {
+          assetPath = "assets"
+          cachePath = "cache"
+          maximumCacheSize = 1024L
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf(
+          { assetPath = "other-assets" },
+          { cachePath = "other-cache" },
+          { maximumCacheSize = 2048L },
+        ),
+    )
+  }
+
+  @Test
+  fun tileSourceOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        TileSourceOptions().apply {
+          minZoom = 1.0
+          maxZoom = 2.0
+          attribution = "attribution"
+          scheme = TileScheme.XYZ
+          bounds = LatLngBounds(LatLng(0.0, 0.0), LatLng(1.0, 1.0))
+          tileSize = 256
+          vectorEncoding = VectorTileEncoding.MVT
+          rasterDemEncoding = RasterDemEncoding.MAPBOX
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf(
+          { minZoom = 10.0 },
+          { maxZoom = 20.0 },
+          { attribution = "other" },
+          { scheme = TileScheme.TMS },
+          { bounds = LatLngBounds(LatLng(-1.0, -1.0), LatLng(2.0, 2.0)) },
+          { tileSize = 512 },
+          { vectorEncoding = VectorTileEncoding.MLT },
+          { rasterDemEncoding = RasterDemEncoding.TERRARIUM },
+        ),
+    )
+  }
+
+  @Test
+  fun styleImageOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        StyleImageOptions().apply {
+          pixelRatio = 2.0f
+          sdf = true
+        }
+      },
+      copyOf = { it.copy() },
+      mutators = listOf({ pixelRatio = 3.0f }, { sdf = false }),
+    )
+  }
+
+  @Test
+  fun renderedFeatureQueryOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        RenderedFeatureQueryOptions().apply {
+          layerIds = listOf("a", "b")
+          filter = JsonValue.Bool(true)
+        }
+      },
+      copyOf = { it.copy() },
+      mutators = listOf({ layerIds = listOf("a") }, { filter = JsonValue.StringValue("filter") }),
+    )
+  }
+
+  @Test
+  fun sourceFeatureQueryOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        SourceFeatureQueryOptions().apply {
+          sourceLayerIds = listOf("a", "b")
+          filter = JsonValue.Bool(true)
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf({ sourceLayerIds = listOf("a") }, { filter = JsonValue.StringValue("filter") }),
+    )
+  }
+
+  @Test
+  fun absentLayerIdsDifferFromEmptyLayerIds() {
+    // The native field mask distinguishes an absent layer filter from an empty one.
+    val absent = RenderedFeatureQueryOptions()
+    val empty = RenderedFeatureQueryOptions().apply { layerIds = emptyList() }
+
+    assertNotEquals(absent, empty)
+  }
+
+  @Test
+  fun copyBlockAppliesToTheCopyOnly() {
+    val original = CameraOptions().apply { zoom = 1.0 }
+    val derived = original.copy { zoom = 2.0 }
+
+    assertEquals(1.0, original.zoom)
+    assertEquals(2.0, derived.zoom)
+  }
+
+  @Test
+  fun copiedQueryOptionsSnapshotCallerOwnedLayerIds() {
+    // BND-069: a copy does not observe later mutation of the caller's list.
+    val layerIds = mutableListOf("a")
+    val copy = RenderedFeatureQueryOptions().apply { this.layerIds = layerIds }.copy()
+
+    layerIds.add("b")
+
+    assertEquals(listOf("a"), copy.layerIds)
+  }
+}

--- a/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/OptionsValueSemanticsTest.kt
+++ b/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/OptionsValueSemanticsTest.kt
@@ -363,13 +363,22 @@ class OptionsValueSemanticsTest {
   }
 
   @Test
-  fun copiedQueryOptionsSnapshotCallerOwnedLayerIds() {
-    // BND-069: a copy does not observe later mutation of the caller's list.
+  fun queryOptionsSnapshotCallerOwnedLayerIds() {
+    // BND-069: neither the descriptor nor its copy observes later mutation of the caller's list.
     val layerIds = mutableListOf("a")
-    val copy = RenderedFeatureQueryOptions().apply { this.layerIds = layerIds }.copy()
+    val options = RenderedFeatureQueryOptions().apply { this.layerIds = layerIds }
+    val copy = options.copy()
 
     layerIds.add("b")
 
+    assertEquals(listOf("a"), options.layerIds)
     assertEquals(listOf("a"), copy.layerIds)
+
+    val sourceLayerIds = mutableListOf("a")
+    val sourceOptions = SourceFeatureQueryOptions().apply { this.sourceLayerIds = sourceLayerIds }
+
+    sourceLayerIds.add("b")
+
+    assertEquals(listOf("a"), sourceOptions.sourceLayerIds)
   }
 }

--- a/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/map/MapHandleTest.kt
+++ b/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/map/MapHandleTest.kt
@@ -525,6 +525,8 @@ class MapHandleTest {
       map.jumpTo(camera)
       assertNear(requireNotNull(camera.center), requireNotNull(map.camera.center))
       assertEquals(3.0, map.camera.zoom ?: 0.0, 1e-6)
+      // BND-070: successive snapshots of an unchanged camera compare equal.
+      assertEquals(map.camera, map.camera)
 
       val animation =
         AnimationOptions().apply {

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/MapCameraControlsTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/MapCameraControlsTest.kt
@@ -72,6 +72,8 @@ class MapCameraControlsTest : org.maplibre.nativeffi.NativeTestBase() {
         assertEquals(0.0, assertNotNull(camera.center).latitude, 0.000001)
         assertEquals(0.0, assertNotNull(camera.center).longitude, 0.000001)
         assertEquals(1.0, assertNotNull(camera.zoom), 0.000001)
+        // BND-070: successive snapshots of an unchanged camera compare equal.
+        assertEquals(camera, map.camera)
         map.easeTo(cameraOptions, animation)
         map.flyTo(cameraOptions, animation)
         map.moveBy(0.0, 0.0)

--- a/docs/src/content/docs/development/binding-specification.md
+++ b/docs/src/content/docs/development/binding-specification.md
@@ -239,6 +239,29 @@ C struct materialization follows this operation:
 
 Structs that C fills and returns by value become copied language values.
 
+### Value semantics
+
+Public option types, copied result values, geometry and feature trees, and
+values wrapping copied byte buffers compare by field value using the target
+language's ordinary equality operation. Option types additionally expose a copy
+operation that produces an independent instance. Callers diff successive
+snapshots and derive modified descriptors without reaching for reference
+identity.
+
+Equality covers every semantic field the value carries, including private copied
+storage, list-valued fields, and nested value trees, and distinguishes an absent
+optional field from a present empty or zero value. Languages whose default
+equality compares collection, array, or pointer members by identity supply the
+comparison that inspects the contents instead, at every level of nesting.
+
+Values that hold callbacks, delegates, or native handles keep identity
+semantics, because behavior rather than field values determines whether two such
+values are interchangeable.
+
+Where the target language hashes values, the hash covers the same fields as
+equality. Values that stay mutable document that an instance in a hash-based
+collection stays unmodified while it is a key.
+
 ### Enums and masks
 
 Public enum values expose named cases for known C values and keep the
@@ -610,18 +633,20 @@ that a real native failure would expose.
 
 ### Input Structs, Values, and Copied Data
 
-| ID      | Test                                                                                                                                                                                               |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| BND-060 | Each public API family that accepts input structs has at least one test that initializes C defaults, `size` fields, field masks, and nested inputs.                                                |
-| BND-061 | Optional field-mask inputs distinguish absent values from present zero values.                                                                                                                     |
-| BND-062 | Unknown output enum values preserve the raw native value, using an internal conversion hook when no real C call can produce one.                                                                   |
-| BND-063 | Borrowed native strings and string views are copied before their native borrow window ends.                                                                                                        |
-| BND-064 | JSON values round-trip scalar and nested container values without type loss.                                                                                                                       |
-| BND-065 | GeoJSON values copy nested geometries, features, properties, and identifiers.                                                                                                                      |
-| BND-066 | Native snapshot/list/result handles are released on success and on copy failure, using fault injection for copy failure.                                                                           |
-| BND-067 | Structured JSON preserves object member order, repeated member names, and signed or unsigned integer width.                                                                                        |
-| BND-068 | Unknown enum values preserve their raw value, and public input APIs report the C API's status and diagnostic unless the binding owns a stricter pre-C invariant.                                   |
-| BND-069 | Public values and descriptors that accept caller-owned mutable storage remain unchanged after later caller mutation, and accessors do not expose mutable storage that can mutate the stored value. |
+| ID      | Test                                                                                                                                                                                                       |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BND-060 | Each public API family that accepts input structs has at least one test that initializes C defaults, `size` fields, field masks, and nested inputs.                                                        |
+| BND-061 | Optional field-mask inputs distinguish absent values from present zero values.                                                                                                                             |
+| BND-062 | Unknown output enum values preserve the raw native value, using an internal conversion hook when no real C call can produce one.                                                                           |
+| BND-063 | Borrowed native strings and string views are copied before their native borrow window ends.                                                                                                                |
+| BND-064 | JSON values round-trip scalar and nested container values without type loss.                                                                                                                               |
+| BND-065 | GeoJSON values copy nested geometries, features, properties, and identifiers.                                                                                                                              |
+| BND-066 | Native snapshot/list/result handles are released on success and on copy failure, using fault injection for copy failure.                                                                                   |
+| BND-067 | Structured JSON preserves object member order, repeated member names, and signed or unsigned integer width.                                                                                                |
+| BND-068 | Unknown enum values preserve their raw value, and public input APIs report the C API's status and diagnostic unless the binding owns a stricter pre-C invariant.                                           |
+| BND-069 | Public values and descriptors that accept caller-owned mutable storage remain unchanged after later caller mutation, and accessors do not expose mutable storage that can mutate the stored value.         |
+| BND-070 | Option types compare and hash by field value, separate absent optional fields from present empty or zero values, and copy to an independent instance; one case per option type mutates each field in turn. |
+| BND-071 | Copied result values, nested geometry and feature trees, and values wrapping copied byte buffers compare by content when built from distinct list or array instances holding equal contents.               |
 
 ### Runtime and events
 


### PR DESCRIPTION
## Summary

- Add value-based equality and hashing across Kotlin, .NET, and Go binding option types.
- Compare nested lists and byte buffers structurally instead of by reference.
- Add comprehensive value-semantics tests and update the binding specification.

## Testing

- Not run.