### PR TITLE
Snapshot caller-owned lists in .NET value trees

### DIFF
--- a/bindings/dotnet/src/Maplibre.Native/Geo/Feature.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Geo/Feature.cs
@@ -27,6 +27,7 @@ public abstract record FeatureIdentifier
 /// <summary>GeoJSON feature value.</summary>
 /// <remarks>
 /// <see cref="Properties"/> compares member by member, preserving order and repeated member names.
+/// Construction and <c>with</c> snapshot the caller's list.
 /// </remarks>
 public sealed record Feature(
     Geometry Geometry,
@@ -34,14 +35,22 @@ public sealed record Feature(
     FeatureIdentifier Identifier
 )
 {
+    private readonly IReadOnlyList<JsonMember> properties = ValueEquality.Snapshot(Properties);
+
+    public IReadOnlyList<JsonMember> Properties
+    {
+        get => properties;
+        init => properties = ValueEquality.Snapshot(value);
+    }
+
     public bool Equals(Feature? other) =>
         other is not null
         && Equals(Geometry, other.Geometry)
-        && ValueEquality.SequenceEquals(Properties, other.Properties)
+        && ValueEquality.SequenceEquals(properties, other.properties)
         && Equals(Identifier, other.Identifier);
 
     public override int GetHashCode() =>
-        HashCode.Combine(Geometry, ValueEquality.SequenceHashCode(Properties), Identifier);
+        HashCode.Combine(Geometry, ValueEquality.SequenceHashCode(properties), Identifier);
 }
 
 /// <summary>GeoJSON value.</summary>
@@ -55,9 +64,17 @@ public abstract record GeoJson
 
     public sealed record FeatureCollection(IReadOnlyList<Feature> Features) : GeoJson
     {
-        public bool Equals(FeatureCollection? other) =>
-            other is not null && ValueEquality.SequenceEquals(Features, other.Features);
+        private readonly IReadOnlyList<Feature> features = ValueEquality.Snapshot(Features);
 
-        public override int GetHashCode() => ValueEquality.SequenceHashCode(Features);
+        public IReadOnlyList<Feature> Features
+        {
+            get => features;
+            init => features = ValueEquality.Snapshot(value);
+        }
+
+        public bool Equals(FeatureCollection? other) =>
+            other is not null && ValueEquality.SequenceEquals(features, other.features);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(features);
     }
 }

--- a/bindings/dotnet/src/Maplibre.Native/Geo/Geometry.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Geo/Geometry.cs
@@ -5,7 +5,8 @@ namespace Maplibre.Native.Geo;
 /// <summary>Immutable geometry tree used by Maplibre descriptors and copied results.</summary>
 /// <remarks>
 /// Coordinate lists compare element by element, so geometries built from distinct list instances
