### PR TITLE
Name the unsupported URL scheme in resource errors

### DIFF
--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -12,6 +12,8 @@
 static const char offline_style_url[] = "http://example.com/offline-style.json";
 static const char unsupported_scheme_style_url[] =
   "jar:file:/packaged/style.json";
+static const char credentialed_unsupported_scheme_style_url[] =
+  "jar://user:password@archive/packaged/style.json?access_token=secret#token";
 
 static mln_runtime_event empty_event(void) {
   return (mln_runtime_event){
@@ -395,6 +397,50 @@ static void unsupported_style_url_scheme_names_scheme_and_url(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+static void unsupported_style_url_diagnostic_redacts_credentials(void) {
+  mln_runtime* runtime = mln_test_create_runtime();
+  mln_map* map = mln_test_create_map(runtime);
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK,
+    mln_map_set_style_url(map, credentialed_unsupported_scheme_style_url)
+  );
+  char message[512];
+  TEST_ASSERT_TRUE(
+    wait_for_map_loading_failure(runtime, map, message, sizeof(message))
+  );
+  TEST_ASSERT_NOT_NULL(strstr(message, "jar://archive/packaged/style.json"));
+  TEST_ASSERT_NULL(strstr(message, "user"));
+  TEST_ASSERT_NULL(strstr(message, "password"));
+  TEST_ASSERT_NULL(strstr(message, "access_token"));
+  TEST_ASSERT_NULL(strstr(message, "secret"));
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
+static void unsupported_style_url_names_declining_provider(void) {
+  mln_runtime* runtime = mln_test_create_runtime();
+  const mln_resource_provider provider = {
+    .size = sizeof(mln_resource_provider),
+    .callback = resource_provider_stub,
+  };
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_runtime_set_resource_provider(runtime, &provider)
+  );
+  mln_map* map = mln_test_create_map(runtime);
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_set_style_url(map, unsupported_scheme_style_url)
+  );
+  char message[512];
+  TEST_ASSERT_TRUE(
+    wait_for_map_loading_failure(runtime, map, message, sizeof(message))
+  );
+  TEST_ASSERT_NOT_NULL(strstr(message, "registered resource provider"));
+  TEST_ASSERT_NOT_NULL(strstr(message, "declined"));
+  TEST_ASSERT_NULL(strstr(message, "register a resource provider"));
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
 void run_resources_abi_tests(void) {
   UnitySetTestFile(__FILE__);
   RUN_TEST(custom_provider_request_handles_reject_raw_null_handles);
@@ -406,4 +452,6 @@ void run_resources_abi_tests(void) {
   RUN_TEST(resource_transform_rejects_raw_invalid_descriptors);
   RUN_TEST(resource_provider_rejects_raw_invalid_descriptors);
   RUN_TEST(unsupported_style_url_scheme_names_scheme_and_url);
+  RUN_TEST(unsupported_style_url_diagnostic_redacts_credentials);
+  RUN_TEST(unsupported_style_url_names_declining_provider);
 }

--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -1,13 +1,17 @@
 // Raw C ABI coverage: null handles/outputs, unknown operation values, null
 // paths, callback descriptor shape, and invalid offline unions are hidden by
-// bindings.
+// bindings, plus the network file source diagnostic that every binding
+// forwards verbatim.
 
 #include <stdint.h>
+#include <string.h>
 
 #include "test_support.h"
 #include "unity.h"
 
 static const char offline_style_url[] = "http://example.com/offline-style.json";
+static const char unsupported_scheme_style_url[] =
+  "jar:file:/packaged/style.json";
 
 static mln_runtime_event empty_event(void) {
   return (mln_runtime_event){
@@ -50,6 +54,41 @@ static bool wait_for_offline_completion(
       if (payload->operation_id == operation_id) {
         return true;
       }
+    }
+    mln_test_sleep_millisecond();
+  }
+  return false;
+}
+
+static bool wait_for_map_loading_failure(
+  mln_runtime* runtime, const mln_map* map, char* out_message,
+  size_t out_message_capacity
+) {
+  for (size_t attempt = 0; attempt < 5000; attempt += 1) {
+    if (mln_runtime_run_once(runtime) != MLN_STATUS_OK) {
+      return false;
+    }
+    while (true) {
+      mln_runtime_event event = empty_event();
+      bool has_event = false;
+      if (
+        mln_runtime_poll_event(runtime, &event, &has_event) != MLN_STATUS_OK
+      ) {
+        return false;
+      }
+      if (!has_event) {
+        break;
+      }
+      if (
+        event.type != MLN_RUNTIME_EVENT_MAP_LOADING_FAILED ||
+        event.source != (const void*)map || event.message == NULL ||
+        event.message_size >= out_message_capacity
+      ) {
+        continue;
+      }
+      memcpy(out_message, event.message, event.message_size);
+      out_message[event.message_size] = '\0';
+      return true;
     }
     mln_test_sleep_millisecond();
   }
@@ -336,6 +375,26 @@ static void resource_provider_rejects_raw_invalid_descriptors(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+// This verifies the network file source diagnostic below every binding: a
+// style URL whose scheme no file source serves reports the scheme, the URL,
+// and the resource provider remedy instead of an HTTP client parse error.
+static void unsupported_style_url_scheme_names_scheme_and_url(void) {
+  mln_runtime* runtime = mln_test_create_runtime();
+  mln_map* map = mln_test_create_map(runtime);
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_set_style_url(map, unsupported_scheme_style_url)
+  );
+  char message[512];
+  TEST_ASSERT_TRUE(
+    wait_for_map_loading_failure(runtime, map, message, sizeof(message))
+  );
+  TEST_ASSERT_NOT_NULL(strstr(message, unsupported_scheme_style_url));
+  TEST_ASSERT_NOT_NULL(strstr(message, "\"jar\""));
+  TEST_ASSERT_NOT_NULL(strstr(message, "mln_runtime_set_resource_provider"));
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
 void run_resources_abi_tests(void) {
   UnitySetTestFile(__FILE__);
   RUN_TEST(custom_provider_request_handles_reject_raw_null_handles);
@@ -346,4 +405,5 @@ void run_resources_abi_tests(void) {
   RUN_TEST(offline_take_rejects_mismatched_result_kind);
   RUN_TEST(resource_transform_rejects_raw_invalid_descriptors);
   RUN_TEST(resource_provider_rejects_raw_invalid_descriptors);
+  RUN_TEST(unsupported_style_url_scheme_names_scheme_and_url);
 }

--- a/src/platform/rust/src/http_client.rs
+++ b/src/platform/rust/src/http_client.rs
@@ -234,7 +234,13 @@ fn send_http_request(request: HttpRequest) -> MlnRustHttpResponse {
                 }
                 return http_response(&mut response, has_range);
             }
-            Err(error) => return http_error(map_transport_error(&error), &error.to_string()),
+            Err(error) => {
+                // Naming the attempted URL keeps redirect failures traceable.
+                return http_error(
+                    map_transport_error(&error),
+                    &format!("{error} for URL \"{url}\""),
+                );
+            }
         }
     }
 

--- a/src/platform/rust/src/http_client.rs
+++ b/src/platform/rust/src/http_client.rs
@@ -234,13 +234,7 @@ fn send_http_request(request: HttpRequest) -> MlnRustHttpResponse {
                 }
                 return http_response(&mut response, has_range);
             }
-            Err(error) => {
-                // Naming the attempted URL keeps redirect failures traceable.
-                return http_error(
-                    map_transport_error(&error),
-                    &format!("{error} for URL \"{url}\""),
-                );
-            }
+            Err(error) => return http_error(map_transport_error(&error), &error.to_string()),
         }
     }
 

