### PR TITLE
Narrow the runtime registry lock scope during teardown

### DIFF
--- a/src/c_api/tests/README.md
+++ b/src/c_api/tests/README.md
@@ -9,3 +9,8 @@ construct: null input or output pointers, undersized structs, unknown raw enum
 or flag values, preinitialized output handles, and stale raw handles. Semantic
 behavior belongs in each applicable binding's test suite whenever its public API
 can express the scenario.
+
+Process-global invariants shared by every binding also belong here, such as the
+lock scope that keeps one runtime's teardown from stalling calls on another
+runtime. Each binding sits on the same C implementation, so one C test covers
+the invariant for all of them.

--- a/src/c_api/tests/README.md
+++ b/src/c_api/tests/README.md
@@ -9,8 +9,3 @@ construct: null input or output pointers, undersized structs, unknown raw enum
 or flag values, preinitialized output handles, and stale raw handles. Semantic
 behavior belongs in each applicable binding's test suite whenever its public API
 can express the scenario.
-
-Process-global invariants shared by every binding also belong here, such as the
-lock scope that keeps one runtime's teardown from stalling calls on another
-runtime. Each binding sits on the same C implementation, so one C test covers
-the invariant for all of them.

--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -2,6 +2,7 @@
 // paths, callback descriptor shape, and invalid offline unions are hidden by
 // bindings.
 
+#include <stdatomic.h>
 #include <stdint.h>
 
 #include "test_support.h"