-/// holding the same coordinates compare equal.
+/// holding the same coordinates compare equal. Construction and <c>with</c> snapshot the caller's
+/// lists at every level, so later caller mutation does not change the geometry.
 /// </remarks>
 public abstract record Geometry
 {
@@ -24,59 +25,112 @@ public abstract record Geometry
 
     public sealed record LineString(IReadOnlyList<LatLng> Coordinates) : Geometry
     {
-        public bool Equals(LineString? other) =>
-            other is not null && ValueEquality.SequenceEquals(Coordinates, other.Coordinates);
+        private readonly IReadOnlyList<LatLng> coordinates = ValueEquality.Snapshot(Coordinates);
 
-        public override int GetHashCode() => ValueEquality.SequenceHashCode(Coordinates);
+        public IReadOnlyList<LatLng> Coordinates
+        {
+            get => coordinates;
+            init => coordinates = ValueEquality.Snapshot(value);
+        }
+
+        public bool Equals(LineString? other) =>
+            other is not null && ValueEquality.SequenceEquals(coordinates, other.coordinates);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(coordinates);
     }
 
     public sealed record Polygon(IReadOnlyList<IReadOnlyList<LatLng>> Rings) : Geometry
     {
-        public bool Equals(Polygon? other) =>
-            other is not null && ValueEquality.NestedSequenceEquals(Rings, other.Rings);
+        private readonly IReadOnlyList<IReadOnlyList<LatLng>> rings = ValueEquality.NestedSnapshot(
+            Rings
+        );
 
-        public override int GetHashCode() => ValueEquality.NestedSequenceHashCode(Rings);
+        public IReadOnlyList<IReadOnlyList<LatLng>> Rings
+        {
+            get => rings;
+            init => rings = ValueEquality.NestedSnapshot(value);
+        }
+
+        public bool Equals(Polygon? other) =>
+            other is not null && ValueEquality.NestedSequenceEquals(rings, other.rings);
+
+        public override int GetHashCode() => ValueEquality.NestedSequenceHashCode(rings);
     }
 
     public sealed record MultiPoint(IReadOnlyList<LatLng> Coordinates) : Geometry
     {
-        public bool Equals(MultiPoint? other) =>
-            other is not null && ValueEquality.SequenceEquals(Coordinates, other.Coordinates);
+        private readonly IReadOnlyList<LatLng> coordinates = ValueEquality.Snapshot(Coordinates);
 
-        public override int GetHashCode() => ValueEquality.SequenceHashCode(Coordinates);
+        public IReadOnlyList<LatLng> Coordinates
+        {
+            get => coordinates;
+            init => coordinates = ValueEquality.Snapshot(value);
+        }
+
+        public bool Equals(MultiPoint? other) =>
+            other is not null && ValueEquality.SequenceEquals(coordinates, other.coordinates);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(coordinates);
     }
 
     public sealed record MultiLineString(IReadOnlyList<IReadOnlyList<LatLng>> Lines) : Geometry
     {
-        public bool Equals(MultiLineString? other) =>
-            other is not null && ValueEquality.NestedSequenceEquals(Lines, other.Lines);
+        private readonly IReadOnlyList<IReadOnlyList<LatLng>> lines = ValueEquality.NestedSnapshot(
+            Lines
+        );
 
-        public override int GetHashCode() => ValueEquality.NestedSequenceHashCode(Lines);
+        public IReadOnlyList<IReadOnlyList<LatLng>> Lines
+        {
+            get => lines;
+            init => lines = ValueEquality.NestedSnapshot(value);
+        }
+
+        public bool Equals(MultiLineString? other) =>
+            other is not null && ValueEquality.NestedSequenceEquals(lines, other.lines);
+
+        public override int GetHashCode() => ValueEquality.NestedSequenceHashCode(lines);
     }
 
     public sealed record MultiPolygon(IReadOnlyList<IReadOnlyList<IReadOnlyList<LatLng>>> Polygons)
         : Geometry
     {
+        private readonly IReadOnlyList<IReadOnlyList<IReadOnlyList<LatLng>>> polygons =
+            ValueEquality.DeepNestedSnapshot(Polygons);
+
+        public IReadOnlyList<IReadOnlyList<IReadOnlyList<LatLng>>> Polygons
+        {
+            get => polygons;
+            init => polygons = ValueEquality.DeepNestedSnapshot(value);
+        }
+
         public bool Equals(MultiPolygon? other) =>
             other is not null
             && ValueEquality.SequenceEquals(
-                Polygons,
-                other.Polygons,
+                polygons,
+                other.polygons,
                 static (left, right) => ValueEquality.NestedSequenceEquals(left, right)
             );
 
         public override int GetHashCode() =>
             ValueEquality.SequenceHashCode(
-                Polygons,
+                polygons,
                 static value => ValueEquality.NestedSequenceHashCode(value)
             );
     }
 
     public sealed record Collection(IReadOnlyList<Geometry> Geometries) : Geometry
     {
-        public bool Equals(Collection? other) =>
-            other is not null && ValueEquality.SequenceEquals(Geometries, other.Geometries);
+        private readonly IReadOnlyList<Geometry> geometries = ValueEquality.Snapshot(Geometries);
 
-        public override int GetHashCode() => ValueEquality.SequenceHashCode(Geometries);
+        public IReadOnlyList<Geometry> Geometries
+        {
+            get => geometries;
+            init => geometries = ValueEquality.Snapshot(value);
+        }
+
+        public bool Equals(Collection? other) =>
+            other is not null && ValueEquality.SequenceEquals(geometries, other.geometries);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(geometries);
     }
 }

