### PR TITLE
Document C API contracts that only the source stated

### DIFF
--- a/docs/src/content/docs/concepts.md
+++ b/docs/src/content/docs/concepts.md
@@ -31,6 +31,11 @@ A map is independent of any particular render target. Host code can create,
 configure, query, and observe the map without tying that map state to a window,
 surface, or texture.
 
+Sources and layers are added as style-spec JSON, which keeps the API in step
+with the style specification across every layer type. Typed entry points exist
+where a layer needs a surface beyond construction, such as source-type
+validation or typed per-frame setters.
+
 ## Render Session
 
 A render session renders one map to one render target. Render targets are
@@ -52,6 +57,12 @@ events from the runtime.
 
 Events report map lifecycle, rendering progress, resource activity, diagnostics,
 and asynchronous failures.
+
+Queued events belong to their source. Destroying a map discards that map's
+queued events without a flush or a terminal event, so host state mirrored from
+events is only as current as the last drain before teardown. Snapshot the state
+a host needs synchronously while the map is live, and let teardown run to
+completion rather than waiting on an event from the map being destroyed.
 
 ## Language Bindings
 

--- a/docs/src/content/docs/development/c-conventions.md
+++ b/docs/src/content/docs/development/c-conventions.md
@@ -84,7 +84,10 @@ commands. Document that behavior on the function. Higher-level adapters build
 threaded models above the C API.
 
 MapLibre's `RunLoop` is owner-thread scheduler state. Each owner thread may hold
-one live runtime. `mln_runtime_run_once()` pumps that runtime's run loop.
+one live runtime. `mln_runtime_run_once()` pumps that runtime's run loop. One
+call drains the queued tasks, expired timers, and ready I/O it finds, including
+work enqueued while it runs, and returns without blocking for more. Document
+pump entry points as draining rather than as a bounded per-call budget.
 
 ## Status And Diagnostics
 

--- a/docs/src/content/docs/development/map-example-specification.md
+++ b/docs/src/content/docs/development/map-example-specification.md
@@ -220,7 +220,9 @@ On host termination or fatal error, close resources in order:
 
 The C API treats runtime pumping and presentation as separate concerns.
 `run_once` advances native scheduler work and fills the event queue; it is not
-display-driven. `render_update` draws only when `render_pending` is true.
+display-driven. One call drains the work it finds instead of running a fixed
+slice, so a single call can take as long as a style parse. `render_update` draws
+only when `render_pending` is true.
 
 `*-map` examples integrate both through a **display-paced host loop** on the
 owner thread: each iteration always pumps the runtime; it renders only when

