### PR TITLE
Align Rust and Python session detach with the C contract

### DIFF
--- a/bindings/python/python/maplibre_native/camera.py
+++ b/bindings/python/python/maplibre_native/camera.py
@@ -64,7 +64,14 @@ class CameraOptions:
     pitch: float | None = None
     center_altitude: float | None = None
     padding: EdgeInsets | None = None
+
     anchor: ScreenPoint | None = None
+    """Screen-space anchor for jump, ease, and fly commands.
+
+    This field is input-only: MapLibre Native applies it to camera commands and
+    never reports it back, so it is always None on a camera read.
+    """
+
     roll: float | None = None
     field_of_view: float | None = None
 

--- a/bindings/python/python/maplibre_native/map.py
+++ b/bindings/python/python/maplibre_native/map.py
@@ -451,7 +451,14 @@ class MapHandle(NativeHandleMixin):
         return self._native_address_value
 
     def close(self) -> None:
-        """Release this map handle exactly once."""
+        """Release this map handle exactly once.
+
+        Closing discards this map's queued runtime events and its recorded
+        loading failure. There is no flush and no terminal event, so read any
+        state you mirror from events before closing, and treat close as the end
+        of this map's event stream rather than awaiting an event during
+        teardown.
+        """
         self._native.close()
         self._runtime._unregister_map(self)  # noqa: SLF001
 
@@ -528,11 +535,32 @@ class MapHandle(NativeHandleMixin):
         )
 
     def set_style_url(self, url: str) -> None:
-        """Load a style URL through MapLibre Native style APIs."""
+        """Load a style URL through MapLibre Native style APIs.
+
+        Loading is asynchronous, so a style that fails to fetch or parse still
+        returns normally here and reports through a later loading-failed
+        runtime event. Watch the event stream for load outcomes.
+
+        A well-formed style whose contents are semantically invalid, such as an
+        unknown "version" or a layer naming a missing source, loads without an
+        error and without an event: MapLibre Native logs it and renders what it
+        can.
+        """
         self._native.set_style_url(url)
 
     def set_style_json(self, json: str) -> None:
-        """Load inline style JSON through MapLibre Native style APIs."""
+        """Load inline style JSON through MapLibre Native style APIs.
+
+        Malformed JSON is reported twice: this call raises the parse error
+        synchronously, and the same message also arrives as a loading-failed
+        runtime event. Handle both, so an event-driven loop stays consistent
+        with the call site.
+
+        A well-formed style whose contents are semantically invalid, such as an
+        unknown "version" or a layer naming a missing source, loads without an
+        error and without an event: MapLibre Native logs it and renders what it
+        can.
+        """
         self._native.set_style_json(json)
 
     def add_style_source_json(self, source_id: str, source_json: JsonObject) -> None:
@@ -919,7 +947,12 @@ class MapHandle(NativeHandleMixin):
         camera: CameraOptions,
         animation: AnimationOptions | None = None,
     ) -> None:
-        """Apply a camera ease transition command."""
+        """Apply a camera ease transition command.
+
+        An absent `animation`, or an animation with no duration, eases over
+        zero duration: the camera reaches the target before this call returns,
+        with no runtime pump in between. Set a duration to animate over time.
+        """
         self._native.ease_to(*_camera_parts(camera), _animation_parts(animation))
 
     def fly_to(
@@ -927,7 +960,13 @@ class MapHandle(NativeHandleMixin):
         camera: CameraOptions,
         animation: AnimationOptions | None = None,
     ) -> None:
-        """Apply a camera fly transition command."""
+        """Apply a camera fly transition command.
+
+        Fly is the one camera command that animates by default: an absent
+        `animation`, or an animation with no duration, derives a duration from
+        a default velocity of 1.2 screenfuls per second, so the camera is still
+        en route when this call returns and advances as the runtime is pumped.
+        """
         self._native.fly_to(*_camera_parts(camera), _animation_parts(animation))
 
     def camera_for_lat_lng_bounds(
@@ -1008,7 +1047,12 @@ class MapHandle(NativeHandleMixin):
         delta_y: float,
         animation: AnimationOptions | None = None,
     ) -> None:
-        """Apply an animated screen-space pan command."""
+        """Apply an animated screen-space pan command.
+
+        Native routes this delta through the ease transition, so an absent
+        `animation`, or an animation with no duration, applies the pan
+        instantly like `ease_to`. Set a duration to animate over time.
+        """
         self._native.move_by_animated(delta_x, delta_y, _animation_parts(animation))
 
     def scale_by(self, scale: float, anchor: ScreenPoint | None = None) -> None:
