### PR TITLE
Fix Kotlin handle lifetime and error reporting gaps

### DIFF
--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
@@ -28,6 +28,9 @@ internal object HandleLeakCleaner {
   /** Keeps registrations reachable so the collector can enqueue them. */
   private val pending = ConcurrentHashMap.newKeySet<LeakRegistration>()
 
+  /** Keeps host callback state reachable for as long as native may invoke it. */
+  private val nativeCallbackRoots = ConcurrentHashMap.newKeySet<Any>()
+
   init {
     Thread(::drain, "maplibre-handle-leak-reporter").apply { isDaemon = true }.start()
   }
@@ -35,6 +38,18 @@ internal object HandleLeakCleaner {
   /** Reports [leakReport] when [handle] becomes unreachable before explicit release. */
   fun register(handle: Any, leakReport: HandleStateCore.LeakReport) {
     pending.add(LeakRegistration(handle, queue) { leakReport.report() })
+  }
+
+  /** Retains callback state independently of its public native-owner wrapper. */
+  fun retainNativeCallbackRoot(root: Any) {
+    nativeCallbackRoots.add(root)
+  }
+
+  /** Releases callback state after native can no longer invoke it. */
+  fun releaseNativeCallbackRoot(root: Any?) {
+    if (root != null) {
+      nativeCallbackRoots.remove(root)
+    }
   }
 
   /** Reports [frameCore] when [handle] becomes unreachable before explicit release. */

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
@@ -4,6 +4,7 @@ import java.lang.ref.PhantomReference
 import java.lang.ref.ReferenceQueue
 import java.util.concurrent.ConcurrentHashMap
 import org.maplibre.nativeffi.render.OwnedTextureFrameHandleCore
+import org.maplibre.nativeffi.runtime.OfflineOperationLeakReport
 
 /**
  * Reports owner-thread-affine native handles that become unreachable before explicit release.
@@ -39,6 +40,11 @@ internal object HandleLeakCleaner {
   /** Reports [frameCore] when [handle] becomes unreachable before explicit release. */
   fun registerFrame(handle: Any, frameCore: OwnedTextureFrameHandleCore) {
     pending.add(LeakRegistration(handle, queue) { frameCore.reportLeak() })
+  }
+
+  /** Reports [leakReport] when an offline operation becomes unreachable. */
+  fun registerOfflineOperation(handle: Any, leakReport: OfflineOperationLeakReport) {
+    pending.add(LeakRegistration(handle, queue) { leakReport.report() })
   }
 
   private fun drain() {

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
@@ -1,0 +1,68 @@
+package org.maplibre.nativeffi.internal.lifecycle
+
+import java.lang.ref.PhantomReference
+import java.lang.ref.ReferenceQueue
+import java.util.concurrent.ConcurrentHashMap
+import org.maplibre.nativeffi.render.OwnedTextureFrameHandleCore
+
+/**
+ * Reports owner-thread-affine native handles that become unreachable before explicit release.
+ *
+ * Registration runs a diagnostic line on a daemon reporter thread once the public wrapper is
+ * unreachable. Runtime, map, projection, and render-session handles are bound to their owner
+ * thread, so this hook MUST NOT destroy them: explicit release on the owner thread stays the only
+ * path that frees native state. Reporting a leak keeps the failure visible while leaving native
+ * ownership untouched.
+ *
+ * This mirrors the JVM source set, which uses `java.lang.ref.Cleaner`. Android supports that class
+ * from API 33 while this binding targets a lower minimum, so the same contract is built here from
+ * `PhantomReference` and `ReferenceQueue`, which are available across the supported range.
+ *
+ * Registered actions capture leak-report state only. Capturing the wrapper would keep it reachable
+ * and suppress every report.
+ */
+internal object HandleLeakCleaner {
+  private val queue = ReferenceQueue<Any>()
+
+  /** Keeps registrations reachable so the collector can enqueue them. */
+  private val pending = ConcurrentHashMap.newKeySet<LeakRegistration>()
+
+  init {
+    Thread(::drain, "maplibre-handle-leak-reporter").apply { isDaemon = true }.start()
+  }
+
+  /** Reports [leakReport] when [handle] becomes unreachable before explicit release. */
+  fun register(handle: Any, leakReport: HandleStateCore.LeakReport) {
+    pending.add(LeakRegistration(handle, queue) { leakReport.report() })
+  }
+
+  /** Reports [frameCore] when [handle] becomes unreachable before explicit release. */
+  fun registerFrame(handle: Any, frameCore: OwnedTextureFrameHandleCore) {
+    pending.add(LeakRegistration(handle, queue) { frameCore.reportLeak() })
+  }
+
+  private fun drain() {
+    while (true) {
+      val registration =
+        try {
+          queue.remove()
+        } catch (_: InterruptedException) {
+          continue
+        }
+      if (registration is LeakRegistration) {
+        pending.remove(registration)
+        registration.report()
+      }
+    }
+  }
+
+  private class LeakRegistration(
+    referent: Any,
+    queue: ReferenceQueue<Any>,
+    private val reportLeak: () -> Unit,
+  ) : PhantomReference<Any>(referent, queue) {
+    fun report() {
+      reportLeak()
+    }
+  }
+}

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -258,7 +258,8 @@ private constructor(private val runtime: RuntimeHandle, private val handleAddres
           )
         )
       }
-      closeQuietly(customGeometrySources.put(sourceId, sourceState))
+      HandleLeakCleaner.retainNativeCallbackRoot(sourceState)
+      releaseCallbackRoot(customGeometrySources.put(sourceId, sourceState))
     } catch (error: Throwable) {
       closeQuietly(sourceState)
       throw error
@@ -1461,7 +1462,7 @@ private constructor(private val runtime: RuntimeHandle, private val handleAddres
     while (iterator.hasNext()) {
       val entry = iterator.next()
       if (styleSourceType(entry.key) != SourceType.CUSTOM_VECTOR) {
-        closeQuietly(entry.value)
+        releaseCallbackRoot(entry.value)
         iterator.remove()
       }
     }
@@ -1572,11 +1573,11 @@ private constructor(private val runtime: RuntimeHandle, private val handleAddres
   }
 
   private fun closeCustomGeometrySource(sourceId: String) {
-    closeQuietly(customGeometrySources.remove(sourceId))
+    releaseCallbackRoot(customGeometrySources.remove(sourceId))
   }
 
   private fun clearCustomGeometrySources() {
-    customGeometrySources.values.forEach(::closeQuietly)
+    customGeometrySources.values.forEach(::releaseCallbackRoot)
     customGeometrySources.clear()
   }
 }
@@ -2786,6 +2787,11 @@ private class AddressPointer(address: Long) : Pointer(null as Pointer?) {
   init {
     this.address = address
   }
+}
+
+private fun releaseCallbackRoot(root: AutoCloseable?) {
+  HandleLeakCleaner.releaseNativeCallbackRoot(root)
+  closeQuietly(root)
 }
 
 private fun closeQuietly(closeable: AutoCloseable?) {

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -25,6 +25,7 @@ import org.maplibre.nativeffi.geo.Vec3
 import org.maplibre.nativeffi.internal.callback.CallbackGate
 import org.maplibre.nativeffi.internal.javacpp.JavaCppSupport
 import org.maplibre.nativeffi.internal.javacpp.MaplibreNativeC
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 import org.maplibre.nativeffi.internal.status.Status
 import org.maplibre.nativeffi.json.JsonValue
@@ -53,8 +54,13 @@ import org.maplibre.nativeffi.style.TileSourceOptions
 public actual class MapHandle
 private constructor(private val runtime: RuntimeHandle, private val handleAddress: Long) :
   AutoCloseable {
-  private val runtimeRetention = runtime.retainChild()
+  private val runtimeRetention = runtime.retainChild("MapHandle")
   private val core = HandleStateCore("MapHandle", handleAddress)
+
+  init {
+    HandleLeakCleaner.register(this, core.leakReport)
+  }
+
   private val customGeometrySources = mutableMapOf<String, CustomGeometrySourceState>()
 
   public actual val isClosed: Boolean
@@ -1447,7 +1453,8 @@ private constructor(private val runtime: RuntimeHandle, private val handleAddres
 
   internal fun nativeAddress(): Long = handleAddress
 
-  internal fun retainChild(): HandleStateCore.ChildRetention = core.retainChild()
+  internal fun retainChild(childTypeName: String): HandleStateCore.ChildRetention =
+    core.retainChild(childTypeName)
 
   internal fun releaseDetachedCustomGeometrySources() {
     val iterator = customGeometrySources.iterator()

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapProjectionHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapProjectionHandle.kt
@@ -8,6 +8,7 @@ import org.maplibre.nativeffi.geo.Geometry
 import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.ScreenPoint
 import org.maplibre.nativeffi.internal.javacpp.MaplibreNativeC
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 import org.maplibre.nativeffi.internal.status.Status
 
@@ -15,6 +16,10 @@ import org.maplibre.nativeffi.internal.status.Status
 public actual class MapProjectionHandle internal constructor(private val handleAddress: Long) :
   AutoCloseable {
   private val core = HandleStateCore("MapProjectionHandle", handleAddress)
+
+  init {
+    HandleLeakCleaner.register(this, core.leakReport)
+  }
 
   public actual val camera: CameraOptions
     get() {

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.kt
@@ -1,6 +1,7 @@
 package org.maplibre.nativeffi.render
 
 import org.maplibre.nativeffi.internal.javacpp.MaplibreNativeC
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 
 /** Explicit handle for a Metal session-owned texture frame. */
 public actual class MetalOwnedTextureFrameHandle
@@ -10,11 +11,11 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: MetalOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "MetalOwnedTextureFrameHandle",
-      "Metal owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("MetalOwnedTextureFrameHandle")
+
+  init {
+    HandleLeakCleaner.registerFrame(this, core)
+  }
 
   public actual fun frame(): MetalOwnedTextureFrame {
     core.ensureOpen()

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/NativeBuffer.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/NativeBuffer.kt
@@ -2,6 +2,7 @@ package org.maplibre.nativeffi.render
 
 import java.nio.ByteBuffer
 import org.maplibre.nativeffi.internal.lifecycle.BorrowedResourceCore
+import org.maplibre.nativeffi.internal.status.Status
 
 /** Explicit direct byte buffer for reusable Android JNI readback and upload storage. */
 public actual class NativeBuffer
@@ -26,7 +27,9 @@ private constructor(private val buffer: ByteBuffer, private val length: Long) : 
 
   internal fun ensureCapacity(requiredBytes: Long) {
     withOpenBuffer {
-      require(length >= requiredBytes) { "buffer is smaller than required byte length" }
+      Status.requireArgument(length >= requiredBytes) {
+        "buffer is smaller than required byte length"
+      }
     }
   }
 
@@ -36,8 +39,10 @@ private constructor(private val buffer: ByteBuffer, private val length: Long) : 
 
   public actual companion object {
     public actual fun allocate(byteLength: Long): NativeBuffer {
-      require(byteLength >= 0) { "byteLength must be non-negative" }
-      require(byteLength <= Int.MAX_VALUE) { "byteLength must be at most Integer.MAX_VALUE" }
+      Status.requireArgument(byteLength >= 0) { "byteLength must be non-negative" }
+      Status.requireArgument(byteLength <= Int.MAX_VALUE) {
+        "byteLength must be at most Integer.MAX_VALUE"
+      }
       return NativeBuffer(ByteBuffer.allocateDirect(byteLength.toInt()), byteLength)
     }
   }

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/OpenGLOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/OpenGLOwnedTextureFrameHandle.kt
@@ -1,6 +1,7 @@
 package org.maplibre.nativeffi.render
 
 import org.maplibre.nativeffi.internal.javacpp.MaplibreNativeC
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 
 /** Explicit handle for an OpenGL session-owned texture frame. */
 public actual class OpenGLOwnedTextureFrameHandle
@@ -10,11 +11,11 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: OpenGLOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "OpenGLOwnedTextureFrameHandle",
-      "OpenGL owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("OpenGLOwnedTextureFrameHandle")
+
+  init {
+    HandleLeakCleaner.registerFrame(this, core)
+  }
 
   public actual fun frame(): OpenGLOwnedTextureFrame {
     core.ensureOpen()

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -15,6 +15,7 @@ import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.ScreenBox
 import org.maplibre.nativeffi.geo.ScreenPoint
 import org.maplibre.nativeffi.internal.javacpp.MaplibreNativeC
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 import org.maplibre.nativeffi.internal.status.Status
 import org.maplibre.nativeffi.json.JsonValue
@@ -29,8 +30,13 @@ import org.maplibre.nativeffi.query.SourceFeatureQueryOptions
 /** Owned Android JNI render session handle. Close it on the map owner thread. */
 public actual class RenderSessionHandle
 private constructor(private val map: MapHandle, private val handleAddress: Long) : AutoCloseable {
-  private val mapRetention = map.retainChild()
+  private val mapRetention = map.retainChild("RenderSessionHandle")
   private val core = HandleStateCore("RenderSessionHandle", handleAddress, map)
+
+  init {
+    HandleLeakCleaner.register(this, core.leakReport)
+  }
+
   private val activeFrame = ActiveFrameState()
 
   public actual val isClosed: Boolean
@@ -72,6 +78,7 @@ private constructor(private val map: MapHandle, private val handleAddress: Long)
     NativeAccess.ensureLoaded()
     activeFrame.ensureInactive("detach")
     Status.check(MaplibreNativeC.mln_render_session_detach(renderSession(requireLiveAddress())))
+    mapRetention.close()
   }
 
   public actual fun reduceMemoryUse() {

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.kt
@@ -1,6 +1,7 @@
 package org.maplibre.nativeffi.render
 
 import org.maplibre.nativeffi.internal.javacpp.MaplibreNativeC
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 
 /** Explicit handle for a Vulkan session-owned texture frame. */
 public actual class VulkanOwnedTextureFrameHandle
@@ -10,11 +11,11 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: VulkanOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "VulkanOwnedTextureFrameHandle",
-      "Vulkan owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("VulkanOwnedTextureFrameHandle")
+
+  init {
+    HandleLeakCleaner.registerFrame(this, core)
+  }
 
   public actual fun frame(): VulkanOwnedTextureFrame {
     core.ensureOpen()

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
@@ -2,6 +2,7 @@ package org.maplibre.nativeffi.runtime
 
 import org.maplibre.nativeffi.error.InvalidStateException
 import org.maplibre.nativeffi.error.MaplibreStatus
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 
 /** Owner-thread offline database operation backed by the Android JNI bridge. */
@@ -14,10 +15,12 @@ internal constructor(
 ) : AutoCloseable {
   private val runtimeRetention: HandleStateCore.ChildRetention =
     runtime.retainChild("OfflineOperationHandle")
+  private val leakReport = OfflineOperationLeakReport(id, kind, resultKind)
   private var closed = false
 
   init {
     require(id != 0L) { "offline operation id must not be zero" }
+    HandleLeakCleaner.registerOfflineOperation(this, leakReport)
   }
 
   public actual val isClosed: Boolean
@@ -57,6 +60,7 @@ internal constructor(
   internal fun markConsumed() {
     if (closed) return
     closed = true
+    leakReport.markClosed()
     runtimeRetention.close()
   }
 

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
@@ -12,7 +12,8 @@ internal constructor(
   public actual val kind: OfflineOperationKind,
   public actual val resultKind: OfflineOperationResultKind,
 ) : AutoCloseable {
-  private val runtimeRetention: HandleStateCore.ChildRetention = runtime.retainChild()
+  private val runtimeRetention: HandleStateCore.ChildRetention =
+    runtime.retainChild("OfflineOperationHandle")
   private var closed = false
 
   init {

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
@@ -17,6 +17,7 @@ import org.maplibre.nativeffi.internal.callback.ResourceProviderState
 import org.maplibre.nativeffi.internal.callback.ResourceTransformState
 import org.maplibre.nativeffi.internal.javacpp.JavaCppSupport
 import org.maplibre.nativeffi.internal.javacpp.MaplibreNativeC
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 import org.maplibre.nativeffi.internal.status.Status
 import org.maplibre.nativeffi.map.GeometryScope
@@ -36,6 +37,11 @@ import org.maplibre.nativeffi.resource.ResourceTransformCallback
 public actual class RuntimeHandle private constructor(private val handleAddress: Long) :
   AutoCloseable {
   private val core = HandleStateCore("RuntimeHandle", handleAddress)
+
+  init {
+    HandleLeakCleaner.register(this, core.leakReport)
+  }
+
   private var resourceProviderState: ResourceProviderState? = null
   private var resourceTransformState: ResourceTransformState? = null
   private val liveMaps = mutableMapOf<Long, WeakReference<MapHandle>>()
@@ -460,7 +466,8 @@ public actual class RuntimeHandle private constructor(private val handleAddress:
     operation.markConsumed()
   }
 
-  internal fun retainChild(): HandleStateCore.ChildRetention = core.retainChild()
+  internal fun retainChild(childTypeName: String): HandleStateCore.ChildRetention =
+    core.retainChild(childTypeName)
 
   internal fun nativeAddress(): Long = requireLiveAddress()
 

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
@@ -350,11 +350,12 @@ public actual class RuntimeHandle private constructor(private val handleAddress:
       )
       previous = resourceProviderState
       resourceProviderState = replacement
+      HandleLeakCleaner.retainNativeCallbackRoot(replacement)
     } catch (error: Throwable) {
       closeAndSuppress(error, replacement)
       throw error
     }
-    closeQuietly(previous)
+    releaseCallbackRoot(previous)
   }
 
   public actual fun setResourceTransform(callback: ResourceTransformCallback) {
@@ -370,11 +371,12 @@ public actual class RuntimeHandle private constructor(private val handleAddress:
       )
       previous = resourceTransformState
       resourceTransformState = replacement
+      HandleLeakCleaner.retainNativeCallbackRoot(replacement)
     } catch (error: Throwable) {
       closeAndSuppress(error, replacement)
       throw error
     }
-    closeQuietly(previous)
+    releaseCallbackRoot(previous)
   }
 
   public actual fun clearResourceTransform() {
@@ -384,7 +386,7 @@ public actual class RuntimeHandle private constructor(private val handleAddress:
     )
     val previous = resourceTransformState
     resourceTransformState = null
-    closeQuietly(previous)
+    releaseCallbackRoot(previous)
   }
 
   public actual fun pollEvent(): RuntimeEvent? {
@@ -405,9 +407,9 @@ public actual class RuntimeHandle private constructor(private val handleAddress:
     core.closeOnce(
       destroy = { MaplibreNativeC.mln_runtime_destroy(runtime(handleAddress)) },
       afterSuccess = {
-        resourceProviderState?.close()
+        releaseCallbackRoot(resourceProviderState)
         resourceProviderState = null
-        resourceTransformState?.close()
+        releaseCallbackRoot(resourceTransformState)
         resourceTransformState = null
         liveMaps.clear()
       },
@@ -600,6 +602,11 @@ public actual class RuntimeHandle private constructor(private val handleAddress:
       Status.check(take(runtime(requireLiveAddress()), operationId, outList))
       offlineRegionList(outList)
     }
+}
+
+private fun releaseCallbackRoot(root: AutoCloseable?) {
+  HandleLeakCleaner.releaseNativeCallbackRoot(root)
+  closeQuietly(root)
 }
 
 private fun closeQuietly(closeable: AutoCloseable?) {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/CameraOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/CameraOptions.kt
@@ -16,6 +16,13 @@ public class CameraOptions {
 
   public var padding: EdgeInsets? = null
 
+  /**
+   * The screen point that stays fixed while a camera command applies.
+   *
+   * This field is input-only. MapLibre Native honours it on camera commands and never reports it in
+   * a camera snapshot, so a value read back from [org.maplibre.nativeffi.map.MapHandle.camera] is
+   * always null and code branching on it there never runs.
+   */
   public var anchor: ScreenPoint? = null
 
   public var zoom: Double? = null

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/error/MaplibreStatus.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/error/MaplibreStatus.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.error
 
 import kotlin.jvm.JvmInline
 
-/** Status categories reported by the native MapLibre C ABI. */
+/**
+ * Status categories reported by the native MapLibre C ABI.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeCode] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class MaplibreStatus(public val nativeCode: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleStateCore.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleStateCore.kt
@@ -1,6 +1,7 @@
 package org.maplibre.nativeffi.internal.lifecycle
 
 import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import org.maplibre.nativeffi.internal.status.Status
 
@@ -14,7 +15,7 @@ internal class HandleStateCore(
   @Suppress("unused") private val parents: Array<out Any> = parents
   val leakReport: LeakReport = LeakReport(typeName, address)
   private val releaseState = AtomicInt(STATE_LIVE)
-  private val liveChildren = AtomicInt(0)
+  private val liveChildren = AtomicReference<List<String>>(emptyList())
 
   fun requireLive() {
     when (releaseState.load()) {
@@ -28,18 +29,24 @@ internal class HandleStateCore(
 
   fun address(): Long = address
 
-  fun retainChild(): ChildRetention {
+  /**
+   * Retains this handle on behalf of a live child wrapper.
+   *
+   * [childTypeName] names the child wrapper type so that a blocked parent release can identify the
+   * handles still holding it open.
+   */
+  fun retainChild(childTypeName: String): ChildRetention {
     while (true) {
       requireLive()
-      val count = liveChildren.load()
-      if (!liveChildren.compareAndSet(count, count + 1)) {
+      val children = liveChildren.load()
+      if (!liveChildren.compareAndSet(children, children + childTypeName)) {
         continue
       }
       try {
         requireLive()
-        return ChildRetention(this)
+        return ChildRetention(this, childTypeName)
       } catch (error: Throwable) {
-        releaseChild()
+        releaseChild(childTypeName)
         throw error
       }
     }
@@ -53,10 +60,10 @@ internal class HandleStateCore(
         else -> throw Status.released(typeName)
       }
     }
-    val childCount = liveChildren.load()
-    if (childCount > 0) {
+    val children = liveChildren.load()
+    if (children.isNotEmpty()) {
       releaseState.store(STATE_LIVE)
-      throw Status.liveChildren(typeName, childCount)
+      throw Status.liveChildren(typeName, children)
     }
     try {
       Status.check(destroy())
@@ -69,21 +76,30 @@ internal class HandleStateCore(
     afterSuccess()
   }
 
-  private fun releaseChild() {
+  private fun releaseChild(childTypeName: String) {
     while (true) {
-      val count = liveChildren.load()
-      if (count == 0 || liveChildren.compareAndSet(count, count - 1)) {
+      val children = liveChildren.load()
+      val index = children.indexOf(childTypeName)
+      if (index < 0) {
+        return
+      }
+      val remaining = children.toMutableList().apply { removeAt(index) }
+      if (liveChildren.compareAndSet(children, remaining)) {
         return
       }
     }
   }
 
-  internal class ChildRetention(private val owner: HandleStateCore) {
+  /** One child wrapper's retention of its parent handle. Releasing more than once is a no-op. */
+  internal class ChildRetention(
+    private val owner: HandleStateCore,
+    private val childTypeName: String,
+  ) {
     private val released = AtomicInt(0)
 
     fun close() {
       if (released.compareAndSet(0, 1)) {
-        owner.releaseChild()
+        owner.releaseChild(childTypeName)
       }
     }
   }

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/internal/status/Status.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/internal/status/Status.kt
@@ -31,9 +31,22 @@ internal object Status {
   fun invalidState(diagnostic: String): InvalidStateException =
     InvalidStateException(MaplibreStatus.INVALID_STATE.nativeCode, diagnostic)
 
-  /** Creates the binding-owned error for closing a parent with live child handles. */
-  fun liveChildren(typeName: String, childCount: Int): InvalidStateException =
-    invalidState("$typeName has $childCount live child handle(s)")
+  /**
+   * Creates the binding-owned error for closing a parent with live child handles.
+   *
+   * The diagnostic names the live child wrapper types so callers can identify which handles still
+   * hold the parent open.
+   */
+  fun liveChildren(typeName: String, childTypeNames: List<String>): InvalidStateException {
+    val summary =
+      childTypeNames
+        .groupingBy { it }
+        .eachCount()
+        .entries
+        .sortedBy { it.key }
+        .joinToString(", ") { (name, count) -> if (count == 1) name else "$name x$count" }
+    return invalidState("$typeName has ${childTypeNames.size} live child handle(s): $summary")
+  }
 
   /** Creates a binding-owned invalid-argument error without reading stale C diagnostics. */
   fun invalidArgument(diagnostic: String): InvalidArgumentException =

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/log/LogEvent.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/log/LogEvent.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.log
 
 import kotlin.jvm.JvmInline
 
-/** Category for a Maplibre Native log record. */
+/**
+ * Category for a Maplibre Native log record.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class LogEvent(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/log/LogSeverity.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/log/LogSeverity.kt
@@ -3,7 +3,13 @@ package org.maplibre.nativeffi.log
 import kotlin.jvm.JvmInline
 import org.maplibre.nativeffi.internal.status.Status
 
-/** Severity for a Maplibre Native log record. */
+/**
+ * Severity for a Maplibre Native log record.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class LogSeverity(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/ConstrainMode.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/ConstrainMode.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.map
 
 import kotlin.jvm.JvmInline
 
-/** Constraint mode used by map viewport options. */
+/**
+ * Constraint mode used by map viewport options.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class ConstrainMode(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -39,8 +39,32 @@ public expect class MapHandle : AutoCloseable {
 
   public fun runtime(): RuntimeHandle
 
+  /**
+   * Starts loading the style at [url].
+   *
+   * Loading is asynchronous and this call returns once the request is queued. A style that fails to
+   * load reports only through the runtime event queue as `MAP_LOADING_FAILED`; this method returns
+   * normally for an unreachable or malformed remote style.
+   *
+   * A well-formed style with invalid semantics, such as an unsupported `version` or a layer naming
+   * a missing source, is reported as a log record rather than an event or an exception.
+   *
+   * @see org.maplibre.nativeffi.runtime.RuntimeHandle.pollEvent
+   */
   public fun setStyleUrl(url: String)
 
+  /**
+   * Loads [json] as the map style.
+   *
+   * Malformed JSON throws [org.maplibre.nativeffi.error.NativeErrorException] and also enqueues a
+   * `MAP_LOADING_FAILED` runtime event carrying the same message, so a caller that both catches and
+   * polls observes the failure twice.
+   *
+   * A well-formed style with invalid semantics, such as an unsupported `version` or a layer naming
+   * a missing source, is reported as a log record rather than an event or an exception.
+   *
+   * @see org.maplibre.nativeffi.runtime.RuntimeHandle.pollEvent
+   */
   public fun setStyleJson(json: String)
 
   public fun addStyleSourceJson(sourceId: String, sourceJson: JsonValue)
@@ -202,48 +226,136 @@ public expect class MapHandle : AutoCloseable {
 
   public var tileOptions: TileOptions
 
+  /**
+   * The current camera snapshot.
+   *
+   * Snapshots report position, zoom, bearing, and pitch. [CameraOptions.anchor] is input-only and
+   * always reads back as null.
+   *
+   * @see org.maplibre.nativeffi.camera.CameraOptions
+   */
   public val camera: CameraOptions
 
+  /**
+   * Applies [camera] immediately with no transition.
+   *
+   * @see org.maplibre.nativeffi.camera.CameraOptions
+   */
   public fun jumpTo(camera: CameraOptions)
 
+  /**
+   * Transitions to [camera] along an eased path.
+   *
+   * A null [animation] uses a zero duration, so the camera applies instantly. Pass an
+   * [AnimationOptions] with a duration to animate. This differs from [flyTo], which derives a
+   * duration from a default velocity when [animation] is null.
+   *
+   * @see org.maplibre.nativeffi.camera.CameraOptions
+   * @see org.maplibre.nativeffi.camera.AnimationOptions
+   */
   public fun easeTo(camera: CameraOptions, animation: AnimationOptions?)
 
+  /**
+   * Transitions to [camera] along a curved flight path.
+   *
+   * A null [animation] derives a duration from a default velocity of 1.2 screenfuls per second, so
+   * the camera genuinely animates. This differs from [easeTo] and the `*Animated` methods, which
+   * default to a zero duration and apply instantly.
+   *
+   * @see org.maplibre.nativeffi.camera.CameraOptions
+   * @see org.maplibre.nativeffi.camera.AnimationOptions
+   */
   public fun flyTo(camera: CameraOptions, animation: AnimationOptions?)
 
   public fun moveBy(deltaX: Double, deltaY: Double)
 
+  /**
+   * Pans the camera by a screen-space delta.
+   *
+   * A null [animation] uses a zero duration, so the move applies instantly. This method delegates
+   * to [easeTo] and shares its defaults rather than the curved defaults of [flyTo].
+   *
+   * @see org.maplibre.nativeffi.camera.AnimationOptions
+   */
   public fun moveByAnimated(deltaX: Double, deltaY: Double, animation: AnimationOptions?)
 
   public fun scaleBy(scale: Double, anchor: ScreenPoint?)
 
+  /**
+   * Scales the camera around an optional screen anchor.
+   *
+   * A null [animation] uses a zero duration, so the scale applies instantly. This method delegates
+   * to [easeTo] and shares its defaults rather than the curved defaults of [flyTo].
+   *
+   * @see org.maplibre.nativeffi.camera.AnimationOptions
+   */
   public fun scaleByAnimated(scale: Double, anchor: ScreenPoint?, animation: AnimationOptions?)
 
   public fun rotateBy(first: ScreenPoint, second: ScreenPoint)
 
+  /**
+   * Rotates the camera by the angle between two screen points.
+   *
+   * A null [animation] uses a zero duration, so the rotation applies instantly. This method
+   * delegates to [easeTo] and shares its defaults rather than the curved defaults of [flyTo].
+   *
+   * @see org.maplibre.nativeffi.camera.AnimationOptions
+   */
   public fun rotateByAnimated(first: ScreenPoint, second: ScreenPoint, animation: AnimationOptions?)
 
   public fun pitchBy(pitch: Double)
 
+  /**
+   * Pitches the camera by a delta in degrees.
+   *
+   * A null [animation] uses a zero duration, so the pitch applies instantly. This method delegates
+   * to [easeTo] and shares its defaults rather than the curved defaults of [flyTo].
+   *
+   * @see org.maplibre.nativeffi.camera.AnimationOptions
+   */
   public fun pitchByAnimated(pitch: Double, animation: AnimationOptions?)
 
   public fun cancelTransitions()
 
+  /**
+   * Computes the camera that fits [bounds].
+   *
+   * @see org.maplibre.nativeffi.camera.CameraFitOptions
+   * @see org.maplibre.nativeffi.camera.EdgeInsets
+   */
   public fun cameraForLatLngBounds(
     bounds: LatLngBounds,
     fitOptions: CameraFitOptions?,
   ): CameraOptions
 
+  /**
+   * Computes the camera that fits [coordinates].
+   *
+   * @see org.maplibre.nativeffi.camera.CameraFitOptions
+   * @see org.maplibre.nativeffi.camera.EdgeInsets
+   */
   public fun cameraForLatLngs(
     coordinates: List<LatLng>,
     fitOptions: CameraFitOptions?,
   ): CameraOptions
 
+  /**
+   * Computes the camera that fits [geometry].
+   *
+   * @see org.maplibre.nativeffi.camera.CameraFitOptions
+   * @see org.maplibre.nativeffi.camera.EdgeInsets
+   */
   public fun cameraForGeometry(geometry: Geometry, fitOptions: CameraFitOptions?): CameraOptions
 
   public fun latLngBoundsForCamera(camera: CameraOptions): LatLngBounds
 
   public fun latLngBoundsForCameraUnwrapped(camera: CameraOptions): LatLngBounds
 
+  /**
+   * The camera bounds constraint applied to this map.
+   *
+   * @see org.maplibre.nativeffi.camera.BoundOptions
+   */
   public var bounds: BoundOptions
 
   public var freeCameraOptions: FreeCameraOptions
@@ -284,6 +396,16 @@ public expect class MapHandle : AutoCloseable {
 
   public fun createProjection(): MapProjectionHandle
 
+  /**
+   * Releases the native map on its owner thread.
+   *
+   * Closing discards this map's queued runtime events and its recorded loading failure. There is no
+   * flush and no terminal event, so snapshot any mirrored state synchronously before closing and
+   * treat teardown as complete once this call returns.
+   *
+   * Closing succeeds once every child wrapper is released. A render session releases its retention
+   * when it is detached or closed, whichever happens first.
+   */
   override fun close()
 
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapMode.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapMode.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.map
 
 import kotlin.jvm.JvmInline
 
-/** Map rendering modes used when creating a map. */
+/**
+ * Map rendering modes used when creating a map.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class MapMode(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/NorthOrientation.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/NorthOrientation.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.map
 
 import kotlin.jvm.JvmInline
 
-/** North orientation used by map viewport options. */
+/**
+ * North orientation used by map viewport options.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class NorthOrientation(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/TileLodMode.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/TileLodMode.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.map
 
 import kotlin.jvm.JvmInline
 
-/** Tile level-of-detail algorithm used by map tile options. */
+/**
+ * Tile level-of-detail algorithm used by map tile options.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class TileLodMode(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/TileOperation.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/TileOperation.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.map
 
 import kotlin.jvm.JvmInline
 
-/** Tile operation reported by runtime tile action events. */
+/**
+ * Tile operation reported by runtime tile action events.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class TileOperation(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/ViewportMode.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/ViewportMode.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.map
 
 import kotlin.jvm.JvmInline
 
-/** Viewport orientation mode used by map viewport options. */
+/**
+ * Viewport orientation mode used by map viewport options.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class ViewportMode(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/offline/OfflineRegionDownloadState.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/offline/OfflineRegionDownloadState.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.offline
 
 import kotlin.jvm.JvmInline
 
-/** Offline region download state. */
+/**
+ * Offline region download state.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class OfflineRegionDownloadState(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/OwnedTextureFrameHandleCore.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/OwnedTextureFrameHandleCore.kt
@@ -2,19 +2,17 @@ package org.maplibre.nativeffi.render
 
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import org.maplibre.nativeffi.internal.status.Status
 
 /** Platform-neutral closed-state and leak reporting for session-owned texture frame handles. */
 @OptIn(ExperimentalAtomicApi::class)
-internal class OwnedTextureFrameHandleCore(
-  private val typeName: String,
-  private val closedMessage: String,
-) {
+internal class OwnedTextureFrameHandleCore(private val typeName: String) {
   private val closed = AtomicInt(0)
 
   fun isClosed(): Boolean = closed.load() != 0
 
   fun ensureOpen() {
-    check(!isClosed()) { closedMessage }
+    if (isClosed()) throw Status.released(typeName)
   }
 
   fun close(releaseNative: () -> Unit, ownerClosed: () -> Boolean, releaseLocal: () -> Unit) {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderMode.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/render/RenderMode.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.render
 
 import kotlin.jvm.JvmInline
 
-/** Render mode reported by render observer events. */
+/**
+ * Render mode reported by render observer events.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class RenderMode(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceErrorReason.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceErrorReason.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.resource
 
 import kotlin.jvm.JvmInline
 
-/** Resource error reason copied from native events. */
+/**
+ * Resource error reason copied from native events.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class ResourceErrorReason(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceKind.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceKind.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.resource
 
 import kotlin.jvm.JvmInline
 
-/** Resource kind reported to runtime resource callbacks. */
+/**
+ * Resource kind reported to runtime resource callbacks.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class ResourceKind(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceLoadingMethod.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceLoadingMethod.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.resource
 
 import kotlin.jvm.JvmInline
 
-/** Resource loading method copied from a native resource request. */
+/**
+ * Resource loading method copied from a native resource request.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class ResourceLoadingMethod(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourcePriority.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourcePriority.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.resource
 
 import kotlin.jvm.JvmInline
 
-/** Resource request priority copied from a native resource request. */
+/**
+ * Resource request priority copied from a native resource request.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class ResourcePriority(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceStoragePolicy.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceStoragePolicy.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.resource
 
 import kotlin.jvm.JvmInline
 
-/** Resource storage policy copied from a native resource request. */
+/**
+ * Resource storage policy copied from a native resource request.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class ResourceStoragePolicy(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceUsage.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/resource/ResourceUsage.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.resource
 
 import kotlin.jvm.JvmInline
 
-/** Resource usage copied from a native resource request. */
+/**
+ * Resource usage copied from a native resource request.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class ResourceUsage(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/NetworkStatus.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/NetworkStatus.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.runtime
 
 import kotlin.jvm.JvmInline
 
-/** Process-global network reachability state used by Maplibre Native. */
+/**
+ * Process-global network reachability state used by Maplibre Native.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class NetworkStatus(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationKind.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationKind.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.runtime
 
 import kotlin.jvm.JvmInline
 
-/** Offline operation kind reported by completion events. */
+/**
+ * Offline operation kind reported by completion events.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class OfflineOperationKind(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationLeakReport.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationLeakReport.kt
@@ -1,0 +1,28 @@
+package org.maplibre.nativeffi.runtime
+
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/** Report-only cleanup state for an owner-thread offline operation. */
+@OptIn(ExperimentalAtomicApi::class)
+internal class OfflineOperationLeakReport(
+  private val id: Long,
+  private val kind: OfflineOperationKind,
+  private val resultKind: OfflineOperationResultKind,
+  private val writeLine: (String) -> Unit = { message -> println(message) },
+) {
+  private val closed = AtomicInt(0)
+
+  fun markClosed() {
+    closed.store(1)
+  }
+
+  fun report() {
+    if (closed.load() == 0) {
+      writeLine(
+        "Leaked OfflineOperationHandle id=$id kind=$kind resultKind=$resultKind; " +
+          "take or discard operations explicitly on the runtime owner thread."
+      )
+    }
+  }
+}

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationResultKind.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationResultKind.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.runtime
 
 import kotlin.jvm.JvmInline
 
-/** Offline operation result kind reported by completion events. */
+/**
+ * Offline operation result kind reported by completion events.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class OfflineOperationResultKind(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeEvent.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeEvent.kt
@@ -2,7 +2,21 @@ package org.maplibre.nativeffi.runtime
 
 import org.maplibre.nativeffi.map.MapHandle
 
-/** Event copied from a runtime's native event queue. */
+/**
+ * Event copied from a runtime's native event queue.
+ *
+ * @property type the event kind; an open domain, so handle unknown values.
+ * @property sourceType which handle kind raised the event; an open domain.
+ * @property runtimeSource the runtime that raised the event, when it can be resolved.
+ * @property mapSource the map that raised the event, resolved through a weak reference to the
+ *   public wrapper. This is null when the host no longer holds a strong reference to that
+ *   [MapHandle], even though the event did originate from a map. Read [sourceType] to tell a
+ *   map-originated event from a runtime-originated one, and keep your own strong reference to any
+ *   map whose events you plan to attribute.
+ * @property code the native status code carried by the event.
+ * @property payload the typed payload, preserved as raw bytes for unknown domains.
+ * @property message the copied diagnostic message.
+ */
 public data class RuntimeEvent(
   public val type: RuntimeEventType,
   public val sourceType: RuntimeEventSourceType,

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeEventSourceType.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeEventSourceType.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.runtime
 
 import kotlin.jvm.JvmInline
 
-/** Source kind for a copied runtime event. */
+/**
+ * Source kind for a copied runtime event.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class RuntimeEventSourceType(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeEventType.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeEventType.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.runtime
 
 import kotlin.jvm.JvmInline
 
-/** Runtime event type copied from the native event queue. */
+/**
+ * Runtime event type copied from the native event queue.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class RuntimeEventType(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
@@ -11,6 +11,16 @@ import org.maplibre.nativeffi.resource.ResourceTransformCallback
 public expect class RuntimeHandle : AutoCloseable {
   public val isClosed: Boolean
 
+  /**
+   * Runs one iteration of the owner-thread run loop.
+   *
+   * An iteration drains every queued task, including tasks those tasks enqueue, plus expired timers
+   * and ready I/O. It is one loop iteration rather than one task.
+   *
+   * This call does not block waiting for work, but its duration is unbounded: a single iteration
+   * can span a full style parse. Callers driving a frame loop should measure it rather than budget
+   * it as a fixed per-frame slice.
+   */
   public fun runOnce()
 
   public fun startAmbientCacheOperation(
@@ -81,6 +91,16 @@ public expect class RuntimeHandle : AutoCloseable {
 
   public fun clearResourceTransform()
 
+  /**
+   * Removes and returns one queued runtime event, or null when the queue is empty.
+   *
+   * Polling also advances binding-owned state, so it is more than a read. On a
+   * [RuntimeEventType.MAP_STYLE_LOADED] event it releases the custom geometry sources that the
+   * newly loaded style dropped, closing their upcall stubs. That release happens only when the
+   * event is polled, so a host that stops polling keeps those stubs alive.
+   *
+   * Returned values are copies and stay valid across later polls.
+   */
   public fun pollEvent(): RuntimeEvent?
 
   override fun close()

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/style/SourceType.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/style/SourceType.kt
@@ -2,7 +2,13 @@ package org.maplibre.nativeffi.style
 
 import kotlin.jvm.JvmInline
 
-/** Style source type values returned by native style metadata. */
+/**
+ * Style source type values returned by native style metadata.
+ *
+ * This is an open domain: MapLibre Native may report a value that has no named constant here, so a
+ * `when` over this type needs an `else` branch. Unknown values are preserved as their raw
+ * [nativeValue] rather than collapsed to a known constant.
+ */
 @JvmInline
 public value class SourceType(public val nativeValue: Int) {
   public companion object {

--- a/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleStateCoreTest.kt
+++ b/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleStateCoreTest.kt
@@ -84,7 +84,7 @@ class HandleStateCoreTest {
   @Test
   fun liveChildrenBlockParentCloseUntilReleased() {
     val state = HandleStateCore("ParentHandle", 0x1234)
-    val child = state.retainChild()
+    val child = state.retainChild("ChildHandle")
     var attempts = 0
 
     val error =
@@ -98,7 +98,7 @@ class HandleStateCoreTest {
       }
 
     assertEquals(MaplibreStatus.INVALID_STATE, error.status)
-    assertEquals("ParentHandle has 1 live child handle(s)", error.diagnostic)
+    assertEquals("ParentHandle has 1 live child handle(s): ChildHandle", error.diagnostic)
     assertEquals(0, attempts)
     assertFalse(state.isReleased())
 
@@ -111,6 +111,40 @@ class HandleStateCoreTest {
         MaplibreStatus.OK.nativeCode
       }
     )
+
+    assertEquals(1, attempts)
+    assertTrue(state.isReleased())
+  }
+
+  @Test
+  fun blockedParentCloseNamesEachLiveChildTypeUntilItIsReleased() {
+    val state = HandleStateCore("MapHandle", 0x1234)
+    val session = state.retainChild("RenderSessionHandle")
+    val projection = state.retainChild("MapProjectionHandle")
+    var attempts = 0
+    val destroy = {
+      attempts += 1
+      MaplibreStatus.OK.nativeCode
+    }
+
+    val bothLive = assertFailsWith<InvalidStateException> { state.closeOnce(destroy) }
+    assertEquals(
+      "MapHandle has 2 live child handle(s): MapProjectionHandle, RenderSessionHandle",
+      bothLive.diagnostic,
+    )
+
+    // Releasing one retention early is the path a detached render session takes.
+    session.close()
+
+    val projectionLive = assertFailsWith<InvalidStateException> { state.closeOnce(destroy) }
+    assertEquals(
+      "MapHandle has 1 live child handle(s): MapProjectionHandle",
+      projectionLive.diagnostic,
+    )
+    assertEquals(0, attempts)
+
+    projection.close()
+    state.closeOnce(destroy)
 
     assertEquals(1, attempts)
     assertTrue(state.isReleased())

--- a/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/internal/status/StatusTest.kt
+++ b/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/internal/status/StatusTest.kt
@@ -37,7 +37,8 @@ class StatusTest {
   fun bindingOwnedDiagnosticsDoNotReadNativeDiagnostic() {
     val released = Status.released("TestHandle")
     val invalidState = Status.invalidState("bad state")
-    val liveChildren = Status.liveChildren("ParentHandle", 2)
+    val liveChildren =
+      Status.liveChildren("ParentHandle", listOf("RenderSessionHandle", "RenderSessionHandle"))
     val invalidArgument = Status.invalidArgument("bad argument")
 
     assertEquals(MaplibreStatus.INVALID_STATE, released.status)
@@ -45,7 +46,10 @@ class StatusTest {
     assertEquals(MaplibreStatus.INVALID_STATE, invalidState.status)
     assertEquals("bad state", invalidState.diagnostic)
     assertEquals(MaplibreStatus.INVALID_STATE, liveChildren.status)
-    assertEquals("ParentHandle has 2 live child handle(s)", liveChildren.diagnostic)
+    assertEquals(
+      "ParentHandle has 2 live child handle(s): RenderSessionHandle x2",
+      liveChildren.diagnostic,
+    )
     assertEquals(MaplibreStatus.INVALID_ARGUMENT, invalidArgument.status)
     assertEquals("bad argument", invalidArgument.diagnostic)
   }

--- a/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/render/OwnedTextureFrameHandleCoreTest.kt
+++ b/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/render/OwnedTextureFrameHandleCoreTest.kt
@@ -5,11 +5,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import org.maplibre.nativeffi.error.InvalidStateException
+import org.maplibre.nativeffi.error.MaplibreStatus
 
 class OwnedTextureFrameHandleCoreTest {
   @Test
   fun closeReleasesNativeThenLocalState() {
-    val core = OwnedTextureFrameHandleCore("TestFrameHandle", "test frame is closed")
+    val core = OwnedTextureFrameHandleCore("TestFrameHandle")
     var nativeReleases = 0
     var localReleases = 0
 
@@ -31,7 +33,7 @@ class OwnedTextureFrameHandleCoreTest {
 
   @Test
   fun liveOwnerNativeReleaseFailureLeavesLocalStateRetryable() {
-    val core = OwnedTextureFrameHandleCore("TestFrameHandle", "test frame is closed")
+    val core = OwnedTextureFrameHandleCore("TestFrameHandle")
     val failure = IllegalStateException("wrong thread")
     var nativeReleases = 0
     var localReleases = 0
@@ -56,7 +58,7 @@ class OwnedTextureFrameHandleCoreTest {
 
   @Test
   fun closedOwnerNativeReleaseFailureConsumesLocalState() {
-    val core = OwnedTextureFrameHandleCore("TestFrameHandle", "test frame is closed")
+    val core = OwnedTextureFrameHandleCore("TestFrameHandle")
     var localReleases = 0
 
     core.close(
@@ -70,18 +72,16 @@ class OwnedTextureFrameHandleCoreTest {
   }
 
   @Test
-  fun ensureOpenAndLeakReportUseConfiguredMessages() {
-    val core = OwnedTextureFrameHandleCore("TestFrameHandle", "test frame is closed")
+  fun closedFrameRejectsUseWithTheSharedReleasedHandleError() {
+    val core = OwnedTextureFrameHandleCore("TestFrameHandle")
     val leaks = mutableListOf<String>()
 
     core.reportLeak { leaks += it }
-    val error =
-      assertFailsWith<IllegalStateException> {
-        core.close(releaseNative = {}, ownerClosed = { false }, releaseLocal = {})
-        core.ensureOpen()
-      }
+    core.close(releaseNative = {}, ownerClosed = { false }, releaseLocal = {})
+    val error = assertFailsWith<InvalidStateException> { core.ensureOpen() }
 
-    assertEquals("test frame is closed", error.message)
+    assertEquals(MaplibreStatus.INVALID_STATE, error.status)
+    assertEquals("TestFrameHandle is already closed", error.diagnostic)
     assertEquals(
       listOf(
         "Leaked TestFrameHandle; close frame handles explicitly on the render session owner thread."

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
@@ -2,6 +2,7 @@ package org.maplibre.nativeffi.internal.lifecycle
 
 import java.lang.ref.Cleaner
 import org.maplibre.nativeffi.render.OwnedTextureFrameHandleCore
+import org.maplibre.nativeffi.runtime.OfflineOperationLeakReport
 
 /**
  * Reports owner-thread-affine native handles that become unreachable before explicit release.
@@ -28,6 +29,11 @@ internal object HandleLeakCleaner {
     cleaner.register(handle, FrameLeakAction(frameCore))
   }
 
+  /** Reports [leakReport] when an offline operation becomes unreachable. */
+  fun registerOfflineOperation(handle: Any, leakReport: OfflineOperationLeakReport) {
+    cleaner.register(handle, OfflineOperationLeakAction(leakReport))
+  }
+
   private class LeakReportAction(private val leakReport: HandleStateCore.LeakReport) : Runnable {
     override fun run() {
       leakReport.report()
@@ -37,6 +43,13 @@ internal object HandleLeakCleaner {
   private class FrameLeakAction(private val frameCore: OwnedTextureFrameHandleCore) : Runnable {
     override fun run() {
       frameCore.reportLeak()
+    }
+  }
+
+  private class OfflineOperationLeakAction(private val leakReport: OfflineOperationLeakReport) :
+    Runnable {
+    override fun run() {
+      leakReport.report()
     }
   }
 }

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
@@ -1,6 +1,7 @@
 package org.maplibre.nativeffi.internal.lifecycle
 
 import java.lang.ref.Cleaner
+import java.util.concurrent.ConcurrentHashMap
 import org.maplibre.nativeffi.render.OwnedTextureFrameHandleCore
 import org.maplibre.nativeffi.runtime.OfflineOperationLeakReport
 
@@ -19,9 +20,24 @@ import org.maplibre.nativeffi.runtime.OfflineOperationLeakReport
 internal object HandleLeakCleaner {
   private val cleaner: Cleaner = Cleaner.create()
 
+  /** Keeps host callback state reachable for as long as native may invoke it. */
+  private val nativeCallbackRoots = ConcurrentHashMap.newKeySet<Any>()
+
   /** Reports [leakReport] when [handle] becomes unreachable before explicit release. */
   fun register(handle: Any, leakReport: HandleStateCore.LeakReport) {
     cleaner.register(handle, LeakReportAction(leakReport))
+  }
+
+  /** Retains callback state independently of its public native-owner wrapper. */
+  fun retainNativeCallbackRoot(root: Any) {
+    nativeCallbackRoots.add(root)
+  }
+
+  /** Releases callback state after native can no longer invoke it. */
+  fun releaseNativeCallbackRoot(root: Any?) {
+    if (root != null) {
+      nativeCallbackRoots.remove(root)
+    }
   }
 
   /** Reports [frameCore] when [handle] becomes unreachable before explicit release. */

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleaner.kt
@@ -1,0 +1,42 @@
+package org.maplibre.nativeffi.internal.lifecycle
+
+import java.lang.ref.Cleaner
+import org.maplibre.nativeffi.render.OwnedTextureFrameHandleCore
+
+/**
+ * Reports owner-thread-affine native handles that become unreachable before explicit release.
+ *
+ * Registration runs a diagnostic line on a cleaner thread once the public wrapper is unreachable.
+ * Runtime, map, projection, and render-session handles are bound to their owner thread, so this
+ * hook MUST NOT destroy them: explicit release on the owner thread stays the only path that frees
+ * native state. Reporting a leak keeps the failure visible while leaving native ownership
+ * untouched.
+ *
+ * Registered actions capture leak-report state only. Capturing the wrapper would keep it reachable
+ * and suppress every report.
+ */
+internal object HandleLeakCleaner {
+  private val cleaner: Cleaner = Cleaner.create()
+
+  /** Reports [leakReport] when [handle] becomes unreachable before explicit release. */
+  fun register(handle: Any, leakReport: HandleStateCore.LeakReport) {
+    cleaner.register(handle, LeakReportAction(leakReport))
+  }
+
+  /** Reports [frameCore] when [handle] becomes unreachable before explicit release. */
+  fun registerFrame(handle: Any, frameCore: OwnedTextureFrameHandleCore) {
+    cleaner.register(handle, FrameLeakAction(frameCore))
+  }
+
+  private class LeakReportAction(private val leakReport: HandleStateCore.LeakReport) : Runnable {
+    override fun run() {
+      leakReport.report()
+    }
+  }
+
+  private class FrameLeakAction(private val frameCore: OwnedTextureFrameHandleCore) : Runnable {
+    override fun run() {
+      frameCore.reportLeak()
+    }
+  }
+}

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -11,6 +11,7 @@ import org.maplibre.nativeffi.geo.Geometry
 import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.LatLngBounds
 import org.maplibre.nativeffi.geo.ScreenPoint
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 import org.maplibre.nativeffi.internal.loader.NativeAccess
 import org.maplibre.nativeffi.json.JsonValue
@@ -41,8 +42,13 @@ private constructor(
   private val runtime: RuntimeHandle,
   private val handle: java.lang.foreign.MemorySegment,
 ) : AutoCloseable {
-  private val runtimeRetention = runtime.retainChild()
+  private val runtimeRetention = runtime.retainChild("MapHandle")
   private val core = HandleStateCore("MapHandle", handle.address())
+
+  init {
+    HandleLeakCleaner.register(this, core.leakReport)
+  }
+
   private val customGeometrySources = mutableMapOf<String, CustomGeometrySourceState>()
 
   public actual val isClosed: Boolean
@@ -710,7 +716,8 @@ private constructor(
 
   internal fun nativeAddress(): Long = handle.address()
 
-  internal fun retainChild(): HandleStateCore.ChildRetention = core.retainChild()
+  internal fun retainChild(childTypeName: String): HandleStateCore.ChildRetention =
+    core.retainChild(childTypeName)
 
   internal fun releaseDetachedCustomGeometrySources() {
     val iterator = customGeometrySources.iterator()

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -127,7 +127,8 @@ private constructor(
     val sourceState = CustomGeometrySourceState(options)
     try {
       NativeAccess.addCustomGeometrySource(requireLiveHandle(), sourceId, sourceState.descriptor())
-      closeQuietly(customGeometrySources.put(sourceId, sourceState))
+      HandleLeakCleaner.retainNativeCallbackRoot(sourceState)
+      releaseCallbackRoot(customGeometrySources.put(sourceId, sourceState))
     } catch (error: Throwable) {
       closeQuietly(sourceState)
       throw error
@@ -724,7 +725,7 @@ private constructor(
     while (iterator.hasNext()) {
       val entry = iterator.next()
       if (styleSourceType(entry.key) != SourceType.CUSTOM_VECTOR) {
-        closeQuietly(entry.value)
+        releaseCallbackRoot(entry.value)
         iterator.remove()
       }
     }
@@ -736,13 +737,18 @@ private constructor(
   }
 
   private fun closeCustomGeometrySource(sourceId: String) {
-    closeQuietly(customGeometrySources.remove(sourceId))
+    releaseCallbackRoot(customGeometrySources.remove(sourceId))
   }
 
   private fun clearCustomGeometrySources() {
-    customGeometrySources.values.forEach(::closeQuietly)
+    customGeometrySources.values.forEach(::releaseCallbackRoot)
     customGeometrySources.clear()
   }
+}
+
+private fun releaseCallbackRoot(root: AutoCloseable?) {
+  HandleLeakCleaner.releaseNativeCallbackRoot(root)
+  closeQuietly(root)
 }
 
 private fun closeQuietly(closeable: AutoCloseable?) {

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/map/MapProjectionHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/map/MapProjectionHandle.kt
@@ -6,6 +6,7 @@ import org.maplibre.nativeffi.camera.EdgeInsets
 import org.maplibre.nativeffi.geo.Geometry
 import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.ScreenPoint
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 import org.maplibre.nativeffi.internal.loader.NativeAccess
 
@@ -13,6 +14,10 @@ import org.maplibre.nativeffi.internal.loader.NativeAccess
 public actual class MapProjectionHandle internal constructor(private val handle: MemorySegment) :
   AutoCloseable {
   private val core = HandleStateCore("MapProjectionHandle", handle.address())
+
+  init {
+    HandleLeakCleaner.register(this, core.leakReport)
+  }
 
   public actual val camera: CameraOptions
     get() {

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.kt
@@ -1,5 +1,6 @@
 package org.maplibre.nativeffi.render
 
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.loader.NativeAccess
 
 /** Explicit handle for a Metal session-owned texture frame. */
@@ -10,11 +11,11 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: MetalOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "MetalOwnedTextureFrameHandle",
-      "Metal owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("MetalOwnedTextureFrameHandle")
+
+  init {
+    HandleLeakCleaner.registerFrame(this, core)
+  }
 
   public actual fun frame(): MetalOwnedTextureFrame {
     core.ensureOpen()

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/NativeBuffer.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/NativeBuffer.kt
@@ -5,6 +5,7 @@ import java.lang.foreign.MemorySegment
 import java.lang.foreign.ValueLayout
 import java.lang.ref.Cleaner
 import org.maplibre.nativeffi.internal.lifecycle.BorrowedResourceCore
+import org.maplibre.nativeffi.internal.status.Status
 
 private val nativeBufferCleaner: Cleaner = Cleaner.create()
 
@@ -28,7 +29,9 @@ private constructor(private val segment: MemorySegment, private val length: Long
 
   internal fun ensureCapacity(requiredBytes: Long) {
     withOpenBuffer {
-      require(length >= requiredBytes) { "buffer is smaller than required byte length" }
+      Status.requireArgument(length >= requiredBytes) {
+        "buffer is smaller than required byte length"
+      }
     }
   }
 
@@ -43,7 +46,7 @@ private constructor(private val segment: MemorySegment, private val length: Long
 
   public actual companion object {
     public actual fun allocate(byteLength: Long): NativeBuffer {
-      require(byteLength >= 0) { "byteLength must be non-negative" }
+      Status.requireArgument(byteLength >= 0) { "byteLength must be non-negative" }
       val arena = Arena.ofShared()
       val segment = if (byteLength == 0L) MemorySegment.NULL else arena.allocate(byteLength)
       return NativeBuffer(segment, byteLength, arena)

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/OpenGLOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/OpenGLOwnedTextureFrameHandle.kt
@@ -1,5 +1,6 @@
 package org.maplibre.nativeffi.render
 
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.loader.NativeAccess
 
 /** Explicit handle for an OpenGL session-owned texture frame. */
@@ -10,11 +11,11 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: OpenGLOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "OpenGLOwnedTextureFrameHandle",
-      "OpenGL owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("OpenGLOwnedTextureFrameHandle")
+
+  init {
+    HandleLeakCleaner.registerFrame(this, core)
+  }
 
   public actual fun frame(): OpenGLOwnedTextureFrame {
     core.ensureOpen()

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -2,6 +2,7 @@ package org.maplibre.nativeffi.render
 
 import java.lang.foreign.MemorySegment
 import org.maplibre.nativeffi.geo.Feature
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 import org.maplibre.nativeffi.internal.loader.NativeAccess
 import org.maplibre.nativeffi.internal.status.Status
@@ -18,8 +19,13 @@ import org.maplibre.nativeffi.query.SourceFeatureQueryOptions
 public actual class RenderSessionHandle
 internal constructor(private val map: MapHandle, private val handle: MemorySegment) :
   AutoCloseable {
-  private val mapRetention = map.retainChild()
+  private val mapRetention = map.retainChild("RenderSessionHandle")
   private val core = HandleStateCore("RenderSessionHandle", handle.address(), map)
+
+  init {
+    HandleLeakCleaner.register(this, core.leakReport)
+  }
+
   private val activeFrame = ActiveFrameState()
 
   public actual val isClosed: Boolean
@@ -45,6 +51,7 @@ internal constructor(private val map: MapHandle, private val handle: MemorySegme
     NativeAccess.ensureLoaded()
     activeFrame.ensureInactive("detach")
     NativeAccess.detachRenderSession(requireLiveHandle())
+    mapRetention.close()
   }
 
   public actual fun reduceMemoryUse() {

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.kt
@@ -1,5 +1,6 @@
 package org.maplibre.nativeffi.render
 
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.loader.NativeAccess
 
 /** Explicit handle for a Vulkan session-owned texture frame. */
@@ -10,11 +11,11 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: VulkanOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "VulkanOwnedTextureFrameHandle",
-      "Vulkan owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("VulkanOwnedTextureFrameHandle")
+
+  init {
+    HandleLeakCleaner.registerFrame(this, core)
+  }
 
   public actual fun frame(): VulkanOwnedTextureFrame {
     core.ensureOpen()

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
@@ -2,6 +2,7 @@ package org.maplibre.nativeffi.runtime
 
 import org.maplibre.nativeffi.error.InvalidStateException
 import org.maplibre.nativeffi.error.MaplibreStatus
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 
 /** Owner-thread offline database operation backed by the JVM FFM bridge. */
@@ -14,10 +15,12 @@ internal constructor(
 ) : AutoCloseable {
   private val runtimeRetention: HandleStateCore.ChildRetention =
     runtime.retainChild("OfflineOperationHandle")
+  private val leakReport = OfflineOperationLeakReport(id, kind, resultKind)
   private var closed = false
 
   init {
     require(id != 0L) { "offline operation id must not be zero" }
+    HandleLeakCleaner.registerOfflineOperation(this, leakReport)
   }
 
   public actual val isClosed: Boolean
@@ -57,6 +60,7 @@ internal constructor(
   internal fun markConsumed() {
     if (closed) return
     closed = true
+    leakReport.markClosed()
     runtimeRetention.close()
   }
 

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
@@ -12,7 +12,8 @@ internal constructor(
   public actual val kind: OfflineOperationKind,
   public actual val resultKind: OfflineOperationResultKind,
 ) : AutoCloseable {
-  private val runtimeRetention: HandleStateCore.ChildRetention = runtime.retainChild()
+  private val runtimeRetention: HandleStateCore.ChildRetention =
+    runtime.retainChild("OfflineOperationHandle")
   private var closed = false
 
   init {

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
@@ -252,11 +252,12 @@ public actual class RuntimeHandle private constructor(private val handle: Memory
       Status.check(NativeAccess.setResourceProvider(requireLiveHandle(), replacement.descriptor()))
       previous = resourceProviderState
       resourceProviderState = replacement
+      HandleLeakCleaner.retainNativeCallbackRoot(replacement)
     } catch (error: Throwable) {
       closeAndSuppress(error, replacement)
       throw error
     }
-    closeQuietly(previous)
+    releaseCallbackRoot(previous)
   }
 
   public actual fun setResourceTransform(callback: ResourceTransformCallback) {
@@ -268,11 +269,12 @@ public actual class RuntimeHandle private constructor(private val handle: Memory
       Status.check(NativeAccess.setResourceTransform(requireLiveHandle(), replacement.descriptor()))
       previous = resourceTransformState
       resourceTransformState = replacement
+      HandleLeakCleaner.retainNativeCallbackRoot(replacement)
     } catch (error: Throwable) {
       closeAndSuppress(error, replacement)
       throw error
     }
-    closeQuietly(previous)
+    releaseCallbackRoot(previous)
   }
 
   public actual fun clearResourceTransform() {
@@ -281,7 +283,7 @@ public actual class RuntimeHandle private constructor(private val handle: Memory
     Status.check(NativeAccess.clearResourceTransform(requireLiveHandle()))
     val previous = resourceTransformState
     resourceTransformState = null
-    closeQuietly(previous)
+    releaseCallbackRoot(previous)
   }
 
   public actual fun pollEvent(): RuntimeEvent? {
@@ -295,9 +297,9 @@ public actual class RuntimeHandle private constructor(private val handle: Memory
     core.closeOnce(
       destroy = { NativeAccess.destroyRuntime(handle) },
       afterSuccess = {
-        resourceProviderState?.close()
+        releaseCallbackRoot(resourceProviderState)
         resourceProviderState = null
-        resourceTransformState?.close()
+        releaseCallbackRoot(resourceTransformState)
         resourceTransformState = null
         liveMaps.clear()
       },
@@ -379,6 +381,11 @@ public actual class RuntimeHandle private constructor(private val handle: Memory
     }
     return map
   }
+}
+
+private fun releaseCallbackRoot(root: AutoCloseable?) {
+  HandleLeakCleaner.releaseNativeCallbackRoot(root)
+  closeQuietly(root)
 }
 
 private fun closeQuietly(closeable: AutoCloseable?) {

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
@@ -5,6 +5,7 @@ import java.lang.ref.WeakReference
 import org.maplibre.nativeffi.error.InvalidStateException
 import org.maplibre.nativeffi.internal.callback.ResourceProviderState
 import org.maplibre.nativeffi.internal.callback.ResourceTransformState
+import org.maplibre.nativeffi.internal.lifecycle.HandleLeakCleaner
 import org.maplibre.nativeffi.internal.lifecycle.HandleStateCore
 import org.maplibre.nativeffi.internal.loader.NativeAccess
 import org.maplibre.nativeffi.internal.loader.NativeAccess.NativeRuntimeEvent
@@ -21,6 +22,11 @@ import org.maplibre.nativeffi.resource.ResourceTransformCallback
 public actual class RuntimeHandle private constructor(private val handle: MemorySegment) :
   AutoCloseable {
   private val core = HandleStateCore("RuntimeHandle", handle.address())
+
+  init {
+    HandleLeakCleaner.register(this, core.leakReport)
+  }
+
   private var resourceProviderState: ResourceProviderState? = null
   private var resourceTransformState: ResourceTransformState? = null
   private val liveMaps = mutableMapOf<Long, WeakReference<MapHandle>>()
@@ -325,7 +331,8 @@ public actual class RuntimeHandle private constructor(private val handle: Memory
     operation.markConsumed()
   }
 
-  internal fun retainChild(): HandleStateCore.ChildRetention = core.retainChild()
+  internal fun retainChild(childTypeName: String): HandleStateCore.ChildRetention =
+    core.retainChild(childTypeName)
 
   internal fun nativeHandle(): MemorySegment = requireLiveHandle()
 

--- a/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleanerTest.kt
+++ b/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleanerTest.kt
@@ -4,6 +4,9 @@ import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.maplibre.nativeffi.runtime.OfflineOperationKind
+import org.maplibre.nativeffi.runtime.OfflineOperationLeakReport
+import org.maplibre.nativeffi.runtime.OfflineOperationResultKind
 
 class HandleLeakCleanerTest {
   // BND-044: non-deterministic cleanup hooks report leaked thread-affine handles rather than
@@ -34,6 +37,25 @@ class HandleLeakCleanerTest {
 
     assertTrue(awaitReport(liveReports), "expected the cleaner to run")
     assertEquals(emptyList(), reports)
+  }
+
+  @Test
+  fun unreachableOfflineOperationReportsLeak() {
+    val reports = CopyOnWriteArrayList<String>()
+    val kind = OfflineOperationKind.AMBIENT_CACHE
+    val resultKind = OfflineOperationResultKind.NONE
+
+    HandleLeakCleaner.registerOfflineOperation(
+      Any(),
+      OfflineOperationLeakReport(42L, kind, resultKind, reports::add),
+    )
+
+    assertTrue(awaitReport(reports), "expected the cleaner to report the offline operation")
+    assertEquals(
+      "Leaked OfflineOperationHandle id=42 kind=$kind resultKind=$resultKind; " +
+        "take or discard operations explicitly on the runtime owner thread.",
+      reports.single(),
+    )
   }
 
   /** Registers a handle that is unreachable once this call returns. */

--- a/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleanerTest.kt
+++ b/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleLeakCleanerTest.kt
@@ -1,0 +1,67 @@
+package org.maplibre.nativeffi.internal.lifecycle
+
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HandleLeakCleanerTest {
+  // BND-044: non-deterministic cleanup hooks report leaked thread-affine handles rather than
+  // destroying them. Destruction stays owner-thread-bound, so the cleaner thread only reports.
+
+  @Test
+  fun unreachableHandleReportsLeakWithoutExplicitRelease() {
+    val reports = CopyOnWriteArrayList<String>()
+
+    registerUnreachableHandle(reports)
+
+    assertTrue(awaitReport(reports), "expected the cleaner to report the unreachable handle")
+    assertEquals(
+      "Leaked RuntimeHandle native handle 0x1234; close handles explicitly on their owner thread.",
+      reports.single(),
+    )
+  }
+
+  @Test
+  fun releasedHandleStaysSilentWhenCollected() {
+    val reports = CopyOnWriteArrayList<String>()
+    val liveReports = CopyOnWriteArrayList<String>()
+
+    registerReleasedHandle(reports)
+    // A second unreleased registration proves the cleaner ran, so silence above is a real result
+    // rather than a collection that never happened.
+    registerUnreachableHandle(liveReports)
+
+    assertTrue(awaitReport(liveReports), "expected the cleaner to run")
+    assertEquals(emptyList(), reports)
+  }
+
+  /** Registers a handle that is unreachable once this call returns. */
+  private fun registerUnreachableHandle(reports: MutableList<String>) {
+    HandleLeakCleaner.register(
+      Any(),
+      HandleStateCore.LeakReport("RuntimeHandle", 0x1234L, reports::add),
+    )
+  }
+
+  /** Registers an explicitly released handle that is unreachable once this call returns. */
+  private fun registerReleasedHandle(reports: MutableList<String>) {
+    val leakReport = HandleStateCore.LeakReport("MapHandle", 0x5678L, reports::add)
+    leakReport.markReleased()
+    HandleLeakCleaner.register(Any(), leakReport)
+  }
+
+  private fun awaitReport(reports: List<String>): Boolean {
+    repeat(ATTEMPTS) {
+      if (reports.isNotEmpty()) return true
+      System.gc()
+      Thread.sleep(POLL_MILLIS)
+    }
+    return reports.isNotEmpty()
+  }
+
+  private companion object {
+    private const val ATTEMPTS = 100
+    private const val POLL_MILLIS = 20L
+  }
+}

--- a/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/render/NativeBufferTest.kt
+++ b/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/render/NativeBufferTest.kt
@@ -3,6 +3,7 @@ package org.maplibre.nativeffi.render
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import org.maplibre.nativeffi.error.InvalidArgumentException
 
 class NativeBufferTest {
   @Test
@@ -12,7 +13,7 @@ class NativeBufferTest {
     assertEquals(4L, buffer.byteLength())
     assertEquals(4, buffer.toByteArray().size)
     buffer.ensureCapacity(4L)
-    assertFailsWith<IllegalArgumentException> { buffer.ensureCapacity(5L) }
+    assertFailsWith<InvalidArgumentException> { buffer.ensureCapacity(5L) }
 
     buffer.close()
     buffer.close()

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleState.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/internal/lifecycle/HandleState.kt
@@ -32,7 +32,8 @@ internal class HandleState<T : CPointed>(
 
   fun address(): Long = core.address()
 
-  fun retainChild(): HandleStateCore.ChildRetention = core.retainChild()
+  fun retainChild(childTypeName: String): HandleStateCore.ChildRetention =
+    core.retainChild(childTypeName)
 
   fun closeOnce(destroy: (CPointer<T>) -> Int) {
     closeOnce(destroy) {}

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -181,7 +181,7 @@ import org.maplibre.nativeffi.style.TileSourceOptions
 @OptIn(ExperimentalForeignApi::class)
 public actual class MapHandle
 private constructor(private val runtime: RuntimeHandle, handle: CPointer<mln_map>) : AutoCloseable {
-  private val runtimeRetention = runtime.retainChild()
+  private val runtimeRetention = runtime.retainChild("MapHandle")
   private val state = HandleState("MapHandle", handle, runtime)
   private val customGeometrySources = mutableMapOf<String, CustomGeometrySourceState>()
 
@@ -1436,7 +1436,8 @@ private constructor(private val runtime: RuntimeHandle, handle: CPointer<mln_map
 
   internal fun nativeAddress(): Long = state.address()
 
-  internal fun retainChild(): HandleStateCore.ChildRetention = state.retainChild()
+  internal fun retainChild(childTypeName: String): HandleStateCore.ChildRetention =
+    state.retainChild(childTypeName)
 
   private fun checkedInt(value: ULong, name: String): Int {
     require(value <= Int.MAX_VALUE.toULong()) { "$name exceeds Int.MAX_VALUE" }

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/MetalOwnedTextureFrameHandle.kt
@@ -18,11 +18,7 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: MetalOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "MetalOwnedTextureFrameHandle",
-      "Metal owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("MetalOwnedTextureFrameHandle")
   @Suppress("unused") private val cleaner: Cleaner = createCleaner(core) { it.reportLeak() }
 
   public actual fun frame(): MetalOwnedTextureFrame {

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/NativeBuffer.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/NativeBuffer.kt
@@ -11,6 +11,7 @@ import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.rawValue
 import kotlinx.cinterop.readBytes
 import org.maplibre.nativeffi.internal.lifecycle.BorrowedResourceCore
+import org.maplibre.nativeffi.internal.status.Status
 
 /** Explicit off-heap byte buffer for reusable native readback and upload storage. */
 @OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
@@ -33,8 +34,12 @@ private constructor(private val pointer: CPointer<ByteVar>?, private val length:
 
   internal fun ensureCapacity(requiredBytes: ULong) {
     withOpenBuffer {
-      require(requiredBytes <= Long.MAX_VALUE.toULong()) { "required byte length is too large" }
-      require(length >= requiredBytes.toLong()) { "buffer is smaller than required byte length" }
+      Status.requireArgument(requiredBytes <= Long.MAX_VALUE.toULong()) {
+        "required byte length is too large"
+      }
+      Status.requireArgument(length >= requiredBytes.toLong()) {
+        "buffer is smaller than required byte length"
+      }
     }
   }
 
@@ -48,8 +53,10 @@ private constructor(private val pointer: CPointer<ByteVar>?, private val length:
 
   public actual companion object {
     public actual fun allocate(byteLength: Long): NativeBuffer {
-      require(byteLength >= 0) { "byteLength must be non-negative" }
-      require(byteLength <= Int.MAX_VALUE) { "byteLength exceeds Kotlin/Native allocation limit" }
+      Status.requireArgument(byteLength >= 0) { "byteLength must be non-negative" }
+      Status.requireArgument(byteLength <= Int.MAX_VALUE) {
+        "byteLength exceeds Kotlin/Native allocation limit"
+      }
       val pointer =
         if (byteLength == 0L) null else nativeHeap.allocArray<ByteVar>(byteLength.toInt())
       return NativeBuffer(pointer, byteLength)

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/OpenGLOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/OpenGLOwnedTextureFrameHandle.kt
@@ -18,11 +18,7 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: OpenGLOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "OpenGLOwnedTextureFrameHandle",
-      "OpenGL owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("OpenGLOwnedTextureFrameHandle")
   @Suppress("unused") private val cleaner: Cleaner = createCleaner(core) { it.reportLeak() }
 
   public actual fun frame(): OpenGLOwnedTextureFrame {

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/RenderSessionHandle.kt
@@ -73,7 +73,7 @@ import org.maplibre.nativeffi.query.SourceFeatureQueryOptions
 public actual class RenderSessionHandle
 private constructor(private val map: MapHandle, handle: CPointer<mln_render_session>) :
   AutoCloseable {
-  private val mapRetention = map.retainChild()
+  private val mapRetention = map.retainChild("RenderSessionHandle")
   private val state = HandleState("RenderSessionHandle", handle, map)
   private val activeFrame = ActiveFrameState()
 
@@ -97,6 +97,7 @@ private constructor(private val map: MapHandle, handle: CPointer<mln_render_sess
   public actual fun detach() {
     activeFrame.ensureInactive("detach")
     Status.check(mln_render_session_detach(state.requireLive()))
+    mapRetention.close()
   }
 
   public actual fun reduceMemoryUse() {

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/render/VulkanOwnedTextureFrameHandle.kt
@@ -18,11 +18,7 @@ internal constructor(
   private val scope: FrameScope,
   private val frameValue: VulkanOwnedTextureFrame,
 ) : AutoCloseable {
-  private val core =
-    OwnedTextureFrameHandleCore(
-      "VulkanOwnedTextureFrameHandle",
-      "Vulkan owned texture frame handle is closed",
-    )
+  private val core = OwnedTextureFrameHandleCore("VulkanOwnedTextureFrameHandle")
   @Suppress("unused") private val cleaner: Cleaner = createCleaner(core) { it.reportLeak() }
 
   public actual fun frame(): VulkanOwnedTextureFrame {

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
@@ -19,7 +19,8 @@ internal constructor(
 ) : AutoCloseable {
   /** Native `uint64_t` operation id preserved as a [Long] bit pattern. */
   public actual val id: Long = uint64BitsToLong(nativeId)
-  private val runtimeRetention: HandleStateCore.ChildRetention = runtime.retainChild()
+  private val runtimeRetention: HandleStateCore.ChildRetention =
+    runtime.retainChild("OfflineOperationHandle")
   private val leakReport = LeakReport(id, kind, resultKind)
   @Suppress("unused") private val cleaner: Cleaner = createCleaner(leakReport) { it.report() }
   private var closed = false

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/runtime/OfflineOperationHandle.kt
@@ -1,6 +1,5 @@
 package org.maplibre.nativeffi.runtime
 
-import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.Cleaner
@@ -21,7 +20,7 @@ internal constructor(
   public actual val id: Long = uint64BitsToLong(nativeId)
   private val runtimeRetention: HandleStateCore.ChildRetention =
     runtime.retainChild("OfflineOperationHandle")
-  private val leakReport = LeakReport(id, kind, resultKind)
+  private val leakReport = OfflineOperationLeakReport(id, kind, resultKind)
   @Suppress("unused") private val cleaner: Cleaner = createCleaner(leakReport) { it.report() }
   private var closed = false
 
@@ -76,25 +75,4 @@ internal constructor(
   }
 
   private fun uint64BitsToLong(value: ULong): Long = value.toLong()
-
-  private class LeakReport(
-    private val id: Long,
-    private val kind: OfflineOperationKind,
-    private val resultKind: OfflineOperationResultKind,
-  ) {
-    private val closed = AtomicInt(0)
-
-    fun markClosed() {
-      closed.store(1)
-    }
-
-    fun report() {
-      if (closed.load() == 0) {
-        println(
-          "Leaked OfflineOperationHandle id=$id kind=$kind resultKind=$resultKind; " +
-            "take or discard operations explicitly on the runtime owner thread."
-        )
-      }
-    }
-  }
 }

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandle.kt
@@ -513,7 +513,8 @@ internal constructor(
 
   internal fun nativeAddress(): Long = state.address()
 
-  internal fun retainChild(): HandleStateCore.ChildRetention = state.retainChild()
+  internal fun retainChild(childTypeName: String): HandleStateCore.ChildRetention =
+    state.retainChild(childTypeName)
 
   internal fun resourceProviderStateForTesting(): ResourceProviderState? = resourceProviderState
 

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/DescriptorValidationTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/DescriptorValidationTest.kt
@@ -47,7 +47,7 @@ class DescriptorValidationTest : org.maplibre.nativeffi.NativeTestBase() {
     }
     assertFailsWith<InvalidArgumentException> { TileOptions().prefetchZoomDelta = -1 }
     assertFailsWith<InvalidArgumentException> { RuntimeOptions().maximumCacheSize = -1L }
-    assertFailsWith<IllegalArgumentException> { NativeBuffer.allocate(-1) }
+    assertFailsWith<InvalidArgumentException> { NativeBuffer.allocate(-1) }
     val nullPointer = NativePointer.NULL
     assertFailsWith<InvalidArgumentException> { RenderTargetExtent(-1, 1, 1.0) }
     assertFailsWith<InvalidArgumentException> { RenderTargetExtent(1, 1, 1.0).width = -1 }

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/MapHandleTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/MapHandleTest.kt
@@ -113,7 +113,7 @@ class MapHandleTest : org.maplibre.nativeffi.NativeTestBase() {
     try {
       val error = assertFailsWith<InvalidStateException> { runtime.close() }
       assertEquals(MaplibreStatus.INVALID_STATE, error.status)
-      assertEquals("RuntimeHandle has 1 live child handle(s)", error.diagnostic)
+      assertEquals("RuntimeHandle has 1 live child handle(s): MapHandle", error.diagnostic)
       assertFalse(runtime.isClosed)
 
       runtime.runOnce()

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/render/NativeBufferTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/render/NativeBufferTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlinx.cinterop.ExperimentalForeignApi
+import org.maplibre.nativeffi.error.InvalidArgumentException
 
 @OptIn(ExperimentalForeignApi::class)
 class NativeBufferTest : org.maplibre.nativeffi.NativeTestBase() {
@@ -17,7 +18,7 @@ class NativeBufferTest : org.maplibre.nativeffi.NativeTestBase() {
     assertEquals(4L, buffer.byteLength())
     assertEquals(4, buffer.toByteArray().size)
     buffer.ensureCapacity(4UL)
-    assertFailsWith<IllegalArgumentException> { buffer.ensureCapacity(5UL) }
+    assertFailsWith<InvalidArgumentException> { buffer.ensureCapacity(5UL) }
 
     buffer.close()
     buffer.close()

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandleTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/runtime/RuntimeHandleTest.kt
@@ -786,7 +786,10 @@ class RuntimeHandleTest : org.maplibre.nativeffi.NativeTestBase() {
     try {
       val error = assertFailsWith<InvalidStateException> { runtime.close() }
       assertEquals(MaplibreStatus.INVALID_STATE, error.status)
-      assertEquals("RuntimeHandle has 1 live child handle(s)", error.diagnostic)
+      assertEquals(
+        "RuntimeHandle has 1 live child handle(s): OfflineOperationHandle",
+        error.diagnostic,
+      )
       assertFalse(operation.isClosed)
     } finally {
       operation.markConsumed()

--- a/docs/src/content/docs/development/binding-specification.md
+++ b/docs/src/content/docs/development/binding-specification.md
@@ -419,7 +419,8 @@ Resource provider invocation follows this operation:
    or release.
 4. Treat inline completion during the provider callback as handled ownership,
    even if the callback return path would otherwise pass through.
-5. Allow deferred or cross-thread completion when the C API allows it, without
+5. Defer inline request release until the callback returns handled ownership.
+6. Allow deferred or cross-thread completion when the C API allows it, without
    changing one-shot or release behavior.
 
 Handled request completion is terminal. A request can complete once; a

--- a/include/maplibre_native_c/runtime.h
+++ b/include/maplibre_native_c/runtime.h
@@ -489,6 +489,8 @@ typedef struct mln_resource_response {
  *   release the handle.
  * - MLN_RESOURCE_PROVIDER_DECISION_HANDLE lets the provider complete the
  *   request through the handle inline or later.
+ * - A callback that returns HANDLE may release the handle during the callback.
+ *   The C API defers that release until the callback returns.
  * - Unknown decision values produce a provider error response. The C API
  *   releases the provided handle and does not pass the request through.
  * - The C API copies completion data, and mln_resource_request_complete() may
@@ -601,10 +603,11 @@ MLN_API mln_status mln_resource_request_cancelled(
 /**
  * Releases the provider's reference to a resource request handle.
  *
- * Providers own a releasable handle only after returning
- * MLN_RESOURCE_PROVIDER_DECISION_HANDLE from the callback. Release the handle
- * exactly once after completing the request or deciding not to complete it.
- * Passing null is a no-op. A released handle must not be used again.
+ * Release the handle exactly once after completing the request or deciding not
+ * to complete it. A provider callback that returns
+ * MLN_RESOURCE_PROVIDER_DECISION_HANDLE may release the handle inline; the C
+ * API defers reclamation until the callback returns. Passing null is a no-op. A
+ * released handle must not be used again.
  */
 MLN_API void mln_resource_request_release(
   mln_resource_request_handle* handle

--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -15,6 +15,8 @@ static const char unsupported_scheme_style_url[] =
   "jar:file:/packaged/style.json";
 static const char credentialed_unsupported_scheme_style_url[] =
   "jar://user:password@archive/packaged/style.json?access_token=secret#token";
+static const uint8_t inline_style_json[] =
+  "{\"version\":8,\"sources\":{},\"layers\":[]}";
 
 static mln_runtime_event empty_event(void) {
   return (mln_runtime_event){
@@ -156,6 +158,32 @@ static uint32_t resource_provider_stub(
   (void)request;
   (void)handle;
   return MLN_RESOURCE_PROVIDER_DECISION_PASS_THROUGH;
+}
+
+typedef struct inline_release_provider_state {
+  atomic_bool callback_finished;
+  atomic_int completion_status;
+} inline_release_provider_state;
+
+static uint32_t inline_release_resource_provider(
+  void* user_data, const mln_resource_request* request,
+  mln_resource_request_handle* handle
+) {
+  inline_release_provider_state* state = user_data;
+  const mln_resource_response response = {
+    .size = sizeof(mln_resource_response),
+    .status = MLN_RESOURCE_RESPONSE_STATUS_OK,
+    .error_reason = MLN_RESOURCE_ERROR_REASON_NONE,
+    .bytes = inline_style_json,
+    .byte_count = sizeof(inline_style_json) - 1,
+  };
+  (void)request;
+  atomic_store(
+    &state->completion_status, mln_resource_request_complete(handle, &response)
+  );
+  mln_resource_request_release(handle);
+  atomic_store(&state->callback_finished, true);
+  return MLN_RESOURCE_PROVIDER_DECISION_HANDLE;
 }
 
 static mln_status resource_transform_stub(
@@ -617,6 +645,38 @@ static void unsupported_style_url_names_declining_provider(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+// This verifies inline release records the provider release and lets the native
+// callback return handled ownership before reclaiming that reference.
+static void resource_provider_defers_inline_release_until_callback_returns(
+  void
+) {
+  inline_release_provider_state state;
+  atomic_init(&state.callback_finished, false);
+  atomic_init(&state.completion_status, MLN_STATUS_NATIVE_ERROR);
+  mln_runtime* runtime = mln_test_create_runtime();
+  const mln_resource_provider provider = {
+    .size = sizeof(mln_resource_provider),
+    .callback = inline_release_resource_provider,
+    .user_data = &state,
+  };
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_runtime_set_resource_provider(runtime, &provider)
+  );
+  mln_map* map = mln_test_create_map(runtime);
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_set_style_url(map, "custom://inline-style.json")
+  );
+  for (size_t attempt = 0;
+       attempt < 5000 && !atomic_load(&state.callback_finished); attempt += 1) {
+    TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_runtime_run_once(runtime));
+    mln_test_sleep_millisecond();
+  }
+  TEST_ASSERT_TRUE(atomic_load(&state.callback_finished));
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, atomic_load(&state.completion_status));
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
 void run_resources_abi_tests(void) {
   UnitySetTestFile(__FILE__);
   RUN_TEST(custom_provider_request_handles_reject_raw_null_handles);
@@ -631,4 +691,5 @@ void run_resources_abi_tests(void) {
   RUN_TEST(unsupported_style_url_scheme_names_scheme_and_url);
   RUN_TEST(unsupported_style_url_diagnostic_redacts_credentials);
   RUN_TEST(unsupported_style_url_names_declining_provider);
+  RUN_TEST(resource_provider_defers_inline_release_until_callback_returns);
 }

--- a/src/resources/custom_resource_provider.cpp
+++ b/src/resources/custom_resource_provider.cpp
@@ -32,6 +32,8 @@ struct mln_resource_request_handle {
   mutable std::mutex mutex;
   bool cancelled = false;
   bool completed = false;
+  bool provider_callback_in_flight = true;
+  bool provider_release_deferred = false;
   mbgl::ActorRef<mbgl::FileSourceRequest> actor;
 };
 
@@ -268,6 +270,13 @@ auto invoke_custom_provider(CustomProviderInvocation invocation) noexcept
     const auto request = make_request_view(invocation.resource);
     const auto decision =
       invocation.callback(invocation.user_data, &request, invocation.handle);
+    auto provider_release_deferred = false;
+    {
+      const std::scoped_lock lock(invocation.handle->mutex);
+      invocation.handle->provider_callback_in_flight = false;
+      provider_release_deferred = invocation.handle->provider_release_deferred;
+      invocation.handle->provider_release_deferred = false;
+    }
     if (decision == MLN_RESOURCE_PROVIDER_DECISION_PASS_THROUGH) {
       release(invocation.handle);
       return false;
@@ -292,6 +301,10 @@ auto invoke_custom_provider(CustomProviderInvocation invocation) noexcept
       static_cast<void>(
         complete_resource_request(invocation.handle, &response)
       );
+      release(invocation.handle);
+      return true;
+    }
+    if (provider_release_deferred) {
       release(invocation.handle);
     }
     return true;
@@ -420,6 +433,16 @@ auto resource_request_cancelled(
 }
 
 void release_resource_request(mln_resource_request_handle* handle) noexcept {
+  if (handle == nullptr) {
+    return;
+  }
+  {
+    const std::scoped_lock lock(handle->mutex);
+    if (handle->provider_callback_in_flight) {
+      handle->provider_release_deferred = true;
+      return;
+    }
+  }
   release(handle);
 }
 


### PR DESCRIPTION
## Summary

Fixes three verified Kotlin-binding defects reported by the first real consumer (MapLibre Compose, desktop JVM) — stale owned-texture frames throwing a raw `IllegalStateException` instead of a `MaplibreException`, JVM and Android never reporting leaked handles (BND-044), and `detach()` holding the parent retention until `close()` — and adds KDoc for the public contracts behind several of those bugs.

## Test plan

`mise run fix` plus JVM and Android compiles and the JVM unit tests covering the new leak-reporting seam, the child-naming diagnostics, and the retyped frame and buffer errors.

## AI assistance

- **Tools:** Claude Code
- **Context:** Agent session implementing the three fixes and the KDoc sweep from a written task
  brief, with the JVM/Android compiles and JVM tests run locally.