--- a/src/resources/resource_loader.cpp
+++ b/src/resources/resource_loader.cpp
@@ -1,13 +1,18 @@
+#include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <exception>
 #include <functional>
 #include <memory>
 #include <optional>
+#include <shared_mutex>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include <mbgl/storage/database_file_source.hpp>
 #include <mbgl/storage/file_source.hpp>
+#include <mbgl/storage/file_source_request.hpp>
 #include <mbgl/storage/main_resource_loader.hpp>
 #include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/storage/resource.hpp>
@@ -19,6 +24,7 @@
 #include <mbgl/util/event.hpp>
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/tile_server_options.hpp>
 
 #include "resources/resource_loader.hpp"
 
@@ -32,6 +38,59 @@ namespace {
 
 auto can_request_network(const mbgl::Resource& resource) -> bool {
   return resource.hasLoadingMethod(mbgl::Resource::LoadingMethod::Network);
+}
+
+auto equals_ignoring_case(std::string_view left, std::string_view right)
+  -> bool {
+  return std::ranges::equal(left, right, [](char left_char, char right_char) {
+    return std::tolower(static_cast<unsigned char>(left_char)) ==
+           std::tolower(static_cast<unsigned char>(right_char));
+  });
+}
+
+// Returns the RFC 3986 scheme of a URL, or nullopt when the URL carries none.
+auto url_scheme(std::string_view url) -> std::optional<std::string_view> {
+  const auto separator = url.find(':');
+  if (separator == std::string_view::npos || separator == 0) {
+    return std::nullopt;
+  }
+  const auto scheme = url.substr(0, separator);
+  if (std::isalpha(static_cast<unsigned char>(scheme.front())) == 0) {
+    return std::nullopt;
+  }
+  const auto is_scheme_character = [](char character) -> bool {
+    return std::isalnum(static_cast<unsigned char>(character)) != 0 ||
+           character == '+' || character == '-' || character == '.';
+  };
+  if (!std::ranges::all_of(scheme, is_scheme_character)) {
+    return std::nullopt;
+  }
+  return scheme;
+}
+
+auto unsupported_scheme_response(
+  std::string_view scheme, const std::string& url
+) -> mbgl::Response {
+  auto response = mbgl::Response{};
+  // Reason::Other keeps this a terminal configuration error: it surfaces as
+  // MLN_RESOURCE_ERROR_REASON_OTHER, and the tile and source paths retry or
+  // silently absorb the reasons that describe transport and server state.
+  response.error = std::make_unique<mbgl::Response::Error>(
+    mbgl::Response::Error::Reason::Other,
+    "unsupported URL scheme \"" + std::string{scheme} +
+      "\" for network request \"" + url +
+      "\"; register a resource provider with "
+      "mln_runtime_set_resource_provider() to serve this scheme"
+  );
+  return response;
+}
+
+auto respond_immediately(
+  const mbgl::Response& response, mbgl::FileSource::Callback callback
+) -> std::unique_ptr<mbgl::AsyncRequest> {
+  auto request = std::make_unique<mbgl::FileSourceRequest>(std::move(callback));
+  request->actor().invoke(&mbgl::FileSourceRequest::setResponse, response);
+  return request;
 }
 
 auto resource_kind_to_abi(mbgl::Resource::Kind kind) -> uint32_t {
@@ -112,6 +171,13 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
     if (!native_->canRequest(resource)) {
       return nullptr;
     }
+    const auto unsupported = unsupported_network_scheme(resource.url);
+    if (unsupported.has_value()) {
+      return respond_immediately(
+        unsupported_scheme_response(*unsupported, resource.url),
+        std::move(callback)
+      );
+    }
     return native_->request(resource, std::move(callback));
   }
 
@@ -170,6 +236,44 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
       return std::nullopt;
     }
     return runtime->resource_provider;
