### PR TITLE
Align Go and Zig detach with the C map close contract

### DIFF
--- a/bindings/dotnet/src/Maplibre.Native/Camera/CameraOptions.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Camera/CameraOptions.cs
@@ -12,6 +12,12 @@ public sealed record CameraOptions
     public LatLng? Center { get; set; }
     public double? CenterAltitude { get; set; }
     public EdgeInsets? Padding { get; set; }
+
+    /// <summary>
+    /// Input-only screen point the camera pivots around. Jump, ease, and fly honor
+    /// it; MapLibre leaves it <see langword="null" /> on every read path, including
+    /// camera snapshots and the camera-for-bounds helpers.
+    /// </summary>
     public ScreenPoint? Anchor { get; set; }
     public double? Zoom { get; set; }
     public double? Bearing { get; set; }

--- a/bindings/dotnet/src/Maplibre.Native/Map/MapHandle.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Map/MapHandle.cs
@@ -175,6 +175,12 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Eases to the camera descriptor with animation options.</summary>
+    /// <remarks>
+    /// A <see langword="null" /> <paramref name="animation" />, or one with no
+    /// <c>Duration</c>, uses the native default duration of zero, so the camera
+    /// reaches the target immediately and nothing is animated. Set <c>Duration</c>
+    /// explicitly to animate.
+    /// </remarks>
     public void EaseTo(CameraOptions camera, AnimationOptions? animation)
     {
         var nativeCamera = MapStructs.ToNative(camera);
@@ -189,6 +195,13 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Flies to the camera descriptor with animation options.</summary>
+    /// <remarks>
+    /// <see cref="FlyTo" /> is the one camera command that derives a duration when
+    /// none is given: a <see langword="null" /> <paramref name="animation" />, or
+    /// one with no <c>Duration</c>, flies at a default velocity of 1.2 rho-screenfuls
+    /// per second, so the duration scales with the distance travelled. Set
+    /// <c>Duration</c> explicitly to pin it.
+    /// </remarks>
     public void FlyTo(CameraOptions camera, AnimationOptions? animation)
     {
         var nativeCamera = MapStructs.ToNative(camera);
@@ -209,6 +222,11 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Moves the map by a screen delta with animation options.</summary>
+    /// <remarks>
+    /// A <see langword="null" /> <paramref name="animation" />, or one with no
+    /// <c>Duration</c>, eases with the native default duration of zero, so the
+    /// change applies instantly; see <see cref="EaseTo" />.
+    /// </remarks>
     public void MoveByAnimated(double deltaX, double deltaY, AnimationOptions? animation)
     {
         var nativeAnimation = animation is null ? default : MapStructs.ToNative(animation);
@@ -232,6 +250,11 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Scales the map around a screen anchor with animation options.</summary>
+    /// <remarks>
+    /// A <see langword="null" /> <paramref name="animation" />, or one with no
+    /// <c>Duration</c>, eases with the native default duration of zero, so the
+    /// change applies instantly; see <see cref="EaseTo" />.
+    /// </remarks>
     public void ScaleByAnimated(double scale, ScreenPoint? anchor, AnimationOptions? animation)
     {
         var nativeAnchor = anchor is { } anchorValue ? MapStructs.ToNative(anchorValue) : default;
@@ -255,6 +278,11 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Rotates around two screen points with animation options.</summary>
+    /// <remarks>
+    /// A <see langword="null" /> <paramref name="animation" />, or one with no
+    /// <c>Duration</c>, eases with the native default duration of zero, so the
+    /// change applies instantly; see <see cref="EaseTo" />.
+    /// </remarks>
     public void RotateByAnimated(ScreenPoint first, ScreenPoint second, AnimationOptions? animation)
     {
         var nativeFirst = MapStructs.ToNative(first);
@@ -277,6 +305,11 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Pitches the map by a delta in degrees with animation options.</summary>
+    /// <remarks>
+    /// A <see langword="null" /> <paramref name="animation" />, or one with no
+    /// <c>Duration</c>, eases with the native default duration of zero, so the
+    /// change applies instantly; see <see cref="EaseTo" />.
+    /// </remarks>
     public void PitchByAnimated(double pitch, AnimationOptions? animation)
     {
         var nativeAnimation = animation is null ? default : MapStructs.ToNative(animation);
@@ -533,6 +566,15 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Loads a style URL through MapLibre Native style APIs.</summary>
+    /// <remarks>
+    /// Loading is asynchronous, so a style that is missing, unreachable, or
+    /// malformed still returns normally here and reports through a
+    /// <see cref="RuntimeEventType.MapLoadingFailed" /> runtime event. Watch the
+    /// runtime event queue to observe style load failures. A well-formed style
+    /// that MapLibre rejects semantically, such as an unknown <c>version</c> or a
+    /// layer naming a missing source, produces neither an exception nor an event:
+    /// MapLibre logs it and renders what it can.
+    /// </remarks>
     public void SetStyleUrl(string url)
     {
         ArgumentNullException.ThrowIfNull(url);
@@ -541,6 +583,15 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Loads inline style JSON through MapLibre Native style APIs.</summary>
+    /// <remarks>
+    /// Malformed JSON is reported twice: this call throws the parse error
+    /// synchronously, and the same message also arrives as a
+    /// <see cref="RuntimeEventType.MapLoadingFailed" /> runtime event. Handle both
+    /// so a queued failure event is not a surprise. A well-formed style that
+    /// MapLibre rejects semantically, such as an unknown <c>version</c> or a layer
+    /// naming a missing source, produces neither an exception nor an event:
+    /// MapLibre logs it and renders what it can.
+    /// </remarks>
     public void SetStyleJson(string json)
     {
         ArgumentNullException.ThrowIfNull(json);
@@ -1451,6 +1502,12 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Destroys the map on its owner thread.</summary>
+    /// <remarks>
+    /// Closing discards this map's queued runtime events and its recorded loading
+    /// failure without a flush and without a terminal event. Snapshot any mirrored
+    /// state you still need before closing, and drive teardown from the close
+    /// result rather than awaiting an event.
+    /// </remarks>
     public void Close()
     {
         state.Close();

--- a/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Render/RenderHandles.cs
@@ -1198,7 +1198,12 @@ internal sealed class FrameScope : IDisposable
     {
         if (IsClosed)
         {
-            throw new ObjectDisposedException(owner);
+            throw new InvalidStateException(
+                MaplibreStatus.InvalidState,
+                null,
+                $"{owner} is closed.",
+                null
+            );
         }
     }
 

--- a/bindings/dotnet/src/Maplibre.Native/Runtime/RuntimeHandle.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Runtime/RuntimeHandle.cs
@@ -603,13 +603,35 @@ public sealed unsafe class RuntimeHandle : IDisposable
         }
     }
 
-    /// <summary>Runs one pending owner-thread task for this runtime.</summary>
+    /// <summary>
+    /// Runs one iteration of this runtime's owner-thread run loop. The iteration
+    /// drains the high-priority task queue and then the default queue until both
+    /// are empty, including tasks enqueued during the drain, and also dispatches
+    /// expired timers and ready I/O.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="RunOnce" /> returns without blocking on new work, but its
+    /// duration is unbounded: a single iteration can span a style parse. Treat it
+    /// as "make progress now" rather than as a fixed per-frame time slice.
+    /// </remarks>
     public void RunOnce()
     {
         NativeStatus.Check(NativeMethods.mln_runtime_run_once(Pointer));
     }
 
-    /// <summary>Polls and copies the next runtime event, when one is queued.</summary>
+    /// <summary>
+    /// Polls and copies the next runtime event, when one is queued, and returns
+    /// <see langword="null" /> when the queue is empty.
+    /// </summary>
+    /// <remarks>
+    /// Polling also advances binding-owned state: on a
+    /// <see cref="RuntimeEventType.MapStyleLoaded" /> event this binding releases
+    /// the map's detached custom geometry sources, closing the upcall stubs for
+    /// sources the new style dropped. That release happens when the event is
+    /// polled, so drain the queue to keep dropped sources from lingering. It also
+    /// needs a resolvable <see cref="RuntimeEvent.MapSource" />; see that member
+    /// for the reference caveat.
+    /// </remarks>
     public RuntimeEvent? PollEvent()
     {
         var raw = RuntimeStructs.EmptyNativeEvent();

--- a/bindings/dotnet/src/Maplibre.Native/Runtime/RuntimeTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Runtime/RuntimeTypes.cs
@@ -70,6 +70,13 @@ public enum RuntimeEventType : uint
     OfflineOperationCompleted = 22,
 }
 
+/// <param name="MapSource">
+/// The map that raised this event, resolved from the runtime's weak map registry.
+/// Hold your own strong reference to a <see cref="MapHandle" /> for as long as you
+/// want to attribute its events: once the only remaining reference is the runtime's
+/// weak one, the map can be collected and this member is <see langword="null" />
+/// even though <see cref="SourceType" /> still reports a map source.
+/// </param>
 public sealed record RuntimeEvent(
     RuntimeEventType Type,
     uint RawType,

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/RenderSessionTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/RenderSessionTests.cs
@@ -289,7 +289,7 @@ public sealed unsafe class RenderSessionTests
         );
         Assert.Equal(6, metal.Texture.Address);
         metalScope.Dispose();
-        Assert.Throws<ObjectDisposedException>(() => metal.Texture);
+        Assert.Throws<InvalidStateException>(() => metal.Texture);
 
         var vulkanScope = new FrameScope(nameof(VulkanOwnedTextureFrame));
         var vulkan = new VulkanOwnedTextureFrame(
@@ -307,7 +307,7 @@ public sealed unsafe class RenderSessionTests
         );
         Assert.Equal(7, vulkan.ImageView.Address);
         vulkanScope.Dispose();
-        Assert.Throws<ObjectDisposedException>(() => vulkan.ImageView);
+        Assert.Throws<InvalidStateException>(() => vulkan.ImageView);
 
         var openglScope = new FrameScope(nameof(OpenGLOwnedTextureFrame));
         var opengl = new OpenGLOwnedTextureFrame(
@@ -325,7 +325,7 @@ public sealed unsafe class RenderSessionTests
         );
         Assert.Equal(6u, opengl.Texture);
         openglScope.Dispose();
-        Assert.Throws<ObjectDisposedException>(() => opengl.Texture);
+        Assert.Throws<InvalidStateException>(() => opengl.Texture);
     }
 
     [BindingSpecTest("BND-169")]
@@ -361,7 +361,7 @@ public sealed unsafe class RenderSessionTests
             state.Close();
 
             Assert.True(state.IsClosed);
-            Assert.Throws<ObjectDisposedException>(scope.EnsureActive);
+            Assert.Throws<InvalidStateException>(scope.EnsureActive);
             Assert.Equal(2, releaseCalls);
             session.Close();
         }

--- a/bindings/go/camera.go
+++ b/bindings/go/camera.go
@@ -10,12 +10,15 @@ type CameraOptions struct {
 	Center         *LatLng
 	CenterAltitude *float64
 	Padding        *EdgeInsets
-	Anchor         *ScreenPoint
-	Zoom           *float64
-	Bearing        *float64
-	Pitch          *float64
-	Roll           *float64
-	FieldOfView    *float64
+	// Anchor is input-only: JumpTo, EaseTo, and FlyTo honor it as the screen
+	// point the camera pivots around, and MapLibre leaves it nil on every read
+	// path, including Camera and the CameraFor* fit helpers.
+	Anchor      *ScreenPoint
+	Zoom        *float64
+	Bearing     *float64
+	Pitch       *float64
+	Roll        *float64
+	FieldOfView *float64
 }
 
 // Equal reports whether two descriptors hold the same field values. Use this instead of ==, which

--- a/bindings/go/map.go
+++ b/bindings/go/map.go
@@ -131,7 +131,14 @@ func (m *MapHandle) RequestStillImage() error {
 	return checkNative(func() int32 { return int32(C.mln_map_request_still_image((*C.mln_map)(unsafe.Pointer(ptr)))) })
 }
 
-// SetStyleURL loads a style URL through MapLibre Native style APIs.
+// SetStyleURL loads a style URL through MapLibre Native style APIs. Loading is
+// asynchronous, so a style that is missing, unreachable, or malformed still
+// returns success here and reports through a map-loading-failed runtime event.
+// Watch the runtime event queue to observe style load failures.
+//
+// A well-formed style that MapLibre rejects semantically, such as an unknown
+// "version" or a layer naming a missing source, produces neither an error nor
+// an event: MapLibre logs it and renders what it can.
 func (m *MapHandle) SetStyleURL(url string) error {
 	if err := validateCStringArgument("style URL", url); err != nil {
 		return err
@@ -148,6 +155,13 @@ func (m *MapHandle) SetStyleURL(url string) error {
 }
 
 // SetStyleJSON loads inline style JSON through MapLibre Native style APIs.
+// Malformed JSON is reported twice: this call returns the parse error
+// synchronously, and the same message also arrives as a map-loading-failed
+// runtime event. Handle both so a queued failure event is not a surprise.
+//
+// A well-formed style that MapLibre rejects semantically, such as an unknown
+// "version" or a layer naming a missing source, produces neither an error nor
+// an event: MapLibre logs it and renders what it can.
 func (m *MapHandle) SetStyleJSON(json string) error {
 	if err := validateCStringArgument("style JSON", json); err != nil {
 		return err
@@ -289,8 +303,12 @@ func (m *MapHandle) JumpTo(camera CameraOptions) error {
 	})
 }
 
-// EaseTo applies a camera ease transition command. Passing nil animation uses
-// the native default animation options.
+// EaseTo applies a camera ease transition command. Passing nil animation, or an
+// animation with no Duration, uses the native default duration of zero, so the
+// camera reaches the target immediately and no transition is animated. Set
+// Duration explicitly to animate.
+//
+// Camera anchor comes from camera.Anchor; see CameraOptions.
 func (m *MapHandle) EaseTo(camera CameraOptions, animation *AnimationOptions) error {
 	ptr, release, err := m.ptr()
 	if err != nil {
@@ -306,8 +324,11 @@ func (m *MapHandle) EaseTo(camera CameraOptions, animation *AnimationOptions) er
 	})
 }
 
-// FlyTo applies a camera fly transition command. Passing nil animation uses the
-// native default animation options.
+// FlyTo applies a camera fly transition command. FlyTo is the one camera
+// command that derives a duration when none is given: passing nil animation, or
+// an animation with no Duration, flies at a default velocity of 1.2 ρ-screenfuls
+// per second, so the duration scales with the distance travelled. Set Duration
+// explicitly to pin it.
 func (m *MapHandle) FlyTo(camera CameraOptions, animation *AnimationOptions) error {
 	ptr, release, err := m.ptr()
 	if err != nil {
@@ -337,7 +358,8 @@ func (m *MapHandle) MoveBy(delta ScreenPoint) error {
 }
 
 // MoveByAnimated applies an animated screen-space pan command. Passing nil
-// animation uses the native default animation options.
+// animation, or an animation with no Duration, eases with the native default
+// duration of zero, so the change applies instantly; see EaseTo.
 func (m *MapHandle) MoveByAnimated(delta ScreenPoint, animation *AnimationOptions) error {
 	ptr, release, err := m.ptr()
 	if err != nil {
@@ -418,7 +440,8 @@ func (m *MapHandle) RotateBy(first ScreenPoint, second ScreenPoint) error {
 }
 
 // RotateByAnimated applies an animated screen-space rotate command. Passing nil
-// animation uses the native default animation options.
+// animation, or an animation with no Duration, eases with the native default
+// duration of zero, so the change applies instantly; see EaseTo.
 func (m *MapHandle) RotateByAnimated(first ScreenPoint, second ScreenPoint, animation *AnimationOptions) error {
 	ptr, release, err := m.ptr()
 	if err != nil {
@@ -452,7 +475,8 @@ func (m *MapHandle) PitchBy(pitch float64) error {
 }
 
 // PitchByAnimated applies an animated pitch delta command. Passing nil
-// animation uses the native default animation options.
+// animation, or an animation with no Duration, eases with the native default
+// duration of zero, so the change applies instantly; see EaseTo.
 func (m *MapHandle) PitchByAnimated(pitch float64, animation *AnimationOptions) error {
 	ptr, release, err := m.ptr()
 	if err != nil {
@@ -923,6 +947,11 @@ func (m *MapHandle) releaseCustomGeometrySources() {
 // Close destroys this map. A successful close makes later calls no-ops. A
 // failed close leaves the native handle live so callers can retry on the owner
 // thread.
+//
+// Close discards this map's queued runtime events and its recorded loading
+// failure without a flush and without a terminal event. Snapshot any mirrored
+// state you still need before closing, and drive teardown from the close result
+// rather than awaiting an event.
 func (m *MapHandle) Close() error {
 	if m == nil || m.state == nil {
 		return newBindingError(ErrInvalidArgument, "MapHandle is nil")

--- a/bindings/go/render.go
+++ b/bindings/go/render.go
@@ -215,6 +215,10 @@ var destroyRenderSessionHandle = func(ptr *nativeRenderSession) int32 {
 	return int32(C.mln_render_session_destroy((*C.mln_render_session)(unsafe.Pointer(ptr))))
 }
 
+var detachRenderSessionHandle = func(ptr *nativeRenderSession) int32 {
+	return int32(C.mln_render_session_detach((*C.mln_render_session)(unsafe.Pointer(ptr))))
+}
+
 type metalOwnedTextureFrameState struct {
 	session *RenderSessionHandle
 	raw     C.mln_metal_owned_texture_frame
@@ -756,7 +760,13 @@ func (session *RenderSessionHandle) RenderUpdate() (bool, error) {
 	return bool(rendered), nil
 }
 
-// Detach detaches the render target from the session.
+// Detach detaches the render target from the session. The session stays live
+// and still needs Close, but it no longer holds its map: after a successful
+// detach the map can be closed while this session is still open, and every
+// session operation that needs an attached target reports a native error.
+//
+// A detached session stays detached. Attach a new session on the map to render
+// again.
 func (session *RenderSessionHandle) Detach() error {
 	ptr, release, err := session.ptr()
 	if err != nil {
@@ -766,7 +776,13 @@ func (session *RenderSessionHandle) Detach() error {
 	defer session.state.KeepAlive()
 	defer session.parent.state.KeepAlive()
 	return session.withNoAcquiredFrame(func() error {
-		return checkNative(func() int32 { return int32(C.mln_render_session_detach((*C.mln_render_session)(unsafe.Pointer(ptr)))) })
+		if err := checkNative(func() int32 {
+			return detachRenderSessionHandle(ptr)
+		}); err != nil {
+			return err
+		}
+		session.parentChild.Release()
+		return nil
 	})
 }
 

--- a/bindings/go/render_test.go
+++ b/bindings/go/render_test.go
@@ -150,6 +150,62 @@ func TestMapCloseFailsWhileRenderSessionIsLive(t *testing.T) {
 	}
 }
 
+func TestMapCloseSucceedsAfterRenderSessionDetach(t *testing.T) {
+	mapState, err := handle.New(&nativeMap{}, "MapHandle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := &MapHandle{state: mapState}
+	session, err := newRenderSessionHandle(m, &nativeRenderSession{})
+	if err != nil {
+		t.Fatalf("newRenderSessionHandle(): %v", err)
+	}
+
+	oldDestroyMap := destroyMapHandle
+	oldDestroySession := destroyRenderSessionHandle
+	oldDetachSession := detachRenderSessionHandle
+	defer func() {
+		destroyMapHandle = oldDestroyMap
+		destroyRenderSessionHandle = oldDestroySession
+		detachRenderSessionHandle = oldDetachSession
+	}()
+	var mapDestroyCalls atomic.Int32
+	var sessionDestroyCalls atomic.Int32
+	var detachCalls atomic.Int32
+	destroyMapHandle = func(*nativeMap) int32 {
+		mapDestroyCalls.Add(1)
+		return 0
+	}
+	destroyRenderSessionHandle = func(*nativeRenderSession) int32 {
+		sessionDestroyCalls.Add(1)
+		return 0
+	}
+	detachRenderSessionHandle = func(*nativeRenderSession) int32 {
+		detachCalls.Add(1)
+		return 0
+	}
+
+	if err := session.Detach(); err != nil {
+		t.Fatalf("RenderSession Detach(): %v", err)
+	}
+	// Detaching releases the map, so the map closes while the session is open.
+	if err := m.Close(); err != nil {
+		t.Fatalf("Map Close() after detach: %v", err)
+	}
+	if got := mapDestroyCalls.Load(); got != 1 {
+		t.Fatalf("map destroy calls after detach = %d, want 1", got)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("RenderSession Close() after map close: %v", err)
+	}
+	if got := sessionDestroyCalls.Load(); got != 1 {
+		t.Fatalf("render session destroy calls = %d, want 1", got)
+	}
+	if got := detachCalls.Load(); got != 1 {
+		t.Fatalf("detach calls = %d, want 1", got)
+	}
+}
+
 func newActiveFrameTestSession(t *testing.T) *RenderSessionHandle {
 	t.Helper()
 

--- a/bindings/go/runtime.go
+++ b/bindings/go/runtime.go
@@ -513,7 +513,14 @@ func (runtime *RuntimeHandle) ptr() (*nativeRuntime, func(), error) {
 	return borrow.Ptr(), borrow.Release, nil
 }
 
-// RunOnce runs one pending owner-thread task for this runtime.
+// RunOnce runs one iteration of this runtime's owner-thread run loop. The
+// iteration drains the high-priority task queue and then the default queue
+// until both are empty, including tasks enqueued during the drain, and also
+// dispatches expired timers and ready I/O.
+//
+// RunOnce returns without blocking on new work, but its duration is unbounded:
+// a single iteration can span a style parse. Treat it as "make progress now"
+// rather than as a fixed per-frame time slice.
 func (runtime *RuntimeHandle) RunOnce() error {
 	ptr, release, err := runtime.ptr()
 	if err != nil {
@@ -526,7 +533,13 @@ func (runtime *RuntimeHandle) RunOnce() error {
 	})
 }
 
-// PollEvent polls one queued runtime event and copies it into a Go value.
+// PollEvent polls one queued runtime event and copies it into a Go value. It
+// reports a nil event when the queue is empty.
+//
+// Polling also advances binding-owned state: on a map-style-loaded event this
+// binding releases the map's detached custom geometry sources, closing the
+// upcall stubs for sources the new style dropped. That release happens when the
+// event is polled, so drain the queue to keep dropped sources from lingering.
 func (runtime *RuntimeHandle) PollEvent() (*RuntimeEvent, error) {
 	ptr, release, err := runtime.ptr()
 	if err != nil {

--- a/bindings/swift/Sources/MaplibreNative/Camera.swift
+++ b/bindings/swift/Sources/MaplibreNative/Camera.swift
@@ -6,6 +6,9 @@ public struct CameraOptions: Equatable, Sendable {
   public var pitch: Double?
   public var centerAltitude: Double?
   public var padding: EdgeInsets?
+  /// Input-only screen point the camera pivots around. `jumpTo`, `easeTo`, and
+  /// `flyTo` honor it; MapLibre leaves it `nil` on every read path, including
+  /// camera snapshots and the camera-for-bounds helpers.
   public var anchor: ScreenPoint?
   public var roll: Double?
   public var fieldOfView: Double?

--- a/bindings/swift/Sources/MaplibreNative/Map.swift
+++ b/bindings/swift/Sources/MaplibreNative/Map.swift
@@ -176,6 +176,16 @@ public final class MapHandle {
     resetCallbackRetentionState()
   }
 
+  /// Loads a style URL through MapLibre Native style APIs.
+  ///
+  /// Loading is asynchronous, so a style that is missing, unreachable, or
+  /// malformed still returns normally here and reports through a
+  /// map-loading-failed runtime event. Watch the runtime event queue to observe
+  /// style load failures.
+  ///
+  /// A well-formed style that MapLibre rejects semantically, such as an
+  /// unknown `version` or a layer naming a missing source, produces neither
+  /// an error nor an event: MapLibre logs it and renders what it can.
   public func setStyleURL(_ url: String) throws {
     try mapNativeFailure {
       try NativeString.withCString(url) { url in
@@ -185,6 +195,15 @@ public final class MapHandle {
     }
   }
 
+  /// Loads inline style JSON through MapLibre Native style APIs.
+  ///
+  /// Malformed JSON is reported twice: this call throws the parse error
+  /// synchronously, and the same message also arrives as a map-loading-failed
+  /// runtime event. Handle both so a queued failure event is not a surprise.
+  ///
+  /// A well-formed style that MapLibre rejects semantically, such as an
+  /// unknown `version` or a layer naming a missing source, produces neither
+  /// an error nor an event: MapLibre logs it and renders what it can.
   public func setStyleJSON(_ json: String) throws {
     try mapNativeFailure {
       try NativeString.withCString(json) { json in

--- a/bindings/swift/Sources/MaplibreNative/Runtime.swift
+++ b/bindings/swift/Sources/MaplibreNative/Runtime.swift
@@ -368,12 +368,30 @@ public final class RuntimeHandle {
     try handle.requireLive()
   }
 
+  /// Runs one iteration of this runtime's owner-thread run loop.
+  ///
+  /// The iteration drains the high-priority task queue and then the default
+  /// queue until both are empty, including tasks enqueued during the drain, and
+  /// also dispatches expired timers and ready I/O.
+  ///
+  /// `runOnce` returns without blocking on new work, but its duration is
+  /// unbounded: a single iteration can span a style parse. Treat it as "make
+  /// progress now" rather than as a fixed per-frame time slice.
   public func runOnce() throws {
     try mapNativeFailure {
       try checkStatus(mln_runtime_run_once(handle.requireLive()))
     }
   }
 
+  /// Polls and copies the next queued runtime event, returning `nil` when the
+  /// queue is empty.
+  ///
+  /// Polling also advances binding-owned state: on a map-style-loaded event
+  /// this
+  /// binding releases the map's detached custom geometry sources, closing the
+  /// upcall stubs for sources the new style dropped. That release happens when
+  /// the event is polled, so drain the queue to keep dropped sources from
+  /// lingering.
   public func pollEvent() throws -> RuntimeEvent? {
     try mapNativeFailure {
       guard let event = try NativeRuntime.pollEvent(handle.requireLive()) else {

--- a/bindings/zig/src/map.zig
+++ b/bindings/zig/src/map.zig
@@ -23,7 +23,7 @@ const MapState = struct {
     id_value: values.MapId,
     diagnostic_store: ?*diagnostics.DiagnosticStore,
     custom_geometry_sources: *std.ArrayList(*CustomGeometrySourceState),
-    active_render_sessions: std.atomic.Value(usize),
+    attached_render_sessions: std.atomic.Value(usize),
     closing: bool,
 };
 
@@ -141,7 +141,7 @@ pub const MapHandle = enum(u128) {
             .id_value = map_registration.id,
             .diagnostic_store = diagnostic_store,
             .custom_geometry_sources = custom_geometry_sources,
-            .active_render_sessions = std.atomic.Value(usize).init(0),
+            .attached_render_sessions = std.atomic.Value(usize).init(0),
             .closing = false,
         };
         errdefer std.heap.smp_allocator.destroy(map_state);
@@ -153,6 +153,15 @@ pub const MapHandle = enum(u128) {
         return mapIdForHandle(self);
     }
 
+    /// Loads inline style JSON through MapLibre Native style APIs.
+    ///
+    /// Malformed JSON is reported twice: this call returns the parse error
+    /// synchronously, and the same message also arrives as a map-loading-failed
+    /// runtime event. Handle both so a queued failure event is not a surprise.
+    ///
+    /// A well-formed style that MapLibre rejects semantically, such as an
+    /// unknown `version` or a layer naming a missing source, produces neither an
+    /// error nor an event: MapLibre logs it and renders what it can.
     pub fn setStyleJson(
         self: *MapHandle,
         allocator: std.mem.Allocator,
@@ -165,6 +174,16 @@ pub const MapHandle = enum(u128) {
         clearCustomGeometrySourceStates(self);
     }
 
+    /// Loads a style URL through MapLibre Native style APIs.
+    ///
+    /// Loading is asynchronous, so a style that is missing, unreachable, or
+    /// malformed still returns success here and reports through a
+    /// map-loading-failed runtime event. Watch the runtime event queue to
+    /// observe style load failures.
+    ///
+    /// A well-formed style that MapLibre rejects semantically, such as an
+    /// unknown `version` or a layer naming a missing source, produces neither an
+    /// error nor an event: MapLibre logs it and renders what it can.
     pub fn setStyleUrl(
         self: *MapHandle,
         allocator: std.mem.Allocator,
@@ -1359,7 +1378,7 @@ pub const MapHandle = enum(u128) {
         const map_close = beginMapClose(self.*) catch |err| {
             if (err == error.InvalidState) {
                 if (diagnosticStore(self)) |store| {
-                    try status.setBindingDiagnostic(store, "map has live render sessions");
+                    try status.setBindingDiagnostic(store, "map has an attached render session");
                 }
             }
             return err;
@@ -1661,7 +1680,7 @@ fn beginMapClose(handle: MapHandle) status.BindingError!?MapClose {
     if (slot.generation != mapHandleGeneration(handle)) return null;
     const map_state = slot.state orelse return null;
     if (map_state.closing) return error.ActiveBorrow;
-    if (map_state.active_render_sessions.load(.seq_cst) != 0) return error.InvalidState;
+    if (map_state.attached_render_sessions.load(.seq_cst) != 0) return error.InvalidState;
     const map: *c.mln_map = @ptrCast(map_state.native orelse return null);
     map_state.closing = true;
     return .{
@@ -1724,7 +1743,7 @@ pub fn registerRenderSession(handle: *MapHandle) status.BindingError!RenderSessi
     const map_state = mapStateLocked(handle.*) orelse return error.ClosedHandle;
     if (map_state.closing) return error.ActiveBorrow;
     const map: *c.mln_map = @ptrCast(map_state.native orelse return error.ClosedHandle);
-    _ = map_state.active_render_sessions.fetchAdd(1, .seq_cst);
+    _ = map_state.attached_render_sessions.fetchAdd(1, .seq_cst);
     return .{
         .native = map,
         .diagnostic_store = map_state.diagnostic_store,
@@ -1733,7 +1752,7 @@ pub fn registerRenderSession(handle: *MapHandle) status.BindingError!RenderSessi
 
 pub fn unregisterRenderSession(handle: MapHandle) void {
     const map_state = mapState(handle) orelse return;
-    _ = map_state.active_render_sessions.fetchSub(1, .seq_cst);
+    _ = map_state.attached_render_sessions.fetchSub(1, .seq_cst);
 }
 
 fn customGeometrySourceCountForTesting(handle: *MapHandle) status.BindingError!usize {

--- a/bindings/zig/src/render.zig
+++ b/bindings/zig/src/render.zig
@@ -27,7 +27,9 @@ const RenderSessionFrameState = struct {
 
 const RenderSessionState = struct {
     native: ?*NativeRenderSession,
-    map_handle: map_module.MapHandle,
+    /// The map this session is registered against, cleared once the
+    /// registration is released by a successful detach or close.
+    map_handle: ?map_module.MapHandle,
     diagnostic_store: ?*diagnostics.DiagnosticStore,
     frame_state: ?*RenderSessionFrameState,
     active_leases: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
@@ -76,7 +78,6 @@ const RenderSessionClose = struct {
     native: *c.mln_render_session,
     diagnostic_store: ?*diagnostics.DiagnosticStore,
     frame_state: *RenderSessionFrameState,
-    map_handle: map_module.MapHandle,
 };
 
 const OwnedTextureFrameLease = struct {
@@ -468,11 +469,21 @@ pub const RenderSessionHandle = enum(u128) {
         return rendered;
     }
 
+    /// Detaches the render target from this session. The session stays live and
+    /// still needs `close`, but it no longer holds its map: after a successful
+    /// detach the map can be closed while this session is still open, and every
+    /// session operation that needs an attached target returns a native error.
+    ///
+    /// A detached session stays detached. Attach a new session on the map to
+    /// render again.
     pub fn detach(self: *RenderSessionHandle) status.Error!void {
         const lease = try renderSessionLease(self.*);
         defer lease.release();
         try ensureNoActiveOwnedFrame(lease);
         try status.checkStatus(c.mln_render_session_detach(lease.native), lease.diagnostic_store);
+        if (takeMapRegistration(lease.state)) |map_handle| {
+            map_module.unregisterRenderSession(map_handle);
+        }
     }
 
     pub fn reduceMemoryUse(self: *RenderSessionHandle) status.Error!void {
@@ -752,7 +763,9 @@ pub const RenderSessionHandle = enum(u128) {
             cancelRenderSessionClose(session_close.state);
             return err;
         };
-        map_module.unregisterRenderSession(session_close.map_handle);
+        if (takeMapRegistration(session_close.state)) |map_handle| {
+            map_module.unregisterRenderSession(map_handle);
+        }
         std.heap.smp_allocator.destroy(session_close.frame_state);
         const session_state = finishRenderSessionClose(self.*) orelse session_close.state;
         std.heap.smp_allocator.destroy(session_state);
@@ -1092,8 +1105,19 @@ fn beginRenderSessionClose(handle: RenderSessionHandle) status.BindingError!?Ren
         .native = session,
         .diagnostic_store = session_state.diagnostic_store,
         .frame_state = session_frame_state,
-        .map_handle = session_state.map_handle,
     };
+}
+
+/// Takes this session's map registration exactly once. The caller passes the
+/// returned handle to `map_module.unregisterRenderSession` outside the render
+/// session registry lock.
+fn takeMapRegistration(session_state: *RenderSessionState) ?map_module.MapHandle {
+    lockRenderSessionRegistry();
+    defer unlockRenderSessionRegistry();
+
+    const map_handle = session_state.map_handle orelse return null;
+    session_state.map_handle = null;
+    return map_handle;
 }
 
 fn cancelRenderSessionClose(session_state: *RenderSessionState) void {

--- a/bindings/zig/src/runtime.zig
+++ b/bindings/zig/src/runtime.zig
@@ -1006,12 +1006,29 @@ pub const RuntimeHandle = enum(u128) {
         return createNative(&native_options, diagnostic_store);
     }
 
+    /// Runs one iteration of this runtime's owner-thread run loop.
+    ///
+    /// The iteration drains the high-priority task queue and then the default
+    /// queue until both are empty, including tasks enqueued during the drain,
+    /// and also dispatches expired timers and ready I/O.
+    ///
+    /// `runOnce` returns without blocking on new work, but its duration is
+    /// unbounded: a single iteration can span a style parse. Treat it as "make
+    /// progress now" rather than as a fixed per-frame time slice.
     pub fn runOnce(self: *RuntimeHandle) status.Error!void {
         const runtime_lease = try lease(self);
         defer runtime_lease.release();
         try status.checkStatus(c.mln_runtime_run_once(runtime_lease.native), runtime_lease.diagnostic_store);
     }
 
+    /// Polls and copies the next queued runtime event, returning null when the
+    /// queue is empty. The caller owns the returned event and deinits it.
+    ///
+    /// Polling also advances binding-owned state: on a map-style-loaded event
+    /// this binding releases the map's detached custom geometry sources, closing
+    /// the upcall stubs for sources the new style dropped. That release happens
+    /// when the event is polled, so drain the queue to keep dropped sources from
+    /// lingering.
     pub fn pollEvent(self: *RuntimeHandle, allocator: std.mem.Allocator) status.Error!?OwnedRuntimeEvent {
         const runtime_lease = try lease(self);
         defer runtime_lease.release();

--- a/bindings/zig/src/values.zig
+++ b/bindings/zig/src/values.zig
@@ -44,6 +44,9 @@ pub const CameraOptions = struct {
     center: ?LatLng = null,
     center_altitude: ?f64 = null,
     padding: ?EdgeInsets = null,
+    /// Input-only screen point the camera pivots around. `jumpTo`, `easeTo`, and
+    /// `flyTo` honor it; MapLibre leaves it null on every read path, including
+    /// camera snapshots and the camera-for-bounds helpers.
     anchor: ?ScreenPoint = null,
     zoom: ?f64 = null,
     bearing: ?f64 = null,

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -1146,10 +1146,32 @@ test "map close rejects live render session through public bindings" {
     errdefer owned.close() catch {};
 
     try testing.expectError(error.InvalidState, map.close());
-    try testing.expectEqualStrings("map has live render sessions", diagnostics.get().?.message);
+    try testing.expectEqualStrings("map has an attached render session", diagnostics.get().?.message);
 
     try owned.close();
     try map.close();
+    try runtime.close();
+}
+
+test "map close succeeds after render session detach through public bindings" {
+    if (!supports_test_owned_texture) return error.SkipZigTest;
+    var diagnostics = maplibre.DiagnosticStore.init(testing.allocator);
+    defer diagnostics.deinit();
+
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, &diagnostics);
+    errdefer runtime.close() catch {};
+
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    errdefer map.close() catch {};
+
+    var owned = try attachTestOwnedTexture(&map, .{});
+    errdefer owned.close() catch {};
+
+    try owned.session.detach();
+    // Detaching releases the map, so the map closes while the session is open.
+    try map.close();
+
+    try owned.close();
     try runtime.close();
 }
 


### PR DESCRIPTION
Branch: agent/go-dotnet-handle-contracts

## Summary

Release the map retention on a successful render session detach in Go and Zig so a detached-but-unclosed session stops blocking map close, switch .NET closed-frame access from `ObjectDisposedException` to the binding's own `InvalidStateException`, and document the run-loop semantics of `run_once`, the source release `poll_event` performs, the split failure contract of `set_style_json` vs `set_style_url`, the ease/fly duration defaults, the events map close discards, the input-only camera anchor, and .NET's weak `RuntimeEvent.MapSource`.

## Test plan

Go binding tests (new detach-then-close-map case), .NET build and affected xUnit tests, and Zig render tests (new detach-then-close-map case).

## AI assistance

- **Tools:** Claude Code
- **Context:** Drafted from a verified gap report filed by the first external
  consumer of the bindings; each claim was re-checked against the C
  implementation and the binding sources before editing.