@@ -1022,7 +1066,12 @@ class MapHandle(NativeHandleMixin):
         anchor: ScreenPoint | None = None,
         animation: AnimationOptions | None = None,
     ) -> None:
-        """Apply an animated screen-space zoom command."""
+        """Apply an animated screen-space zoom command.
+
+        Native routes this delta through the ease transition, so an absent
+        `animation`, or an animation with no duration, applies the zoom
+        instantly like `ease_to`. Set a duration to animate over time.
+        """
         raw_anchor = (anchor.x, anchor.y) if anchor is not None else None
         self._native.scale_by_animated(scale, raw_anchor, _animation_parts(animation))
 
@@ -1036,7 +1085,12 @@ class MapHandle(NativeHandleMixin):
         second: ScreenPoint,
         animation: AnimationOptions | None = None,
     ) -> None:
-        """Apply an animated screen-space rotate command."""
+        """Apply an animated screen-space rotate command.
+
+        Native routes this delta through the ease transition, so an absent
+        `animation`, or an animation with no duration, applies the rotation
+        instantly like `ease_to`. Set a duration to animate over time.
+        """
         self._native.rotate_by_animated(
             (first.x, first.y),
             (second.x, second.y),
@@ -1052,7 +1106,12 @@ class MapHandle(NativeHandleMixin):
         pitch: float,
         animation: AnimationOptions | None = None,
     ) -> None:
-        """Apply an animated pitch delta command."""
+        """Apply an animated pitch delta command.
+
+        Native routes this delta through the ease transition, so an absent
+        `animation`, or an animation with no duration, applies the pitch
+        instantly like `ease_to`. Set a duration to animate over time.
+        """
         self._native.pitch_by_animated(pitch, _animation_parts(animation))
 
     def cancel_transitions(self) -> None:

--- a/bindings/python/python/maplibre_native/render.py
+++ b/bindings/python/python/maplibre_native/render.py
@@ -441,7 +441,7 @@ class RenderSessionHandle(NativeHandleMixin):
             msg = "RenderSessionHandle instances are created by MapHandle"
             raise TypeError(msg)
         self._native = native
-        self._map = map_handle
+        self._map: MapHandle | None = map_handle
 
     @classmethod
     def _from_native(cls, native: Any, map_handle: MapHandle) -> "RenderSessionHandle":
@@ -477,7 +477,11 @@ class RenderSessionHandle(NativeHandleMixin):
         suits the host; it stays destroyable after the map closes because a
         detached session no longer reaches its map.
         """
-        return DetachedRenderSessionHandle._from_native(self._native.detach())  # noqa: SLF001
+        native = self._native.detach()
+        # The original wrapper can remain observable through `detached`, but it
+        # no longer retains the map after native detach succeeds.
+        self._map = None
+        return DetachedRenderSessionHandle._from_native(native)  # noqa: SLF001
 
     def reduce_memory_use(self) -> None:
         """Ask the session renderer to release cached resources where possible."""

--- a/bindings/python/python/maplibre_native/render.py
+++ b/bindings/python/python/maplibre_native/render.py
@@ -406,7 +406,11 @@ class OpenGLOwnedTextureFrame:
 
 
 class DetachedRenderSessionHandle(NativeHandleMixin):
-    """Close-only render session handle after backend resources detach."""
+    """Close-only render session handle after backend resources detach.
+
+    A detached session holds no reference to its former map, so it stays
+    destroyable after that map closes.
+    """
 
     _handle_name = "DetachedRenderSessionHandle"
 
@@ -466,7 +470,13 @@ class RenderSessionHandle(NativeHandleMixin):
         return bool(self._native.render_update())
 
     def detach(self) -> DetachedRenderSessionHandle:
-        """Detach backend resources and return a close-only handle."""
+        """Detach backend resources and return a close-only handle.
+
+        Detach ends this session's hold on the map, so a detached session
+        leaves the map free to close. Close the returned handle whenever it
+        suits the host; it stays destroyable after the map closes because a
+        detached session no longer reaches its map.
+        """
         return DetachedRenderSessionHandle._from_native(self._native.detach())  # noqa: SLF001
 
     def reduce_memory_use(self) -> None:

--- a/bindings/python/python/maplibre_native/runtime.py
+++ b/bindings/python/python/maplibre_native/runtime.py
@@ -203,7 +203,15 @@ class RuntimeEventSource:
     """Copied runtime event source metadata."""
 
     source_type: RuntimeEventSourceType
+    """Kind of runtime object the event came from."""
+
     map_handle: MapHandle | None = None
+    """Source map when this binding can prove its identity.
+
+    The runtime holds its maps weakly, so a `MAP` event carries None here once
+    the caller drops its last reference to the source map or closes it. Keep a
+    reference to every map whose events you route by handle.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -298,7 +306,15 @@ class RuntimeHandle(NativeHandleMixin):
         return map_handle
 
     def run_once(self) -> None:
-        """Run one pending owner-thread task for this runtime."""
+        """Run one iteration of this runtime's owner-thread run loop.
+
+        One iteration drains the high-priority task queue and then the default
+        task queue until both are empty, including tasks enqueued while the
+        drain runs, and also services expired timers and ready I/O. The call
+        returns without blocking on new work, yet its duration is unbounded: a
+        single iteration can span a whole style parse. Drive it from a pump
+        loop rather than budgeting it as a fixed per-frame slice.
+        """
         self._native.run_once()
 
     def _offline_operation(
@@ -433,7 +449,13 @@ class RuntimeHandle(NativeHandleMixin):
         )
 
     def poll_event(self) -> RuntimeEvent | None:
-        """Poll and copy one queued runtime event."""
+        """Poll and copy one queued runtime event.
+
+        Map-originated events resolve their source map through this runtime's
+        weakly held map table, so `RuntimeEvent.source.map_handle` is None once
+        the caller drops its last reference to that map. Keep a reference to
+        every map whose events you route by handle.
+        """
         event = self._native.poll_event()
         if event is None:
             return None

--- a/bindings/python/tests/test_package.py
+++ b/bindings/python/tests/test_package.py
@@ -750,6 +750,32 @@ def test_render_session_methods_propagate_wrong_thread_errors() -> None:
         assert_wrong_thread_error(error, diagnostics[name])
 
 
+def test_render_session_detach_releases_python_map_reference() -> None:
+    class FakeDetachedSession:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakeNativeRenderSession:
+        closed = False
+        detached = False
+
+        def detach(self) -> FakeDetachedSession:
+            self.detached = True
+            return FakeDetachedSession()
+
+    session = render.RenderSessionHandle._from_native(
+        FakeNativeRenderSession(), object()
+    )
+
+    detached = session.detach()
+
+    assert session.detached
+    assert session._map is None  # noqa: SLF001
+    detached.close()
+
+
 def test_map_handle_context_manager_closes_once() -> None:
     with mln.RuntimeHandle() as runtime:
         with pytest.raises(TypeError, match="RuntimeHandle.create_map"):