--- a/bindings/dotnet/src/Maplibre.Native/Internal/ValueEquality.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Internal/ValueEquality.cs
@@ -1,12 +1,30 @@
 namespace Maplibre.Native.Internal;
 
 /// <summary>
-/// Structural comparison helpers for public value types that hold list-valued members. Record
-/// synthesis compares such members by reference, so types holding them supply their own
-/// <c>Equals</c> and <c>GetHashCode</c> built on these helpers.
+/// Structural comparison and snapshot helpers for public value types that hold list-valued
+/// members. Record synthesis compares such members by reference and stores the caller's list, so
+/// types holding them supply their own <c>Equals</c>, <c>GetHashCode</c>, and <c>init</c>
+/// accessors built on these helpers.
 /// </summary>
 internal static class ValueEquality
 {
+    /// <summary>Copies a caller-owned list into storage the caller cannot mutate.</summary>
+    internal static IReadOnlyList<T> Snapshot<T>(IReadOnlyList<T>? values) =>
+        values is null || values.Count == 0 ? [] : Array.AsReadOnly([.. values]);
+
+    /// <summary>Copies a caller-owned list of lists at both levels.</summary>
+    internal static IReadOnlyList<IReadOnlyList<T>> NestedSnapshot<T>(
+        IReadOnlyList<IReadOnlyList<T>>? values
+    ) => values is null || values.Count == 0 ? [] : Array.AsReadOnly([.. values.Select(Snapshot)]);
+
+    /// <summary>Copies a caller-owned list of lists of lists at all three levels.</summary>
+    internal static IReadOnlyList<IReadOnlyList<IReadOnlyList<T>>> DeepNestedSnapshot<T>(
+        IReadOnlyList<IReadOnlyList<IReadOnlyList<T>>>? values
+    ) =>
+        values is null || values.Count == 0
+            ? []
+            : Array.AsReadOnly([.. values.Select(NestedSnapshot)]);
+
     internal static bool SequenceEquals<T>(IReadOnlyList<T>? left, IReadOnlyList<T>? right) =>
         SequenceEquals(left, right, static (a, b) => EqualityComparer<T>.Default.Equals(a, b));
 

--- a/bindings/dotnet/src/Maplibre.Native/Json/JsonValue.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Json/JsonValue.cs
@@ -28,18 +28,34 @@ public abstract record JsonValue
 
     public sealed record Array(IReadOnlyList<JsonValue> Values) : JsonValue
     {
-        public bool Equals(Array? other) =>
-            other is not null && ValueEquality.SequenceEquals(Values, other.Values);
+        private readonly IReadOnlyList<JsonValue> values = ValueEquality.Snapshot(Values);
 
-        public override int GetHashCode() => ValueEquality.SequenceHashCode(Values);
+        public IReadOnlyList<JsonValue> Values
+        {
+            get => values;
+            init => values = ValueEquality.Snapshot(value);
+        }
+
+        public bool Equals(Array? other) =>
+            other is not null && ValueEquality.SequenceEquals(values, other.values);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(values);
     }
 
     public sealed record Object(IReadOnlyList<JsonMember> Members) : JsonValue
     {
-        public bool Equals(Object? other) =>
-            other is not null && ValueEquality.SequenceEquals(Members, other.Members);
+        private readonly IReadOnlyList<JsonMember> members = ValueEquality.Snapshot(Members);
 
-        public override int GetHashCode() => ValueEquality.SequenceHashCode(Members);
+        public IReadOnlyList<JsonMember> Members
+        {
+            get => members;
+            init => members = ValueEquality.Snapshot(value);
+        }
+
+        public bool Equals(Object? other) =>
+            other is not null && ValueEquality.SequenceEquals(members, other.members);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(members);
     }
 }
 