+  }
+
+  static auto has_resource_transform(void* platform_context) -> bool {
+    const auto* runtime = find_runtime_for_platform_context(platform_context);
+    if (runtime == nullptr) {
+      return false;
+    }
+    const std::shared_lock lock(runtime->resource_transform_mutex);
+    return runtime->resource_transform_callback != nullptr;
+  }
+
+  // Reports the scheme of a URL the online source is unable to serve. The
+  // resource loader routes file, asset, mbtiles, and pmtiles URLs to their own
+  // sources ahead of the network, so anything left here reaches an HTTP
+  // client. A registered resource transform rewrites URLs inside the online
+  // source, so it keeps every scheme available.
+  [[nodiscard]] auto unsupported_network_scheme(const std::string& url) const
+    -> std::optional<std::string_view> {
+    if (has_resource_transform(resource_options_.platformContext())) {
+      return std::nullopt;
+    }
+    const auto scheme = url_scheme(url);
+    if (!scheme.has_value()) {
+      return std::nullopt;
+    }
+    if (
+      equals_ignoring_case(*scheme, "http") ||
+      equals_ignoring_case(*scheme, "https")
+    ) {
+      return std::nullopt;
+    }
+    // Tile server options name a canonical scheme the online source expands
+    // into its configured base URL.
+    const auto alias = resource_options_.tileServerOptions().uriSchemeAlias();
+    if (!alias.empty() && equals_ignoring_case(*scheme, alias)) {
+      return std::nullopt;
+    }
+    return scheme;
   }
 
   void apply_resource_transform() {

--- a/src/resources/resource_loader.cpp
+++ b/src/resources/resource_loader.cpp
@@ -5,7 +5,6 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -238,15 +237,6 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
     return runtime->resource_provider;
   }
 