@@ -312,6 +313,181 @@ static void resource_transform_rejects_raw_invalid_descriptors(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+// Shared state for the teardown lock-scope test below. The transform callback
+// runs on a MapLibre file source thread and the second runtime lives on its own
+// owner thread, so every field crosses a thread boundary.
+typedef struct teardown_probe {
+  atomic_bool transform_entered;
+  atomic_bool teardown_started;
+  atomic_bool other_runtime_ready;
+  atomic_bool other_runtime_call_done;
+  atomic_bool other_runtime_call_observed;
+  atomic_int other_runtime_status;
+} teardown_probe;
+
+// Wait budgets are generous on purpose: a slow machine delays the passing run
+// instead of turning it red.
+enum {
+  teardown_probe_wait_attempts = 10000,
+  teardown_transform_block_attempts = 3000,
+  teardown_call_delay_milliseconds = 200,
+};
+
+static bool wait_for_flag(atomic_bool* flag) {
+  for (size_t attempt = 0; attempt < teardown_probe_wait_attempts;
+       attempt += 1) {
+    if (atomic_load(flag)) {
+      return true;
+    }
+    mln_test_sleep_millisecond();
+  }
+  return false;
+}
+
+// The C API asks transform callbacks to return quickly. This one blocks on
+// purpose so the per-runtime transform lock stays held while the owner thread
+// tears the runtime down, and it calls no C API function while blocked.
+static mln_status blocking_resource_transform(
+  void* user_data, uint32_t kind, const char* url,
+  mln_resource_transform_response* out_response
+) {
+  (void)kind;
+  (void)url;
+  teardown_probe* probe = user_data;
+  atomic_store(&probe->transform_entered, true);
+  for (size_t attempt = 0; attempt < teardown_transform_block_attempts;
+       attempt += 1) {
+    if (atomic_load(&probe->other_runtime_call_done)) {
+      break;
+    }
+    mln_test_sleep_millisecond();
+  }
+  atomic_store(
+    &probe->other_runtime_call_observed,
+    atomic_load(&probe->other_runtime_call_done)
+  );
+  if (out_response != NULL) {
+    out_response->url = NULL;
+  }
+  return MLN_STATUS_OK;
+}
+
+// Owns a second runtime and calls into it while the first runtime is blocked
+// inside teardown.
+static void other_runtime_entry(void* argument) {
+  teardown_probe* probe = argument;
+  mln_runtime* runtime = NULL;
+  const mln_runtime_options options = mln_runtime_options_default();
+  const mln_status create_status = mln_runtime_create(&options, &runtime);
+  if (create_status != MLN_STATUS_OK) {
+    atomic_store(&probe->other_runtime_status, create_status);
+    atomic_store(&probe->other_runtime_call_done, true);
+    return;
+  }
+
+  atomic_store(&probe->other_runtime_ready, true);
+  wait_for_flag(&probe->teardown_started);
+  // Give the owner thread time to reach the transform wait inside teardown.
+  mln_test_sleep_milliseconds(teardown_call_delay_milliseconds);
+  atomic_store(&probe->other_runtime_status, mln_runtime_run_once(runtime));
+  atomic_store(&probe->other_runtime_call_done, true);
+  mln_runtime_destroy(runtime);
+}
+
+static bool start_offline_region_download(
+  mln_runtime* runtime, teardown_probe* probe
+) {
+  const mln_offline_region_definition definition = offline_tile_definition();
+  const uint8_t metadata[] = {1, 2, 3};
+  mln_offline_operation_id operation_id = 0;
+  if (
+    mln_runtime_offline_region_create_start(
+      runtime, &definition, metadata, sizeof(metadata), &operation_id
+    ) != MLN_STATUS_OK ||
+    !wait_for_offline_completion(runtime, operation_id)
+  ) {
+    return false;
+  }
+
+  mln_offline_region_snapshot* snapshot = NULL;
+  if (
+    mln_runtime_offline_region_create_take_result(
+      runtime, operation_id, &snapshot
+    ) != MLN_STATUS_OK
+  ) {
+    return false;
+  }
+  mln_offline_region_info info = {.size = sizeof(mln_offline_region_info)};
+  const mln_status info_status =
+    mln_offline_region_snapshot_get(snapshot, &info);
+  const mln_offline_region_id region_id = info.id;
+  mln_offline_region_snapshot_destroy(snapshot);
+  if (info_status != MLN_STATUS_OK) {
+    return false;
+  }
+
+  mln_offline_operation_id download_operation_id = 0;
+  if (
+    mln_runtime_offline_region_set_download_state_start(
+      runtime, region_id, MLN_OFFLINE_REGION_DOWNLOAD_ACTIVE,
+      &download_operation_id
+    ) != MLN_STATUS_OK
+  ) {
+    return false;
+  }
+
+  // The download requests the region style URL from a MapLibre file source
+  // thread, which is where the transform callback runs.
+  for (size_t attempt = 0; attempt < teardown_probe_wait_attempts;
+       attempt += 1) {
+    if (atomic_load(&probe->transform_entered)) {
+      return true;
+    }
+    if (mln_runtime_run_once(runtime) != MLN_STATUS_OK) {
+      return false;
+    }
+    mln_test_sleep_millisecond();
+  }
+  return false;
+}
+
+// This verifies that runtime teardown waits for an in-flight resource transform
+// callback without holding the process-global runtime registry lock, so calls
+// on an unrelated runtime keep running while teardown is blocked. An offline
+// download supplies the callback because it needs no live map, which teardown
+// forbids.
+static void runtime_teardown_leaves_other_runtimes_responsive(void) {
+  teardown_probe probe = {0};
+  atomic_store(&probe.other_runtime_status, MLN_STATUS_NATIVE_ERROR);
+  mln_runtime* runtime = mln_test_create_runtime();
+  mln_test_thread* other_thread =
+    mln_test_thread_start(other_runtime_entry, &probe);
+  TEST_ASSERT_TRUE(wait_for_flag(&probe.other_runtime_ready));
+
+  const mln_resource_transform transform = {
+    .size = sizeof(mln_resource_transform),
+    .callback = blocking_resource_transform,
+    .user_data = &probe,
+  };
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_runtime_set_resource_transform(runtime, &transform)
+  );
+  TEST_ASSERT_TRUE(start_offline_region_download(runtime, &probe));
+
+  atomic_store(&probe.teardown_started, true);
+  // Teardown blocks here until the transform callback returns.
+  mln_test_destroy_runtime(runtime);
+  mln_test_thread_join(other_thread);
+
+  TEST_ASSERT_TRUE_MESSAGE(
+    atomic_load(&probe.other_runtime_call_observed),
+    "a call on an unrelated runtime was stalled by runtime teardown"
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, atomic_load(&probe.other_runtime_status)
+  );
+}
+
 // This verifies null, undersized, and missing-callback provider descriptors
 // below binding-owned validation.
 static void resource_provider_rejects_raw_invalid_descriptors(void) {
@@ -345,5 +521,6 @@ void run_resources_abi_tests(void) {
   RUN_TEST(offline_database_merge_rejects_raw_null_path);
   RUN_TEST(offline_take_rejects_mismatched_result_kind);
   RUN_TEST(resource_transform_rejects_raw_invalid_descriptors);
+  RUN_TEST(runtime_teardown_leaves_other_runtimes_responsive);
   RUN_TEST(resource_provider_rejects_raw_invalid_descriptors);
 }

--- a/src/c_api/tests/test_support.c
+++ b/src/c_api/tests/test_support.c
@@ -13,6 +13,7 @@
 #if defined(_WIN32)
 #include <windows.h>
 #else
+#include <pthread.h>
 #include <time.h>
 #endif
 
@@ -51,13 +52,71 @@ void mln_test_destroy_map(mln_map* map) {
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_destroy(map));
 }
 