--- a/bindings/python/tests/test_render_opengl_egl.py
+++ b/bindings/python/tests/test_render_opengl_egl.py
@@ -307,6 +307,20 @@ def test_attach_returns_public_render_session_and_rejects_second_session(
     assert not session.closed
 
 
+def test_detached_session_leaves_the_map_free_to_close(
+    opengl_owned_session: OpenGLOwnedSession,
+) -> None:
+    session = opengl_owned_session.session
+
+    assert_invalid_state(opengl_owned_session.map.close)
+
+    detached = session.detach()
+    opengl_owned_session.map.close()
+    detached.close()
+
+    assert session.closed
+
+
 def test_render_update_without_pending_update_reports_false_and_keeps_session_live(
     opengl_owned_session: OpenGLOwnedSession,
 ) -> None:

--- a/bindings/python/tests/test_render_vulkan_owned.py
+++ b/bindings/python/tests/test_render_vulkan_owned.py
@@ -180,6 +180,20 @@ def test_attach_returns_public_render_session_and_rejects_second_session(
     assert not session.closed
 
 
+def test_detached_session_leaves_the_map_free_to_close(
+    vulkan_owned_session: VulkanOwnedSession,
+) -> None:
+    session = vulkan_owned_session.session
+
+    assert_invalid_state(vulkan_owned_session.map.close)
+
+    detached = session.detach()
+    vulkan_owned_session.map.close()
+    detached.close()
+
+    assert session.closed
+
+
 def test_render_update_without_pending_update_reports_false_and_keeps_session_live(
     vulkan_owned_session: VulkanOwnedSession,
 ) -> None:

--- a/bindings/rust/crates/maplibre-native-core/src/camera.rs
+++ b/bindings/rust/crates/maplibre-native-core/src/camera.rs
@@ -18,6 +18,10 @@ pub struct CameraOptions {
     pub pitch: Option<f64>,
     pub center_altitude: Option<f64>,
     pub padding: Option<EdgeInsets>,
+    /// Screen-space anchor for jump, ease, and fly commands.
+    ///
+    /// This field is input-only: MapLibre Native applies it to camera commands
+    /// and never reports it back, so it is always `None` on a camera read.
     pub anchor: Option<ScreenPoint>,
     pub roll: Option<f64>,
     pub field_of_view: Option<f64>,

--- a/bindings/rust/crates/maplibre-native/src/map.rs
+++ b/bindings/rust/crates/maplibre-native/src/map.rs
@@ -194,6 +194,12 @@ impl MapHandle {
     /// Native destruction errors are returned. When destruction fails, the
     /// underlying native handle remains live in the shared state so future child
     /// handles can continue to retain and close the map safely.
+    ///
+    /// Closing discards this map's queued runtime events and its recorded
+    /// loading failure. There is no flush and no terminal event, so read any
+    /// state you mirror from events before closing, and treat close as the end
+    /// of this map's event stream rather than awaiting an event during
+    /// teardown. Dropping the handle ends the stream the same way.
     pub fn close(self) -> std::result::Result<(), HandleOperationError<Self>> {
         if self.inner.is_closed() {
             return Ok(());
@@ -335,6 +341,10 @@ impl MapHandle {
     }
 
     /// Applies a camera ease transition command.
+    ///
+    /// An absent `animation`, or an animation with no duration, eases over zero
+    /// duration: the camera reaches the target before this call returns, with
+    /// no runtime pump in between. Set a duration to animate over time.
     pub fn ease_to(
         &self,
         camera: &CameraOptions,
@@ -351,6 +361,11 @@ impl MapHandle {
     }
 
     /// Applies a camera fly transition command.
+    ///
+    /// Fly is the one camera command that animates by default: an absent
+    /// `animation`, or an animation with no duration, derives a duration from a
+    /// default velocity of 1.2 screenfuls per second, so the camera is still en
+    /// route when this call returns and advances as the runtime is pumped.
     pub fn fly_to(
         &self,
         camera: &CameraOptions,
@@ -374,6 +389,10 @@ impl MapHandle {
     }
 
     /// Applies an animated screen-space pan command.
+    ///
+    /// Native routes this delta through the ease transition, so an absent
+    /// `animation`, or an animation with no duration, applies the pan instantly
+    /// like [`Self::ease_to`]. Set a duration to animate over time.
     pub fn move_by_animated(
         &self,
         delta_x: f64,
@@ -401,6 +420,10 @@ impl MapHandle {
     }
 
     /// Applies an animated screen-space zoom command.
+    ///
+    /// Native routes this delta through the ease transition, so an absent
+    /// `animation`, or an animation with no duration, applies the zoom
+    /// instantly like [`Self::ease_to`]. Set a duration to animate over time.
     pub fn scale_by_animated(
         &self,
         scale: f64,
@@ -432,6 +455,10 @@ impl MapHandle {
     }
 
     /// Applies an animated screen-space rotate command.
+    ///
+    /// Native routes this delta through the ease transition, so an absent
+    /// `animation`, or an animation with no duration, applies the rotation
+    /// instantly like [`Self::ease_to`]. Set a duration to animate over time.
     pub fn rotate_by_animated(
         &self,
         first: ScreenPoint,
@@ -460,6 +487,10 @@ impl MapHandle {
     }
 
     /// Applies an animated pitch delta command.
+    ///
+    /// Native routes this delta through the ease transition, so an absent
+    /// `animation`, or an animation with no duration, applies the pitch
+    /// instantly like [`Self::ease_to`]. Set a duration to animate over time.
     pub fn pitch_by_animated(
         &self,
         pitch: f64,

--- a/bindings/rust/crates/maplibre-native/src/map.rs
+++ b/bindings/rust/crates/maplibre-native/src/map.rs
@@ -362,10 +362,11 @@ impl MapHandle {
 
     /// Applies a camera fly transition command.
     ///
-    /// Fly is the one camera command that animates by default: an absent
-    /// `animation`, or an animation with no duration, derives a duration from a
-    /// default velocity of 1.2 screenfuls per second, so the camera is still en
-    /// route when this call returns and advances as the runtime is pumped.
+    /// Fly is the one camera command that animates by default. When duration is
+    /// absent, native derives it from `AnimationOptions::velocity`; when
+    /// velocity is absent too, native defaults to 1.2 screenfuls per second.
+    /// The camera is therefore still en route when this call returns and
+    /// advances as the runtime is pumped.
     pub fn fly_to(
         &self,
         camera: &CameraOptions,

--- a/bindings/rust/crates/maplibre-native/src/map/style.rs
+++ b/bindings/rust/crates/maplibre-native/src/map/style.rs
@@ -28,10 +28,9 @@ impl super::MapHandle {
     /// returns `Ok` here and reports through a later loading-failed runtime
     /// event. Watch the event stream for load outcomes.
     ///
-    /// A well-formed style whose contents are semantically invalid, such as an
-    /// unknown `"version"` or a layer naming a missing source, loads without an
-    /// error and without an event: MapLibre Native logs it and renders what it
-    /// can.
+    /// Unsupported style versions and other parse failures report a
+    /// loading-failed event; callers must not treat syntactically valid JSON as
+    /// a successful style load until the event stream confirms it.
     pub fn set_style_url(&self, url: &str) -> Result<()> {
         let map = self.inner.as_ptr()?;
         let url = maplibre_core::string::c_string(url)?;
@@ -49,10 +48,9 @@ impl super::MapHandle {
     /// runtime event. Handle both, so an event-driven loop stays consistent
     /// with the call site.
     ///
-    /// A well-formed style whose contents are semantically invalid, such as an
-    /// unknown `"version"` or a layer naming a missing source, loads without an
-    /// error and without an event: MapLibre Native logs it and renders what it
-    /// can.
+    /// Unsupported style versions and other parse failures return an error and
+    /// also report a loading-failed event. Callers must not equate syntactically
+    /// valid JSON with a supported style document.
     pub fn set_style_json(&self, json: &str) -> Result<()> {
         let map = self.inner.as_ptr()?;
         let json = maplibre_core::string::c_string(json)?;

--- a/bindings/rust/crates/maplibre-native/src/map/style.rs
+++ b/bindings/rust/crates/maplibre-native/src/map/style.rs
@@ -24,6 +24,14 @@ use crate::{
 impl super::MapHandle {
     /// Loads a style URL through MapLibre Native style APIs.
     ///
+    /// Loading is asynchronous, so a style that fails to fetch or parse still
+    /// returns `Ok` here and reports through a later loading-failed runtime
+    /// event. Watch the event stream for load outcomes.
+    ///
+    /// A well-formed style whose contents are semantically invalid, such as an
+    /// unknown `"version"` or a layer naming a missing source, loads without an
+    /// error and without an event: MapLibre Native logs it and renders what it
+    /// can.
     pub fn set_style_url(&self, url: &str) -> Result<()> {
         let map = self.inner.as_ptr()?;
         let url = maplibre_core::string::c_string(url)?;
@@ -35,6 +43,16 @@ impl super::MapHandle {
     }
 
     /// Loads inline style JSON through MapLibre Native style APIs.
+    ///
+    /// Malformed JSON is reported twice: this call returns the parse error
+    /// synchronously, and the same message also arrives as a loading-failed
+    /// runtime event. Handle both, so an event-driven loop stays consistent
+    /// with the call site.
+    ///
+    /// A well-formed style whose contents are semantically invalid, such as an
+    /// unknown `"version"` or a layer naming a missing source, loads without an
+    /// error and without an event: MapLibre Native logs it and renders what it
+    /// can.
     pub fn set_style_json(&self, json: &str) -> Result<()> {
         let map = self.inner.as_ptr()?;
         let json = maplibre_core::string::c_string(json)?;

--- a/bindings/rust/crates/maplibre-native/src/render.rs
+++ b/bindings/rust/crates/maplibre-native/src/render.rs
@@ -773,9 +773,18 @@ impl RenderSessionState {
         }
     }
 
+    /// Releases the retained parent map state at most once.
+    ///
+    /// Detach and close both call this. `Option::take` leaves the second call a
+    /// no-op, so the parent retention is released exactly once no matter which
+    /// order a detached session reaches close in.
+    fn release_map(&self) {
+        self.map.borrow_mut().take();
+    }
+
     fn close(&self) -> Result<()> {
         self.handle.close()?;
-        self.map.borrow_mut().take();
+        self.release_map();
         Ok(())
     }
 }
@@ -795,6 +804,9 @@ impl fmt::Debug for RenderSessionHandle {
 }
 
 /// Render session after backend resources have been detached.
+///
+/// A detached session holds no reference to its former map, so it stays
+/// destroyable after that map closes.
 pub struct DetachedRenderSessionHandle {
     inner: Rc<RenderSessionState>,
 }
@@ -1295,6 +1307,11 @@ impl RenderSessionHandle {
     ///
     /// The native session remains live only for destruction, so successful
     /// detach consumes this handle and returns a detached close-only handle.
+    ///
+    /// Detach also releases this session's retention of the parent map, so a
+    /// detached session leaves the map free to close. Close the detached
+    /// session whenever it suits the host; it stays destroyable after the map
+    /// closes because a detached session no longer reaches its map.
     pub fn detach(
         self,
     ) -> std::result::Result<DetachedRenderSessionHandle, HandleOperationError<Self>> {
@@ -1311,6 +1328,10 @@ impl RenderSessionHandle {
             return Err(HandleOperationError::new(error, self));
         }
         self.inner.detached.set(true);
+        // A detached session cannot reattach and never dereferences its map
+        // again, so the parent retention ends here and the map becomes free to
+        // close while this session is still open.
+        self.inner.release_map();
         Ok(DetachedRenderSessionHandle {
             inner: Rc::clone(&self.inner),
         })

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -1999,6 +1999,30 @@ fn owned_texture_session_retains_parent_and_enforces_single_session() {
 }
 
 #[test]
+// Spec coverage: BND-042. The C API rejects destroying a map that still has an
+// attached session and allows destroying one whose session detached, so the
+// binding's parent retention ends at detach rather than at close.
+fn detached_session_releases_the_parent_map_retention() {
+    if !has_test_owned_texture_session_backend() {
+        return;
+    }
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::new(64, 64, 1.0)).unwrap();
+    let (_context, session) =
+        create_owned_texture_session(&map, RenderTargetExtent::new(32, 16, 1.0))
+            .expect("Metal or Vulkan owned texture test session should attach when supported");
+
+    let error = map.close().unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidState);
+    let map = error.into_handle();
+
+    let detached = session.detach().unwrap();
+    map.close().unwrap();
+    detached.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
 // Spec coverage: BND-165.
 fn resize_updates_owned_texture_frame_extent() {
     if !has_test_owned_texture_session_backend() {

--- a/bindings/rust/crates/maplibre-native/src/runtime.rs
+++ b/bindings/rust/crates/maplibre-native/src/runtime.rs
@@ -777,7 +777,14 @@ impl RuntimeHandle {
         )
     }
 
-    /// Runs one pending owner-thread task for this runtime.
+    /// Runs one iteration of this runtime's owner-thread run loop.
+    ///
+    /// One iteration drains the high-priority task queue and then the default
+    /// task queue until both are empty, including tasks enqueued while the
+    /// drain runs, and also services expired timers and ready I/O. The call
+    /// returns without blocking on new work, yet its duration is unbounded: a
+    /// single iteration can span a whole style parse. Drive it from a pump loop
+    /// rather than budgeting it as a fixed per-frame slice.
     pub fn run_once(&self) -> Result<()> {
         let runtime = self.inner.as_ptr()?;
         // SAFETY: runtime is a live runtime handle owned by this wrapper.
@@ -785,6 +792,12 @@ impl RuntimeHandle {
     }
 
     /// Polls one queued runtime event and copies it into an owned Rust value.
+    ///
+    /// Polling also advances binding-owned state that the event reports. A
+    /// polled [`crate::RuntimeEventType::MapStyleLoaded`] event releases the
+    /// upcall state of custom geometry sources the newly loaded style dropped,
+    /// so keep polling to completion to let that state be reclaimed; a map
+    /// whose events go unpolled keeps those sources' callback state alive.
     pub fn poll_event(&self) -> Result<Option<RuntimeEvent>> {
         let runtime = self.inner.as_ptr()?;
         let mut event = empty_runtime_event();


### PR DESCRIPTION
## Summary

Rust render sessions now release their parent map retention on successful detach, matching the C contract where only an *attached* session blocks map destruction, and both bindings' per-method docs are corrected for `run_once`, `poll_event`, the style setters, `ease_to`/`fly_to` duration defaults, map close discarding queued events, and the input-only `CameraOptions.anchor`.

## Test plan

Added Rust and Python render-session tests that detach, close the map, then close the detached session, alongside the existing lint and formatter checks.

## AI assistance

- **Tools:** Claude Code
- **Context:** Drafted from a first-consumer bug report; the divergence and the corrected C semantics were verified against `src/map/map.cpp` and the mbgl transform sources before editing.