### PR TITLE
Copy runtime state under the registry lock in file source lookups

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1124,6 +1124,7 @@ impl RuntimeHandle {
 
     fn set_resource_provider(
         &self,
+        py: Python<'_>,
         callback: Py<PyAny>,
         max_pending_callbacks: usize,
     ) -> PyResult<()> {
@@ -1137,15 +1138,37 @@ impl RuntimeHandle {
             max_pending_callbacks,
         ));
         let descriptor = replacement.descriptor();
-        let state = self.state_for_operation()?;
-        // SAFETY: state owns a runtime pointer that passed the binding
-        // lifecycle gate. The C API validates that it is live. descriptor
-        // points to replacement state, which is retained after a successful
-        // native registration.
-        maplibre_core::check(unsafe {
-            sys::mln_runtime_set_resource_provider(state.as_ptr(), &descriptor)
-        })
-        .map_err(map_error)?;
+        let _operation = self.operation_gate.begin_detached_operation()?;
+        let runtime_address = {
+            let state = self.state_for_operation()?;
+            let Some(runtime_address) = state.address() else {
+                return Err(invalid_state_error("runtime handle is closed"));
+            };
+            runtime_address
+        };
+        let callback = descriptor.callback;
+        let user_data_address = descriptor.user_data as usize;
+        let size = descriptor.size;
+        // SAFETY: runtime_address came from a runtime pointer that passed the
+        // binding lifecycle gate. The C API validates that it is live.
+        // descriptor points to replacement state, which is retained after a
+        // successful native registration. Replacement can wait for in-flight
+        // callbacks, so release the GIL while it runs without holding the Rust
+        // handle-state mutex.
+        let status = py.detach(move || {
+            let descriptor = sys::mln_resource_provider {
+                size,
+                callback,
+                user_data: user_data_address as *mut c_void,
+            };
+            unsafe {
+                sys::mln_runtime_set_resource_provider(
+                    runtime_address as *mut sys::mln_runtime,
+                    &descriptor,
+                )
+            }
+        });
+        maplibre_core::check(status).map_err(map_error)?;
         self.resource_provider
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -861,6 +861,123 @@ static void resource_provider_defers_inline_release_until_callback_returns(
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, atomic_load(&state.completion_status));
   mln_test_destroy_map(map);
   mln_test_destroy_runtime(runtime);
+typedef struct provider_teardown_probe {
+  atomic_bool entered;
+  atomic_bool teardown_started;
+  atomic_bool callback_returned;
+} provider_teardown_probe;
+
+enum {
+  provider_teardown_wait_attempts = 10000,
+  provider_teardown_block_milliseconds = 200,
+};
+
+// Blocks after teardown starts so the test can distinguish teardown waiting
+// for this invocation from teardown returning while callback state is live.
+static uint32_t blocking_resource_provider(
+  void* user_data, const mln_resource_request* request,
+  mln_resource_request_handle* handle
+) {
+  (void)request;
+  (void)handle;
+  provider_teardown_probe* probe = user_data;
+  atomic_store(&probe->entered, true);
+  for (size_t attempt = 0; attempt < provider_teardown_wait_attempts;
+       attempt += 1) {
+    if (atomic_load(&probe->teardown_started)) {
+      break;
+    }
+    mln_test_sleep_millisecond();
+  }
+  for (size_t elapsed = 0; elapsed < provider_teardown_block_milliseconds;
+       elapsed += 1) {
+    mln_test_sleep_millisecond();
+  }
+  atomic_store(&probe->callback_returned, true);
+  // An unknown decision is converted to a handled provider error. Keeping the
+  // request on the provider path avoids involving native network teardown in
+  // this provider-lifetime regression.
+  return UINT32_MAX;
+}
+
+// Starts an offline download because its network request runs on a MapLibre
+// file-source thread and does not require a live map during runtime teardown.
+static bool wait_for_provider_callback(
+  mln_runtime* runtime, provider_teardown_probe* probe
+) {
+  const mln_offline_region_definition definition = offline_tile_definition();
+  const uint8_t metadata[] = {1, 2, 3};
+  mln_offline_operation_id operation_id = 0;
+  if (
+    mln_runtime_offline_region_create_start(
+      runtime, &definition, metadata, sizeof(metadata), &operation_id
+    ) != MLN_STATUS_OK ||
+    !wait_for_offline_completion(runtime, operation_id)
+  ) {
+    return false;
+  }
+
+  mln_offline_region_snapshot* snapshot = NULL;
+  if (
+    mln_runtime_offline_region_create_take_result(
+      runtime, operation_id, &snapshot
+    ) != MLN_STATUS_OK
+  ) {
+    return false;
+  }
+  mln_offline_region_info info = {.size = sizeof(mln_offline_region_info)};
+  const mln_status info_status =
+    mln_offline_region_snapshot_get(snapshot, &info);
+  const mln_offline_region_id region_id = info.id;
+  mln_offline_region_snapshot_destroy(snapshot);
+  if (info_status != MLN_STATUS_OK) {
+    return false;
+  }
+
+  mln_offline_operation_id download_operation_id = 0;
+  if (
+    mln_runtime_offline_region_set_download_state_start(
+      runtime, region_id, MLN_OFFLINE_REGION_DOWNLOAD_ACTIVE,
+      &download_operation_id
+    ) != MLN_STATUS_OK
+  ) {
+    return false;
+  }
+
+  for (size_t attempt = 0; attempt < provider_teardown_wait_attempts;
+       attempt += 1) {
+    if (atomic_load(&probe->entered)) {
+      return true;
+    }
+    if (mln_runtime_run_once(runtime) != MLN_STATUS_OK) {
+      return false;
+    }
+    mln_test_sleep_millisecond();
+  }
+  return false;
+}
+
+// The provider callback and borrowed user_data remain valid until runtime
+// destruction returns, including callbacks already running on worker threads.
+static void runtime_teardown_waits_for_in_flight_provider_callback(void) {
+  provider_teardown_probe probe = {0};
+  mln_runtime* runtime = mln_test_create_runtime();
+  const mln_resource_provider provider = {
+    .size = sizeof(mln_resource_provider),
+    .callback = blocking_resource_provider,
+    .user_data = &probe,
+  };
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_runtime_set_resource_provider(runtime, &provider)
+  );
+  TEST_ASSERT_TRUE(wait_for_provider_callback(runtime, &probe));
+
+  atomic_store(&probe.teardown_started, true);
+  mln_test_destroy_runtime(runtime);
+  TEST_ASSERT_TRUE_MESSAGE(
+    atomic_load(&probe.callback_returned),
+    "runtime teardown returned while a provider callback was still running"
+  );
 }
 
 void run_resources_abi_tests(void) {
@@ -879,4 +996,5 @@ void run_resources_abi_tests(void) {
   RUN_TEST(unsupported_style_url_diagnostic_redacts_credentials);
   RUN_TEST(unsupported_style_url_names_declining_provider);
   RUN_TEST(resource_provider_defers_inline_release_until_callback_returns);
+  RUN_TEST(runtime_teardown_waits_for_in_flight_provider_callback);
 }

--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -861,6 +861,8 @@ static void resource_provider_defers_inline_release_until_callback_returns(
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, atomic_load(&state.completion_status));
   mln_test_destroy_map(map);
   mln_test_destroy_runtime(runtime);
+}
+
 typedef struct provider_teardown_probe {
   atomic_bool entered;
   atomic_bool teardown_started;

--- a/src/resources/resource_loader.cpp
+++ b/src/resources/resource_loader.cpp
@@ -188,15 +188,22 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
 
   auto request(const mbgl::Resource& resource, Callback callback)
     -> std::unique_ptr<mbgl::AsyncRequest> override {
-    const auto provider = find_resource_provider_for_platform_context(
-      resource_options_.platformContext()
-    );
-    if (can_request_network(resource) && provider.has_value()) {
-      auto request = request_custom_resource(
-        resource, provider->callback, provider->user_data, callback
+    bool has_provider = false;
+    if (can_request_network(resource)) {
+      // Keep the lease through the synchronous callback, then release it
+      // before falling through to native loading: the native source may invoke
+      // a transform that needs the runtime registry lock during teardown.
+      const auto provider = acquire_resource_provider_for_platform_context(
+        resource_options_.platformContext()
       );
-      if (request != nullptr) {
-        return request;
+      has_provider = provider.has_value();
+      if (provider.has_value()) {
+        auto request = request_custom_resource(
+          resource, provider->callback(), provider->user_data(), callback
+        );
+        if (request != nullptr) {
+          return request;
+        }
       }
     }
     if (!native_->canRequest(resource)) {
@@ -205,9 +212,7 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
     const auto unsupported = unsupported_network_scheme(resource.url);
     if (unsupported.has_value()) {
       return respond_immediately(
-        unsupported_scheme_response(
-          *unsupported, resource.url, provider.has_value()
-        ),
+        unsupported_scheme_response(*unsupported, resource.url, has_provider),
         std::move(callback)
       );
     }
@@ -216,7 +221,7 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
 
   [[nodiscard]] auto canRequest(const mbgl::Resource& resource) const
     -> bool override {
-    const auto provider = find_resource_provider_for_platform_context(
+    const auto provider = acquire_resource_provider_for_platform_context(
       resource_options_.platformContext()
     );
     return (can_request_network(resource) && provider.has_value()) ||

--- a/src/resources/resource_loader.cpp
+++ b/src/resources/resource_loader.cpp
@@ -188,8 +188,9 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
 
   auto request(const mbgl::Resource& resource, Callback callback)
     -> std::unique_ptr<mbgl::AsyncRequest> override {
-    const auto provider =
-      runtime_resource_provider(resource_options_.platformContext());
+    const auto provider = find_resource_provider_for_platform_context(
+      resource_options_.platformContext()
+    );
     if (can_request_network(resource) && provider.has_value()) {
       auto request = request_custom_resource(
         resource, provider->callback, provider->user_data, callback
@@ -215,10 +216,10 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
 
   [[nodiscard]] auto canRequest(const mbgl::Resource& resource) const
     -> bool override {
-    const auto has_provider =
-      runtime_resource_provider(resource_options_.platformContext())
-        .has_value();
-    return (can_request_network(resource) && has_provider) ||
+    const auto provider = find_resource_provider_for_platform_context(
+      resource_options_.platformContext()
+    );
+    return (can_request_network(resource) && provider.has_value()) ||
            native_->canRequest(resource);
   }
 
@@ -261,15 +262,6 @@ class AbiNetworkFileSource final : public mbgl::FileSource {
   }
 
  private:
-  static auto runtime_resource_provider(void* platform_context)
-    -> std::optional<ResourceProvider> {
-    const auto* runtime = find_runtime_for_platform_context(platform_context);
-    if (runtime == nullptr || !runtime->has_resource_provider) {
-      return std::nullopt;
-    }
-    return runtime->resource_provider;
-  }
-
   // Reports the scheme of a URL the online source is unable to serve. The
   // resource loader routes file, asset, mbtiles, and pmtiles URLs to their own
   // sources ahead of the network, so anything left here reaches an HTTP
@@ -341,11 +333,13 @@ auto make_database_file_source(
     auto source = std::make_unique<mbgl::DatabaseFileSource>(
       resource_options, client_options
     );
-    const auto* runtime =
-      find_runtime_for_platform_context(resource_options.platformContext());
-    if (runtime != nullptr && runtime->has_maximum_cache_size) {
+    const auto maximum_cache_size =
+      find_maximum_cache_size_for_platform_context(
+        resource_options.platformContext()
+      );
+    if (maximum_cache_size.has_value()) {
       source->setMaximumAmbientCacheSize(
-        runtime->maximum_cache_size, [](std::exception_ptr exception) -> void {
+        *maximum_cache_size, [](std::exception_ptr exception) -> void {
           if (exception != nullptr) {
             mbgl::Log::Error(
               mbgl::Event::Database,

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2333,11 +2333,12 @@ auto set_resource_provider(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  const std::scoped_lock lock(runtime_registry_mutex());
+  const std::scoped_lock registry_lock(runtime_registry_mutex());
   if (runtime->live_maps != 0) {
     set_thread_error("resource provider must be set before map creation");
     return MLN_STATUS_INVALID_STATE;
   }
+  const std::unique_lock provider_lock(runtime->resource_provider_mutex);
   runtime->has_resource_provider = true;
   runtime->resource_provider = ResourceProvider{
     .callback = provider->callback,
@@ -2378,6 +2379,17 @@ auto destroy_runtime(mln_runtime* runtime) -> mln_status {
 
     owned_runtime = std::move(found->second);
     runtime_registry().erase(found);
+  }
+
+  {
+    // A file-source thread that found this runtime under the registry lock
+    // holds a shared provider lock through the callback. Taking the exclusive
+    // lock here keeps callback and user_data lifetime inside runtime lifetime.
+    const std::unique_lock provider_lock(
+      owned_runtime->resource_provider_mutex
+    );
+    owned_runtime->has_resource_provider = false;
+    owned_runtime->resource_provider = ResourceProvider{};
   }
 
   // A resource transform callback that entered `invoke_resource_transform()`
@@ -2539,25 +2551,31 @@ auto resource_options_for_runtime(mln_runtime* runtime)
   return options;
 }
 
-auto find_resource_provider_for_platform_context(
+auto acquire_resource_provider_for_platform_context(
   void* platform_context
-) noexcept -> std::optional<ResourceProvider> {
+) noexcept -> std::optional<ResourceProviderLease> {
   if (platform_context == nullptr) {
     return std::nullopt;
   }
 
-  // Reading the provider while the registry lock is held keeps the whole read
-  // inside the critical section that `destroy_runtime()` uses to retire the
-  // entry, and `set_resource_provider()` writes these fields under the same
-  // lock. Returning a copy leaves the caller with no borrowed runtime state.
-  const std::scoped_lock lock(runtime_registry_mutex());
   auto* runtime = static_cast<mln_runtime*>(platform_context);
-  if (
-    !runtime_registry().contains(runtime) || !runtime->has_resource_provider
-  ) {
+  std::shared_lock<std::shared_mutex> provider_lock;
+  {
+    // Acquire in registry-to-provider order, matching replacement and teardown.
+    // Teardown cannot remove and free the runtime between the registry lookup
+    // and the provider lock, then waits for the lease after removing it.
+    const std::scoped_lock registry_lock(runtime_registry_mutex());
+    if (!runtime_registry().contains(runtime)) {
+      return std::nullopt;
+    }
+    provider_lock = std::shared_lock{runtime->resource_provider_mutex};
+  }
+  if (!runtime->has_resource_provider) {
     return std::nullopt;
   }
-  return runtime->resource_provider;
+  return ResourceProviderLease{
+    std::move(provider_lock), runtime->resource_provider
+  };
 }
 
 auto find_maximum_cache_size_for_platform_context(

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2333,11 +2333,21 @@ auto set_resource_provider(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  const std::scoped_lock registry_lock(runtime_registry_mutex());
-  if (runtime->live_maps != 0) {
-    set_thread_error("resource provider must be set before map creation");
-    return MLN_STATUS_INVALID_STATE;
+  // Validate under the registry lock, then release it before the provider wait
+  // below. `validate_runtime()` and `destroy_runtime()` both require the owner
+  // thread, so this thread's ownership keeps the runtime alive without holding
+  // the process-global lock while an in-flight callback drains.
+  {
+    const std::scoped_lock registry_lock(runtime_registry_mutex());
+    if (runtime->live_maps != 0) {
+      set_thread_error("resource provider must be set before map creation");
+      return MLN_STATUS_INVALID_STATE;
+    }
   }
+
+  // A file-source thread that entered the callback holds a shared provider
+  // lock, so the exclusive lock keeps the outgoing callback and user_data alive
+  // until that invocation returns.
   const std::unique_lock provider_lock(runtime->resource_provider_mutex);
   runtime->has_resource_provider = true;
   runtime->resource_provider = ResourceProvider{

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -2539,15 +2539,42 @@ auto resource_options_for_runtime(mln_runtime* runtime)
   return options;
 }
 
-auto find_runtime_for_platform_context(void* platform_context) noexcept
-  -> mln_runtime* {
+auto find_resource_provider_for_platform_context(
+  void* platform_context
+) noexcept -> std::optional<ResourceProvider> {
   if (platform_context == nullptr) {
-    return nullptr;
+    return std::nullopt;
+  }
+
+  // Reading the provider while the registry lock is held keeps the whole read
+  // inside the critical section that `destroy_runtime()` uses to retire the
+  // entry, and `set_resource_provider()` writes these fields under the same
+  // lock. Returning a copy leaves the caller with no borrowed runtime state.
+  const std::scoped_lock lock(runtime_registry_mutex());
+  auto* runtime = static_cast<mln_runtime*>(platform_context);
+  if (
+    !runtime_registry().contains(runtime) || !runtime->has_resource_provider
+  ) {
+    return std::nullopt;
+  }
+  return runtime->resource_provider;
+}
+
+auto find_maximum_cache_size_for_platform_context(
+  void* platform_context
+) noexcept -> std::optional<std::uint64_t> {
+  if (platform_context == nullptr) {
+    return std::nullopt;
   }
 
   const std::scoped_lock lock(runtime_registry_mutex());
   auto* runtime = static_cast<mln_runtime*>(platform_context);
-  return runtime_registry().contains(runtime) ? runtime : nullptr;
+  if (
+    !runtime_registry().contains(runtime) || !runtime->has_maximum_cache_size
+  ) {
+    return std::nullopt;
+  }
+  return runtime->maximum_cache_size;
 }
 
 auto has_resource_transform_for_platform_context(

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -11,6 +11,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <mbgl/storage/resource_options.hpp>
@@ -49,6 +50,26 @@ struct ResourceTransformState {
   void* user_data = nullptr;
 };
 
+// Borrows one registered provider through its synchronous callback invocation.
+// Replacement and runtime teardown take the same mutex exclusively, so the
+// callback and its borrowed user data stay valid while a lease exists.
+class ResourceProviderLease {
+ public:
+  ResourceProviderLease(
+    std::shared_lock<std::shared_mutex> lock, ResourceProvider provider
+  )
+      : lock_(std::move(lock)), provider_(provider) {}
+
+  [[nodiscard]] auto callback() const -> mln_resource_provider_callback {
+    return provider_.callback;
+  }
+  [[nodiscard]] auto user_data() const -> void* { return provider_.user_data; }
+
+ private:
+  std::shared_lock<std::shared_mutex> lock_;
+  ResourceProvider provider_;
+};
+
 struct OfflineRegionEventState {
   std::mutex mutex;
   mln_runtime* runtime = nullptr;
@@ -82,6 +103,7 @@ struct mln_runtime {
   std::shared_ptr<mbgl::DatabaseFileSource> database_source;
   bool has_maximum_cache_size = false;
   std::uint64_t maximum_cache_size = 0;
+  mutable std::shared_mutex resource_provider_mutex;
   bool has_resource_provider = false;
   mln::core::ResourceProvider resource_provider;
   std::shared_ptr<mln::core::OfflineRegionEventState> offline_event_state;
@@ -220,15 +242,15 @@ auto release_runtime_map(mln_runtime* runtime) noexcept -> void;
 auto validate_runtime(mln_runtime* runtime) -> mln_status;
 auto resource_options_for_runtime(mln_runtime* runtime)
   -> mbgl::ResourceOptions;
-// Copies the resource provider registered on the runtime named by a MapLibre
-// platform context. Every read of the runtime happens while the registry lock
-// is held, so callers on MapLibre worker and network threads hold copied values
-// instead of a handle that runtime teardown may retire. Returns nullopt when
-// the platform context names no live runtime or the runtime carries no
-// provider.
-auto find_resource_provider_for_platform_context(
+// Leases the resource provider registered on the runtime named by a MapLibre
+// platform context. Acquiring the shared provider lock while the registry lock
+// is held hands runtime lifetime safely to the caller. Hold the returned lease
+// across the synchronous provider callback so teardown cannot retire its
+// callback or user_data. Returns nullopt when the platform context names no
+// live runtime or the runtime carries no provider.
+auto acquire_resource_provider_for_platform_context(
   void* platform_context
-) noexcept -> std::optional<ResourceProvider>;
+) noexcept -> std::optional<ResourceProviderLease>;
 
 // Copies the maximum ambient cache size configured on the runtime named by a
 // MapLibre platform context, under the same registry lock. Returns nullopt when

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -5,6 +5,7 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <thread>
@@ -219,8 +220,23 @@ auto release_runtime_map(mln_runtime* runtime) noexcept -> void;
 auto validate_runtime(mln_runtime* runtime) -> mln_status;
 auto resource_options_for_runtime(mln_runtime* runtime)
   -> mbgl::ResourceOptions;
-auto find_runtime_for_platform_context(void* platform_context) noexcept
-  -> mln_runtime*;
+// Copies the resource provider registered on the runtime named by a MapLibre
+// platform context. Every read of the runtime happens while the registry lock
+// is held, so callers on MapLibre worker and network threads hold copied values
+// instead of a handle that runtime teardown may retire. Returns nullopt when
+// the platform context names no live runtime or the runtime carries no
+// provider.
+auto find_resource_provider_for_platform_context(
+  void* platform_context
+) noexcept -> std::optional<ResourceProvider>;
+
+// Copies the maximum ambient cache size configured on the runtime named by a
+// MapLibre platform context, under the same registry lock. Returns nullopt when
+// the platform context names no live runtime or the runtime carries no maximum.
+auto find_maximum_cache_size_for_platform_context(
+  void* platform_context
+) noexcept -> std::optional<std::uint64_t>;
+
 // Reports whether a resource transform is registered. MapLibre-owned threads
 // observe a value instead of a runtime pointer teardown may retire, and the
 // process-global registry lock is released before the per-runtime transform


### PR DESCRIPTION
## Summary

Replaces `find_runtime_for_platform_context()`, which released the runtime registry lock before returning a raw `mln_runtime*` that its callers then dereferenced, with two lookups that copy the fields they need while the lock is still held.

## Test plan

Not verified locally — the cold native build in this worktree did not finish within the session, so compilation and `mise run test` are left to CI; `mise run fix` passed.

## Notes

**The window.** `find_runtime_for_platform_context()` took `runtime_registry_mutex()`, confirmed the handle was live, released the lock, and returned the pointer. Every caller dereferenced it afterwards with no lock and no ownership:

- `AbiNetworkFileSource::request` via `runtime_resource_provider` (`src/resources/resource_loader.cpp:103`, `:168`)
- `AbiNetworkFileSource::canRequest` via the same helper (`src/resources/resource_loader.cpp:121`)
- `make_database_file_source` reading `has_maximum_cache_size` / `maximum_cache_size` (`src/resources/resource_loader.cpp:214`)

**Reachability.** The threads that reach these are MapLibre-owned, not the runtime owner thread. `MainResourceLoader` dispatches `request` onto its ResourceLoaderThread (`third_party/maplibre-native/src/mbgl/storage/main_resource_loader.cpp:160-168`, `:178`), and `DatabaseFileSource` holds a strong reference to the network source and drives offline downloads from its own thread (`.../storage/database_file_source.cpp:208`) — the offline path needs no live map, so it runs in exactly the state `destroy_runtime()` allows. `canRequest` is not hopped at all: `MainResourceLoader::canRequest` (`.../main_resource_loader.cpp:265-267`) forwards synchronously to `Impl::canRequest` (`:182-189`), so it runs on whichever thread calls it.

Nothing joins those threads against runtime teardown. `FileSourceManager` caches file sources weakly, keyed on a string that includes the platform context reinterpreted as an integer address (`.../storage/file_source_manager.cpp:47-50`), so a cached source stays associated with a runtime address after that runtime is gone. `PMTilesFileSource` also forms a strong reference cycle with `MainResourceLoader` (`.../storage/pmtiles_file_source.cpp:216`, `:223-230`), which keeps that loader and its thread alive indefinitely once any pmtiles resource is requested.

I want to be precise about what that does and does not establish. In the ordinary single-map case the ordering does protect you: `destroy_runtime()` requires `live_maps == 0`, destroying the last map releases the `MainResourceLoader`, and `~MainResourceLoader` joins the ResourceLoaderThread before teardown runs. The reachable path depends on the file source outliving the runtime, which the weak address-keyed cache and the pmtiles cycle both permit. I did not build a deterministic reproducer, so treat this as a window I could characterize but not demonstrate.

**A second defect, unconditional.** `set_resource_provider()` writes `has_resource_provider` and `resource_provider` while holding `runtime_registry_mutex()` (`src/runtime/runtime.cpp:2311`, `:2316`). The registry mutex is therefore the designated guard for those fields, and the old reader read them outside it. That is a data race independent of any use-after-free, and it needs no exotic ordering: `set_resource_provider()` permits `live_maps == 0` with an offline download already in flight, so the owner thread can write while a file source thread reads.

**The fix.** Both new lookups follow the handoff already used by `invoke_resource_transform()` (`src/runtime/runtime.cpp:2506`) — resolve under the registry lock — but return a copied value rather than a lock, which suits these call sites because they need only plain data. Deleting the pointer-returning helper is deliberate: it removes the shape rather than patching the three current callers.

**What this does not fix.** Copying the provider closes the window on the `mln_runtime` object, but the host callback and `user_data` are still invoked after the copy, and the header promises they need only stay valid "until the runtime is destroyed" (`include/maplibre_native_c/runtime.h:544-545`). A callback entered just before teardown can therefore still run against freed host state. Closing that needs the other half of the transform's pattern — a per-runtime shared lock taken under the registry lock, with teardown waiting on it exclusively. The provider callback invocation is synchronous and bounded (`src/resources/custom_resource_provider.cpp:329`, and `mln_resource_request_handle` is refcounted independently of the runtime), so that wait would be bounded too. I left it out because it edits `destroy_runtime()`, which #351 rewrites; it belongs on top of that PR.

**Interaction with open PRs.**

- #351 does not introduce this window and does not remove it. Before it, `destroy_runtime()` erased the entry and ran `~mln_runtime` together under the registry lock; after it, the erase happens under the lock and the destruction with the lock released. Either way the race is the same instructions — between this lookup's lock release and the caller's dereference. #351 shortens the lock hold, so the free follows the erase more closely and no longer queues behind unrelated registry traffic, which marginally widens the window in wall-clock terms.
- #347 also edits `AbiNetworkFileSource::request` and adds a third caller, `has_resource_transform`, which takes `runtime->resource_transform_mutex` after the registry lock is released — the same defect in a worse form, since it locks a mutex inside a possibly-freed object. Since this PR deletes `find_runtime_for_platform_context()`, #347 will need a rebase; the fix there is a `runtime_has_resource_transform(platform_context)` helper in `runtime.cpp` shaped like the two added here. I did not add it in this PR to avoid landing an unused function.

The repository has no sanitizer build, so nothing in CI detects this class of bug automatically.

## AI assistance

- **Tools:** Claude Code
- **Context:** Investigated the reported window, traced the mbgl threading and file source ownership in the vendored submodule, and wrote the fix and this description.