-void mln_test_sleep_millisecond(void) {
+void mln_test_sleep_millisecond(void) { mln_test_sleep_milliseconds(1); }
+
+void mln_test_sleep_milliseconds(unsigned int milliseconds) {
 #if defined(_WIN32)
-  Sleep(1);
+  Sleep(milliseconds);
 #else
-  const struct timespec duration = {.tv_sec = 0, .tv_nsec = 1000000};
+  const struct timespec duration = {
+    .tv_sec = (time_t)(milliseconds / 1000u),
+    .tv_nsec = (long)(milliseconds % 1000u) * 1000000L,
+  };
   nanosleep(&duration, NULL);
 #endif
+}
+
+struct mln_test_thread {
+  void (*entry)(void*);
+  void* argument;
+#if defined(_WIN32)
+  HANDLE handle;
+#else
+  pthread_t handle;
+#endif
+};
+
+#if defined(_WIN32)
+static DWORD WINAPI thread_trampoline(LPVOID argument) {
+  mln_test_thread* thread = argument;
+  thread->entry(thread->argument);
+  return 0;
+}
+#else
+static void* thread_trampoline(void* argument) {
+  mln_test_thread* thread = argument;
+  thread->entry(thread->argument);
+  return NULL;
+}
+#endif
+
+mln_test_thread* mln_test_thread_start(void (*entry)(void*), void* argument) {
+  mln_test_thread* thread = calloc(1, sizeof(*thread));
+  TEST_ASSERT_NOT_NULL(thread);
+  thread->entry = entry;
+  thread->argument = argument;
+#if defined(_WIN32)
+  thread->handle = CreateThread(NULL, 0, thread_trampoline, thread, 0, NULL);
+  TEST_ASSERT_NOT_NULL(thread->handle);
+#else
+  TEST_ASSERT_EQUAL_INT(
+    0, pthread_create(&thread->handle, NULL, thread_trampoline, thread)
+  );
+#endif
+  return thread;
+}
+
+void mln_test_thread_join(mln_test_thread* thread) {
+  if (thread == NULL) {
+    return;
+  }
+#if defined(_WIN32)
+  WaitForSingleObject(thread->handle, INFINITE);
+  CloseHandle(thread->handle);
+#else
+  pthread_join(thread->handle, NULL);
+#endif
+  free(thread);
 }
 
 #if defined(MLN_TEST_BACKEND_METAL)

--- a/src/c_api/tests/test_support.h
+++ b/src/c_api/tests/test_support.h
@@ -11,6 +11,13 @@ typedef struct mln_test_render_fixture {
   void* backend_state;
 } mln_test_render_fixture;
 
+// Opaque host thread used by tests that need a second owner thread.
+typedef struct mln_test_thread mln_test_thread;
+
+mln_test_thread* mln_test_thread_start(void (*entry)(void*), void* argument);
+void mln_test_thread_join(mln_test_thread* thread);
+void mln_test_sleep_milliseconds(unsigned int milliseconds);
+
 mln_runtime* mln_test_create_runtime(void);
 mln_map* mln_test_create_map(mln_runtime* runtime);
 void mln_test_destroy_runtime(mln_runtime* runtime);

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2322,63 +2322,79 @@ auto set_resource_provider(
 }
 
 auto destroy_runtime(mln_runtime* runtime) -> mln_status {
-  const std::scoped_lock lock(runtime_registry_mutex());
   if (runtime == nullptr) {
     set_thread_error("runtime must not be null");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  const auto found = runtime_registry().find(runtime);
-  if (found == runtime_registry().end()) {
-    set_thread_error("runtime is not a live handle");
-    return MLN_STATUS_INVALID_ARGUMENT;
+  // Take ownership of the runtime out of the registry, then release the
+  // process-global registry lock before any teardown step that can block on a
+  // native callback. Removing the entry under the registry lock makes the
+  // handle unreachable to every later registry lookup, so the waits below stall
+  // this runtime alone while calls on unrelated runtimes keep running.
+  std::unique_ptr<mln_runtime> owned_runtime;
+  {
+    const std::scoped_lock lock(runtime_registry_mutex());
+    const auto found = runtime_registry().find(runtime);
+    if (found == runtime_registry().end()) {
+      set_thread_error("runtime is not a live handle");
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (found->second->owner_thread != std::this_thread::get_id()) {
+      set_thread_error("runtime must be destroyed on its owner thread");
+      return MLN_STATUS_WRONG_THREAD;
+    }
+
+    if (found->second->live_maps != 0) {
+      set_thread_error("runtime still owns live maps");
+      return MLN_STATUS_INVALID_STATE;
+    }
+
+    owned_runtime = std::move(found->second);
+    runtime_registry().erase(found);
   }
 
-  if (found->second->owner_thread != std::this_thread::get_id()) {
-    set_thread_error("runtime must be destroyed on its owner thread");
-    return MLN_STATUS_WRONG_THREAD;
-  }
-
-  if (found->second->live_maps != 0) {
-    set_thread_error("runtime still owns live maps");
-    return MLN_STATUS_INVALID_STATE;
-  }
-
+  // A resource transform callback that entered `invoke_resource_transform()`
+  // before the erase above holds a shared transform lock, so this wait covers
+  // every callback that can still observe the runtime.
   {
     const std::unique_lock transform_lock(
-      found->second->resource_transform_mutex
+      owned_runtime->resource_transform_mutex
     );
-    found->second->resource_transform_callback = nullptr;
-    found->second->resource_transform_user_data = nullptr;
+    owned_runtime->resource_transform_callback = nullptr;
+    owned_runtime->resource_transform_user_data = nullptr;
   }
 
   {
     const std::scoped_lock state_lock(
-      found->second->offline_event_state->mutex
+      owned_runtime->offline_event_state->mutex
     );
-    found->second->offline_event_state->alive = false;
-    found->second->offline_event_state->runtime = nullptr;
-    const std::scoped_lock event_lock(found->second->event_mutex);
-    found->second->observed_offline_regions.clear();
-    std::erase_if(found->second->events, [](const auto& event) -> bool {
+    owned_runtime->offline_event_state->alive = false;
+    owned_runtime->offline_event_state->runtime = nullptr;
+    const std::scoped_lock event_lock(owned_runtime->event_mutex);
+    owned_runtime->observed_offline_regions.clear();
+    std::erase_if(owned_runtime->events, [](const auto& event) -> bool {
       return event.has_offline_region;
     });
   }
 
   {
     const std::scoped_lock state_lock(
-      found->second->offline_operation_state->mutex
+      owned_runtime->offline_operation_state->mutex
     );
-    found->second->offline_operation_state->alive = false;
-    found->second->offline_operation_state->runtime = nullptr;
-    found->second->offline_operation_state->operations.clear();
-    const std::scoped_lock event_lock(found->second->event_mutex);
-    std::erase_if(found->second->events, [](const auto& event) -> bool {
+    owned_runtime->offline_operation_state->alive = false;
+    owned_runtime->offline_operation_state->runtime = nullptr;
+    owned_runtime->offline_operation_state->operations.clear();
+    const std::scoped_lock event_lock(owned_runtime->event_mutex);
+    std::erase_if(owned_runtime->events, [](const auto& event) -> bool {
       return event.has_offline_operation;
     });
   }
 
-  runtime_registry().erase(runtime);
+  // Releasing the run loop and the database file source can join native
+  // threads, and that happens here with the registry lock released.
+  owned_runtime.reset();
   return MLN_STATUS_OK;
 }
 
@@ -2461,6 +2477,10 @@ auto retain_runtime_map(mln_runtime* runtime) -> mln_status {
   }
 
   const std::scoped_lock lock(runtime_registry_mutex());
+  if (!runtime_registry().contains(runtime)) {
+    set_thread_error("runtime is not a live handle");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
   ++runtime->live_maps;
   return MLN_STATUS_OK;
 }
@@ -2514,6 +2534,12 @@ auto invoke_resource_transform(
   auto* runtime = static_cast<mln_runtime*>(platform_context);
   std::shared_lock<std::shared_mutex> transform_lock;
   {
+    // Taking the shared transform lock while the registry lock is held is the
+    // handoff that keeps the runtime alive for the callback:
+    // `destroy_runtime()` removes the registry entry under the same registry
+    // lock and then waits for the exclusive transform lock. A callback that
+    // reaches the shared lock first holds teardown until it returns, and one
+    // that arrives after the erase finds no entry and skips the transform.
     const std::scoped_lock registry_lock(runtime_registry_mutex());
     if (!runtime_registry().contains(runtime)) {
       return MLN_STATUS_OK;


### PR DESCRIPTION
## Summary

`destroy_runtime()` now takes the runtime out of the process-global registry
under the registry lock and runs every blocking teardown step with that lock
released, so one slow resource transform callback no longer stalls `mln_*` calls
on unrelated runtimes.

## Test plan

`mise run test` on `linux-x64-vulkan`, including a new C test that fails on
`main` (3.3s stall, ~0.3s after the fix) and passes here.

## AI assistance

- **Tools:** Claude Code
- **Context:** Agent session: diagnosed the lock ordering, wrote the fix and the
  regression test, and verified red/green locally on `linux-x64-vulkan`.