-  static auto has_resource_transform(void* platform_context) -> bool {
-    const auto* runtime = find_runtime_for_platform_context(platform_context);
-    if (runtime == nullptr) {
-      return false;
-    }
-    const std::shared_lock lock(runtime->resource_transform_mutex);
-    return runtime->resource_transform_callback != nullptr;
-  }
-
   // Reports the scheme of a URL the online source is unable to serve. The
   // resource loader routes file, asset, mbtiles, and pmtiles URLs to their own
   // sources ahead of the network, so anything left here reaches an HTTP
@@ -254,7 +244,11 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
   // source, so it keeps every scheme available.
   [[nodiscard]] auto unsupported_network_scheme(const std::string& url) const
     -> std::optional<std::string_view> {
-    if (has_resource_transform(resource_options_.platformContext())) {
+    if (
+      has_resource_transform_for_platform_context(
+        resource_options_.platformContext()
+      )
+    ) {
       return std::nullopt;
     }
     const auto scheme = url_scheme(url);

--- a/src/resources/resource_loader.cpp
+++ b/src/resources/resource_loader.cpp
@@ -67,8 +67,36 @@ auto url_scheme(std::string_view url) -> std::optional<std::string_view> {
   return scheme;
 }
 
+// Keeps enough URL context to identify the failing resource without copying
+// credentials into public diagnostics. Query and fragment values are omitted,
+// and RFC 3986 userinfo is removed from hierarchical URLs.
+auto diagnostic_url(std::string_view url) -> std::string {
+  const auto query = url.find('?');
+  const auto fragment = url.find('#');
+  const auto suffix = std::min(query, fragment);
+  auto sanitized = std::string{url.substr(0, suffix)};
+
+  const auto scheme_separator = sanitized.find(':');
+  if (
+    scheme_separator == std::string::npos ||
+    sanitized.substr(scheme_separator + 1, 2) != "//"
+  ) {
+    return sanitized;
+  }
+
+  const auto authority_start = scheme_separator + 3;
+  const auto authority_end = sanitized.find('/', authority_start);
+  const auto at = sanitized.rfind(
+    '@', authority_end == std::string::npos ? sanitized.size() : authority_end
+  );
+  if (at != std::string::npos && at >= authority_start) {
+    sanitized.erase(authority_start, at - authority_start + 1);
+  }
+  return sanitized;
+}
+
 auto unsupported_scheme_response(
-  std::string_view scheme, const std::string& url
+  std::string_view scheme, const std::string& url, bool provider_declined
 ) -> mbgl::Response {
   auto response = mbgl::Response{};
   // Reason::Other keeps this a terminal configuration error: it surfaces as
@@ -77,9 +105,12 @@ auto unsupported_scheme_response(
   response.error = std::make_unique<mbgl::Response::Error>(
     mbgl::Response::Error::Reason::Other,
     "unsupported URL scheme \"" + std::string{scheme} +
-      "\" for network request \"" + url +
-      "\"; register a resource provider with "
-      "mln_runtime_set_resource_provider() to serve this scheme"
+      "\" for network request \"" + diagnostic_url(url) +
+      (provider_declined
+         ? "\"; the registered resource provider declined this request; "
+           "update it to serve this scheme"
+         : "\"; register a resource provider with "
+           "mln_runtime_set_resource_provider() to serve this scheme")
   );
   return response;
 }
@@ -173,7 +204,9 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
     const auto unsupported = unsupported_network_scheme(resource.url);
     if (unsupported.has_value()) {
       return respond_immediately(
-        unsupported_scheme_response(*unsupported, resource.url),
+        unsupported_scheme_response(
+          *unsupported, resource.url, provider.has_value()
+        ),
         std::move(callback)
       );
     }

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2503,6 +2503,24 @@ auto find_runtime_for_platform_context(void* platform_context) noexcept
   return runtime_registry().contains(runtime) ? runtime : nullptr;
 }
 
+auto has_resource_transform_for_platform_context(
+  void* platform_context
+) noexcept -> bool {
+  if (platform_context == nullptr) {
+    return false;
+  }
+
+  auto* runtime = static_cast<mln_runtime*>(platform_context);
+  // The registry lock stays held across the read: releasing it first would
+  // leave an unowned pointer, and this locks a mutex inside the runtime.
+  const std::scoped_lock registry_lock(runtime_registry_mutex());
+  if (!runtime_registry().contains(runtime)) {
+    return false;
+  }
+  const std::shared_lock transform_lock(runtime->resource_transform_mutex);
+  return runtime->resource_transform_callback != nullptr;
+}
+
 auto invoke_resource_transform(
   void* platform_context, uint32_t kind, const char* url,
   std::string& out_replacement_url

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -203,6 +203,11 @@ auto resource_options_for_runtime(mln_runtime* runtime)
   -> mbgl::ResourceOptions;
 auto find_runtime_for_platform_context(void* platform_context) noexcept
   -> mln_runtime*;
+// Reads resource transform presence under the registry lock, so MapLibre-owned
+// threads observe a value instead of a runtime pointer teardown may retire.
+auto has_resource_transform_for_platform_context(
+  void* platform_context
+) noexcept -> bool;
 auto push_runtime_map_event(
   mln_runtime* runtime, mln_map* map, uint32_t type, int32_t code = 0,
   const char* message = nullptr


### PR DESCRIPTION
## Summary

The built-in network file source forwarded its HTTP client's parse error
verbatim, so a `jar:file:` style URL reported `loading style failed: http:
invalid authority`; it now synthesizes an error naming the scheme, the URL, and
the resource provider remedy.

## Test plan

Added a C test asserting a `jar:file:` style URL produces a loading-failed event
naming the scheme, the URL, and `mln_runtime_set_resource_provider()`; `cargo
check` passes on the Rust file source, but the cold native build did not finish
locally, so CI runs the C suite.

## Notes

Three cases the guard deliberately leaves alone, so it only fires where nothing
else could have served or rewritten the URL:

- Tile server options' `uriSchemeAlias` counts as supported. The online source
  expands `mapbox://`/`maptiler://` into the configured base URL, so rejecting
  the alias would have been a silent regression.
- A registered resource transform suppresses the guard, since a transform
  rewrites URLs inside the online source and can legitimately turn an unknown
  scheme into HTTPS.
- The check sits after `native_->canRequest()`, so cache-only requests still
  return `nullptr` as before. `file`, `asset`, `mbtiles`, and `pmtiles` reach
  their own sources ahead of the network in `MainResourceLoader`'s waterfall and
  never arrive here.

Reason is `Response::Error::Reason::Other` (surfacing as
`MLN_RESOURCE_ERROR_REASON_OTHER`): this is a terminal configuration error, and
the reasons describing transport and server state get retried or absorbed by the
tile and source paths.

The matching `mln_runtime_set_resource_provider` header prose is landing
separately.

## Runtime pointer lifetime

The transform check reads runtime state from MapLibre-owned threads
(`MainResourceLoader`'s ResourceLoaderThread, and the `DatabaseFileSource`
thread for offline downloads, which needs no live map). It goes through a new
`has_resource_transform_for_platform_context()` in `src/runtime/runtime.cpp`
that holds `runtime_registry_mutex()` across both the containment check and the
per-runtime `shared_lock`, returning a plain `bool`.

Taking `find_runtime_for_platform_context()`'s pointer and locking the runtime's
own mutex after the registry lock was released would be a use-after-free during
teardown. Lock order stays registry then transform, matching
`invoke_resource_transform()` and the teardown path.

Overlaps #353, which deletes `find_runtime_for_platform_context` in favor of
value-returning `find_*_for_platform_context` helpers; whichever merges second
takes a small conflict in `runtime.cpp`/`runtime.hpp`.

## AI assistance

- **Tools:** Claude Code
- **Context:** Agent-authored fix from a reported Compose Desktop `jar:file:`
  diagnostic, following `docs/.../c-conventions.md`.