--- a/include/maplibre_native_c/camera.h
+++ b/include/maplibre_native_c/camera.h
@@ -207,7 +207,9 @@ MLN_API mln_status mln_map_set_tile_options(
 /**
  * Copies the current camera snapshot.
  *
- * On success, *out_camera is overwritten.
+ * On success, *out_camera is overwritten. MapLibre Native reports no anchor in
+ * a camera snapshot, so out_camera->fields leaves MLN_CAMERA_OPTION_ANCHOR
+ * clear; anchor is input-only, as documented on mln_camera_options.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -240,8 +242,12 @@ mln_map_jump_to(mln_map* map, const mln_camera_options* camera) MLN_NOEXCEPT;
 /**
  * Applies a camera ease transition command.
  *
- * Only fields indicated by camera->fields affect the map. Passing a null
- * animation uses MapLibre Native's default animation options.
+ * Only fields indicated by camera->fields affect the map.
+ *
+ * MapLibre Native's default ease duration is zero, so a null animation, or one
+ * that omits MLN_ANIMATION_OPTION_DURATION, moves the camera to the target
+ * immediately and reports it on the next snapshot without any pumping. Set
+ * MLN_ANIMATION_OPTION_DURATION to animate.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -261,8 +267,13 @@ MLN_API mln_status mln_map_ease_to(
 /**
  * Applies a camera fly transition command.
  *
- * Only fields indicated by camera->fields affect the map. Passing a null
- * animation uses MapLibre Native's default animation options.
+ * Only fields indicated by camera->fields affect the map.
+ *
+ * This is the one camera command that animates by default. When the animation
+ * is null or omits MLN_ANIMATION_OPTION_DURATION, MapLibre Native derives a
+ * duration from the flight distance and the velocity, which defaults to 1.2
+ * screenfuls per second, so the camera reaches the target over several pumped
+ * frames.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -296,7 +307,8 @@ mln_map_move_by(mln_map* map, double delta_x, double delta_y) MLN_NOEXCEPT;
 /**
  * Applies an animated screen-space pan command.
  *
- * Passing a null animation uses MapLibre Native's default animation options.
+ * This command eases, so it inherits the zero default duration described on
+ * mln_map_ease_to(). Set MLN_ANIMATION_OPTION_DURATION to animate.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -332,8 +344,9 @@ MLN_API mln_status mln_map_scale_by(
 /**
  * Applies an animated screen-space zoom command.
  *
- * Passing a null anchor uses MapLibre Native's default zoom anchor. Passing a
- * null animation uses MapLibre Native's default animation options.
+ * Passing a null anchor uses MapLibre Native's default zoom anchor. This
+ * command eases, so it inherits the zero default duration described on
+ * mln_map_ease_to(). Set MLN_ANIMATION_OPTION_DURATION to animate.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -368,7 +381,8 @@ MLN_API mln_status mln_map_rotate_by(
 /**
  * Applies an animated screen-space rotate command.
  *
- * Passing a null animation uses MapLibre Native's default animation options.
+ * This command eases, so it inherits the zero default duration described on
+ * mln_map_ease_to(). Set MLN_ANIMATION_OPTION_DURATION to animate.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -400,7 +414,8 @@ MLN_API mln_status mln_map_pitch_by(mln_map* map, double pitch) MLN_NOEXCEPT;
 /**
  * Applies an animated pitch delta command.
  *
- * Passing a null animation uses MapLibre Native's default animation options.
+ * This command eases, so it inherits the zero default duration described on
+ * mln_map_ease_to(). Set MLN_ANIMATION_OPTION_DURATION to animate.
  *
  * Returns:
  * - MLN_STATUS_OK on success.

--- a/include/maplibre_native_c/map.h
+++ b/include/maplibre_native_c/map.h
@@ -190,6 +190,14 @@ typedef struct mln_camera_options {
   double longitude;
   double center_altitude;
   mln_edge_insets padding;
+  /**
+   * Screen-space focal point for a camera command. This field is input-only.
+   *
+   * MapLibre Native applies it to camera commands and leaves it out of every
+   * camera snapshot it reports, so MLN_CAMERA_OPTION_ANCHOR is set only by the
+   * caller. mln_map_get_camera(), mln_map_projection_get_camera(), and the
+   * mln_map_camera_for_* family leave it clear.
+   */
   mln_screen_point anchor;
   double zoom;
   double bearing;
@@ -213,9 +221,16 @@ typedef struct mln_animation_options {
   /**
    * Duration in milliseconds. Must be finite and non-negative. Values that
    * would overflow MapLibre Native's internal duration are invalid.
+   *
+   * When this field is omitted, ease, pan, zoom, rotate, and pitch transitions
+   * default to zero and apply instantly, while mln_map_fly_to() derives a
+   * duration from velocity instead.
    */
   double duration_ms;
-  /** Average flyTo velocity in screenfuls per second. Must be positive. */
+  /**
+   * Average flyTo velocity in screenfuls per second. Must be positive.
+   * Defaults to 1.2 when omitted. Applies to mln_map_fly_to().
+   */
   double velocity;
   /** Peak zoom for flyTo transitions. */
   double min_zoom;
@@ -1087,6 +1102,12 @@ MLN_API mln_status mln_map_request_still_image(mln_map* map) MLN_NOEXCEPT;
  *
  * The map must not have an attached render session.
  *
+ * Destruction also discards this map's queued events, including queued style
+ * loading failures. There is no flush and no terminal event, so the last state
+ * a host mirrored from events can stay behind the map's final state. Snapshot
+ * whatever state the host needs while the map is still live, and let teardown
+ * proceed without awaiting an event for this map.
+ *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not a live map handle.
@@ -1103,7 +1124,10 @@ MLN_API mln_status mln_map_destroy(mln_map* map) MLN_NOEXCEPT;
  *
  * This is a map command. The return status reports synchronous acceptance or
  * failure. Later native success and failure are reported through runtime
- * events.
+ * events. A URL that is unreachable, malformed, or serves invalid style
+ * content is still accepted synchronously; every such failure arrives later as
+ * a style loading-failed event, so hosts report style URL errors from the event
+ * stream rather than from this return status.
  *
  * Returns:
  * - MLN_STATUS_OK when the load request was accepted.

--- a/include/maplibre_native_c/projection.h
+++ b/include/maplibre_native_c/projection.h
@@ -54,7 +54,9 @@ mln_map_projection_destroy(mln_map_projection* projection) MLN_NOEXCEPT;
 /**
  * Copies the current camera snapshot from a standalone projection helper.
  *
- * On success, *out_camera is overwritten.
+ * On success, *out_camera is overwritten. MapLibre Native reports no anchor in
+ * a camera snapshot, so out_camera->fields leaves MLN_CAMERA_OPTION_ANCHOR
+ * clear; anchor is input-only, as documented on mln_camera_options.
  *
  * Returns:
  * - MLN_STATUS_OK on success.

--- a/include/maplibre_native_c/query.h
+++ b/include/maplibre_native_c/query.h
@@ -211,6 +211,11 @@ MLN_API mln_status mln_render_session_query_source_features(
 /**
  * Queries a feature extension from the latest render session state.
  *
+ * Feature extensions are renderer-scoped in MapLibre Native: the cluster index
+ * an extension reads lives on the render-side source inside a live renderer,
+ * not on the style source, which is why this query hangs off the session rather
+ * than off a map or a source ID.
+ *
  * The session renderer must already exist. source_id, feature, extension,
  * extension_field, and arguments are borrowed for the duration of the call.
  * arguments may be null. When non-null, arguments must be a JSON object

--- a/include/maplibre_native_c/runtime.h
+++ b/include/maplibre_native_c/runtime.h
@@ -540,9 +540,13 @@ MLN_API mln_status mln_runtime_create(
  * The provider must be set before any map is created from the runtime. It is
  * invoked for requests that reach the C API network file source. Built-in
  * non-network schemes such as file, asset, mbtiles, and pmtiles are handled by
- * native MainResourceLoader before this extension point. The callback and
- * user_data are stored by reference and must remain valid until the runtime is
- * destroyed.
+ * native MainResourceLoader before this extension point. Native
+ * OnlineFileSource claims every remaining scheme, so a URL with a scheme
+ * MapLibre does not recognize, such as jar:file:, is treated as a network
+ * request, reaches this callback, and completes as an HTTP error when the
+ * provider passes it through. Serving those schemes from host storage is what
+ * this extension point is for. The callback and user_data are stored by
+ * reference and must remain valid until the runtime is destroyed.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -690,6 +694,14 @@ MLN_API mln_status mln_runtime_offline_operation_discard(
  *
  * The runtime must no longer own live maps.
  *
+ * When a resource transform is registered, this call waits for in-flight
+ * transform callbacks before returning, the same way
+ * mln_runtime_set_resource_transform() and
+ * mln_runtime_clear_resource_transform() do. The callback contract documented
+ * on mln_resource_transform_callback keeps that wait short: the callback
+ * returns quickly and calls no C API function other than
+ * mln_resource_transform_response_set_url().
+ *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not a live runtime
@@ -702,9 +714,18 @@ MLN_API mln_status mln_runtime_offline_operation_discard(
 MLN_API mln_status mln_runtime_destroy(mln_runtime* runtime) MLN_NOEXCEPT;
 
 /**
- * Runs one pending owner-thread task for this runtime.
+ * Runs one iteration of this runtime's owner-thread run loop.
  *
- * If no task is pending, the call returns MLN_STATUS_OK without doing work.
+ * A single call drains the owner-thread task queues. It runs every task queued
+ * when the call begins plus every task those tasks enqueue, and it services
+ * expired timers and file descriptors that are ready for the runtime's own
+ * network and database work. The call returns as soon as that iteration
+ * finishes and never blocks waiting for new work, so an idle runtime returns
+ * promptly.
+ *
+ * The promise is drain, not slice. The duration of one call is bounded only by
+ * the work it finds and can span a full style parse, so treat it as work that
+ * runs to completion rather than as a fixed-cost per-frame slice.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -734,6 +755,10 @@ MLN_API mln_status mln_runtime_run_once(mln_runtime* runtime) MLN_NOEXCEPT;
  * destroyed. Copy those bytes before then when they must outlive that window.
  * For style-image-missing and tile-action events, out_event->message contains
  * the same ID string exposed by the typed payload.
+ *
+ * Destroying a map discards that map's queued events, so this function returns
+ * events only for maps that are still live. Read the state a host mirrors from
+ * events before destroying the map that produces them.
  *
  * Returns:
  * - MLN_STATUS_OK when the poll completed; out_has_event indicates whether an

--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -1036,6 +1036,15 @@ MLN_API mln_status mln_map_set_location_indicator_image_name(
 /**
  * Adds one style layer from a full style-spec layer JSON object.
  *
+ * This is the primary insertion path for every style-spec layer type, and it
+ * stays in step with the style specification without new C API surface. The
+ * typed adders above cover the three cases that need a dedicated surface for
+ * reasons beyond construction: mln_map_add_hillshade_layer() and
+ * mln_map_add_color_relief_layer() validate that the source is a raster DEM
+ * source, and mln_map_add_location_indicator_layer() pairs with typed
+ * per-frame setters that take coordinates in C API order. Use this function for
+ * the remaining layer types.
+ *
  * layer_json and before_layer_id are borrowed for the call. layer_json must
  * contain id and type members. Passing an empty before_layer_id appends the
  * layer; otherwise the layer is inserted before that existing layer.


### PR DESCRIPTION
## Summary

Documents nine C API behaviors that were true in the implementation but absent or wrong in the public headers, most notably that `mln_runtime_run_once()` drains a full run-loop iteration rather than running a single pending task.

## Test plan

Headers syntax-check clean as C23 and C++, and the change is comment and prose only with no behavior, declaration, or ABI changes.

## AI assistance

- **Tools:** Claude Code
- **Context:**
  Drafted from verified upstream consumer feedback (MapLibre Compose desktop integration); each documented contract was traced to its source in this tree or vendored MapLibre Native before writing.