### PR TITLE
Fix CI regressions from the render resize PR

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -266,21 +266,23 @@ runs:
       if: ${{ startsWith(inputs.target, 'windows-') && endsWith(inputs.target, '-vulkan') }}
       shell: pwsh
       run: |
-        # Where the loader sits differs by SDK: the x64 SDK groups it under
-        # runtime by architecture, while the ARM64 SDK carries it in Bin. Both
-        # folders belong to the SDK being installed, so neither can offer a
-        # loader built for another architecture. This is the search
-        # cmake/render/vulkan.cmake performs for the same file.
+        # Where the loader sits differs by runner: the x64 SDK groups it under
+        # runtime by architecture, while the ARM64 runner carries it in
+        # System32 rather than anywhere inside the SDK. Neither location can
+        # offer a loader built for another architecture. The SDK search
+        # mirrors cmake/render/vulkan.cmake; the PATH fallback mirrors what
+        # find_file there resolves on runners that already have the loader.
         $architecture = if ($env:RUNNER_ARCH -eq "ARM64") { "arm64" } else { "x64" }
         $candidates = @("runtime\$architecture", "Bin", "bin") |
           ForEach-Object { Join-Path $env:VULKAN_SDK $_ }
         $directory = $candidates |
           Where-Object { Test-Path (Join-Path $_ "vulkan-1.dll") } |
           Select-Object -First 1
-        if (-not $directory) {
-          throw "no vulkan-1.dll in $($candidates -join ', ')"
+        if ($directory) {
+          $directory | Out-File -FilePath $env:GITHUB_PATH -Append
+        } elseif (-not (Get-Command vulkan-1.dll -ErrorAction SilentlyContinue)) {
+          throw "no vulkan-1.dll in $($candidates -join ', ') or on PATH"
         }
-        $directory | Out-File -FilePath $env:GITHUB_PATH -Append
 
     - name: Bootstrap repository
       uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/RenderTargetExtentNative.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/RenderTargetExtentNative.kt
@@ -1,5 +1,6 @@
 package org.maplibre.nativeffi.render
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.UIntVar
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
@@ -10,6 +11,7 @@ import org.maplibre.nativeffi.internal.c.mln_render_target_extent
 import org.maplibre.nativeffi.internal.c.mln_render_target_extent_physical_size
 import org.maplibre.nativeffi.internal.status.Status
 
+@OptIn(ExperimentalForeignApi::class)
 public actual fun RenderTargetExtent.physicalSize(): PhysicalRenderTargetSize = memScoped {
   val nativeExtent = alloc<mln_render_target_extent>()
   nativeExtent.size = sizeOf<mln_render_target_extent>().toUInt()

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -1785,6 +1785,8 @@ test "Metal borrowed texture renders through public bindings" {
 
     var session = try maplibre.attachMetalBorrowedTexture(&map, .{
         .extent = .{ .width = 128, .height = 128 },
+        .physical_width = 128,
+        .physical_height = 128,
         .texture = maplibre.NativePointer.fromPtr(borrowed),
     });
     defer session.close() catch {};


### PR DESCRIPTION
## Summary

Fix the Apple build breaks from #343 (missing Kotlin/Native opt-in and zig test fields) and the ARM64 Vulkan loader lookup from #341 (loader is only on PATH via System32 there, not in the SDK).

## Test plan

Verified `zig build test` (macos-arm64-metal) and `:bindings:kotlin:compileKotlinMacosArm64` locally; Windows jobs validated by CI.