--- a/bindings/dotnet/src/Maplibre.Native/Query/QueryTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Query/QueryTypes.cs
@@ -22,10 +22,18 @@ public abstract record RenderedQueryGeometry
 
     public sealed record LineString(IReadOnlyList<ScreenPoint> Points) : RenderedQueryGeometry
     {
-        public bool Equals(LineString? other) =>
-            other is not null && ValueEquality.SequenceEquals(Points, other.Points);
+        private readonly IReadOnlyList<ScreenPoint> points = ValueEquality.Snapshot(Points);
 
-        public override int GetHashCode() => ValueEquality.SequenceHashCode(Points);
+        public IReadOnlyList<ScreenPoint> Points
+        {
+            get => points;
+            init => points = ValueEquality.Snapshot(value);
+        }
+
+        public bool Equals(LineString? other) =>
+            other is not null && ValueEquality.SequenceEquals(points, other.points);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(points);
     }
 }
 
@@ -98,10 +106,18 @@ public abstract record FeatureExtensionResult
 
     public sealed record FeatureCollection(IReadOnlyList<Feature> Features) : FeatureExtensionResult
     {
-        public bool Equals(FeatureCollection? other) =>
-            other is not null && ValueEquality.SequenceEquals(Features, other.Features);
+        private readonly IReadOnlyList<Feature> features = ValueEquality.Snapshot(Features);
 
-        public override int GetHashCode() => ValueEquality.SequenceHashCode(Features);
+        public IReadOnlyList<Feature> Features
+        {
+            get => features;
+            init => features = ValueEquality.Snapshot(value);
+        }
+
+        public bool Equals(FeatureCollection? other) =>
+            other is not null && ValueEquality.SequenceEquals(features, other.features);
+
+        public override int GetHashCode() => ValueEquality.SequenceHashCode(features);
     }
 
     public sealed record Unknown(uint RawType) : FeatureExtensionResult;

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/ValueSnapshotTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/ValueSnapshotTests.cs
@@ -1,0 +1,154 @@
+using Maplibre.Native.Geo;
+using Maplibre.Native.Json;
+using Maplibre.Native.Query;
+using Xunit;
+
+namespace Maplibre.Native.Tests;
+
+/// <summary>
+/// BND-069: public value trees snapshot caller-owned lists, so later caller mutation leaves the
+/// stored value, its equality, and its hash code unchanged. Matches the Kotlin binding, whose
+/// container constructors copy at every level.
+/// </summary>
+public sealed class ValueSnapshotTests
+{
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void FlatGeometriesSnapshotCallerLists()
+    {
+        var coordinates = new List<LatLng> { new(0, 0) };
+        var line = new Geometry.LineString(coordinates);
+        var multiPoint = new Geometry.MultiPoint(coordinates);
+        var expectedHash = line.GetHashCode();
+
+        coordinates.Add(new LatLng(9, 9));
+
+        Assert.Single(line.Coordinates);
+        Assert.Single(multiPoint.Coordinates);
+        Assert.Equal(expectedHash, line.GetHashCode());
+    }
+
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void NestedGeometriesSnapshotInnerLists()
+    {
+        var ring = new List<LatLng> { new(0, 0) };
+        var rings = new List<IReadOnlyList<LatLng>> { ring };
+        var polygon = new Geometry.Polygon(rings);
+        var multiLine = new Geometry.MultiLineString(rings);
+
+        // Mutating either level must not reach the stored geometry.
+        ring.Add(new LatLng(9, 9));
+        rings.Add(new List<LatLng> { new(5, 5) });
+
+        Assert.Single(polygon.Rings);
+        Assert.Single(polygon.Rings[0]);
+        Assert.Single(multiLine.Lines);
+        Assert.Single(multiLine.Lines[0]);
+    }
+
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void MultiPolygonSnapshotsAllThreeLevels()
+    {
+        var ring = new List<LatLng> { new(0, 0) };
+        var rings = new List<IReadOnlyList<LatLng>> { ring };
+        var polygons = new List<IReadOnlyList<IReadOnlyList<LatLng>>> { rings };
+        var multiPolygon = new Geometry.MultiPolygon(polygons);
+
+        ring.Add(new LatLng(9, 9));
+        rings.Add(new List<LatLng> { new(5, 5) });
+        polygons.Add(rings);
+
+        Assert.Single(multiPolygon.Polygons);
+        Assert.Single(multiPolygon.Polygons[0]);
+        Assert.Single(multiPolygon.Polygons[0][0]);
+    }
+
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void GeometryCollectionsSnapshotCallerLists()
+    {
+        var geometries = new List<Geometry> { Geometry.Empty.Instance };
+        var collection = new Geometry.Collection(geometries);
+
+        geometries.Add(new Geometry.Point(new LatLng(1, 1)));
+
+        Assert.Single(collection.Geometries);
+    }
+
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void FeaturesAndFeatureCollectionsSnapshotCallerLists()
+    {
+        var properties = new List<JsonMember> { new("k", new JsonValue.Int(1)) };
+        var feature = new Feature(
+            Geometry.Empty.Instance,
+            properties,
+            FeatureIdentifier.Null.Instance
+        );
+
+        var features = new List<Feature> { feature };
+        var geoJson = new GeoJson.FeatureCollection(features);
+        var extension = new FeatureExtensionResult.FeatureCollection(features);
+
+        properties.Add(new JsonMember("other", new JsonValue.Int(2)));
+        features.Add(feature);
+
+        Assert.Single(feature.Properties);
+        Assert.Single(geoJson.Features);
+        Assert.Single(extension.Features);
+    }
+
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void JsonContainersSnapshotCallerLists()
+    {
+        var values = new List<JsonValue> { new JsonValue.Int(1) };
+        var array = new JsonValue.Array(values);
+
+        var members = new List<JsonMember> { new("k", new JsonValue.Int(1)) };
+        var jsonObject = new JsonValue.Object(members);
+
+        values.Add(new JsonValue.Int(2));
+        members.Add(new JsonMember("other", new JsonValue.Int(2)));
+
+        Assert.Single(array.Values);
+        Assert.Single(jsonObject.Members);
+    }
+
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void RenderedQueryLineStringSnapshotsCallerList()
+    {
+        var points = new List<ScreenPoint> { new(1, 2) };
+        var line = new RenderedQueryGeometry.LineString(points);
+
+        points.Add(new ScreenPoint(3, 4));
+
+        Assert.Single(line.Points);
+    }
+
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void WithAlsoSnapshotsTheAssignedList()
+    {
+        var replacement = new List<LatLng> { new(0, 0) };
+        var line = new Geometry.LineString([new LatLng(7, 7)]) with { Coordinates = replacement };
+
+        replacement.Add(new LatLng(9, 9));
+
+        Assert.Single(line.Coordinates);
+        Assert.Equal(new LatLng(0, 0), line.Coordinates[0]);
+    }
+
+    [BindingSpecTest("BND-069")]
+    [Fact]
+    public void ExposedListsCannotBeCastBackToMutableStorage()
+    {
+        var line = new Geometry.LineString([new LatLng(0, 0)]);
+
+        Assert.IsNotType<LatLng[]>(line.Coordinates);
+        Assert.IsNotType<List<LatLng>>(line.Coordinates);
+    }
+}


### PR DESCRIPTION
## Summary

.NET geometry, feature, GeoJSON, JSON container, and query result values stored the caller's list by reference, so later caller mutation silently changed the value and moved its hash code; construction and `with` now snapshot at every nesting level, matching the Kotlin containers.

## Test plan

`mise run //bindings/dotnet:test` (176 passing, including a new `ValueSnapshotTests` case per container type).

## AI assistance

- **Tools:** Claude Code
- **Context:** Follow-up to #342, which made these types compare by content and so turned this pre-existing aliasing into a hash-stability bug.