### PR TITLE
Distinguish unbounded camera bounds from world bounds

### DIFF
--- a/bindings/dotnet/src/Maplibre.Native/Camera/CameraOptions.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Camera/CameraOptions.cs
@@ -51,6 +51,26 @@ public sealed record CameraFitOptions
     public double? Pitch { get; set; }
 }
 
+/// <summary>Geographic constraint applied to the map camera center.</summary>
+public abstract record BoundsConstraint
+{
+    private BoundsConstraint() { }
+
+    /// <summary>Keeps the camera center inside the given bounds.</summary>
+    public sealed record Bounded(LatLngBounds Bounds) : BoundsConstraint;
+
+    /// <summary>
+    /// Leaves the camera center unconstrained, so the map pans freely across the antimeridian.
+    /// This differs from world bounds of -90/-180 to 90/180, which clamp longitude to that range.
+    /// </summary>
+    public sealed record Unbounded : BoundsConstraint
+    {
+        public static Unbounded Instance { get; } = new();
+
+        private Unbounded() { }
+    }
+}
+
 /// <summary>Camera bound constraint descriptor.</summary>
 /// <remarks>
 /// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
@@ -58,7 +78,7 @@ public sealed record CameraFitOptions
 /// </remarks>
 public sealed record BoundOptions
 {
-    public LatLngBounds? Bounds { get; set; }
+    public BoundsConstraint? Bounds { get; set; }
     public double? MinimumZoom { get; set; }
     public double? MaximumZoom { get; set; }
     public double? MinimumPitch { get; set; }

--- a/bindings/dotnet/src/Maplibre.Native/Generated/map.g.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Generated/map.g.cs
@@ -41,6 +41,7 @@ namespace Maplibre.Native.Internal.C
         MLN_BOUND_OPTION_MAX_ZOOM = 1U << 2,
         MLN_BOUND_OPTION_MIN_PITCH = 1U << 3,
         MLN_BOUND_OPTION_MAX_PITCH = 1U << 4,
+        MLN_BOUND_OPTION_UNBOUNDED = 1U << 5,
     }
 
     [NativeTypeName("uint32_t")]
@@ -352,7 +353,7 @@ namespace Maplibre.Native.Internal.C
         [NativeTypeName("uint32_t")]
         public uint type;
 
-        [NativeTypeName("__AnonymousRecord_map_L336_C3")]
+        [NativeTypeName("__AnonymousRecord_map_L364_C3")]
         public _data_e__Union data;
 
         [StructLayout(LayoutKind.Explicit)]
@@ -428,7 +429,7 @@ namespace Maplibre.Native.Internal.C
         [NativeTypeName("uint32_t")]
         public uint type;
 
-        [NativeTypeName("__AnonymousRecord_map_L393_C3")]
+        [NativeTypeName("__AnonymousRecord_map_L421_C3")]
         public _data_e__Union data;
 
         [StructLayout(LayoutKind.Explicit)]
@@ -512,7 +513,7 @@ namespace Maplibre.Native.Internal.C
         [NativeTypeName("uint32_t")]
         public uint identifier_type;
 
-        [NativeTypeName("__AnonymousRecord_map_L448_C3")]
+        [NativeTypeName("__AnonymousRecord_map_L476_C3")]
         public _identifier_e__Union identifier;
 
         [StructLayout(LayoutKind.Explicit)]
@@ -559,7 +560,7 @@ namespace Maplibre.Native.Internal.C
         [NativeTypeName("uint32_t")]
         public uint type;
 
-        [NativeTypeName("__AnonymousRecord_map_L479_C3")]
+        [NativeTypeName("__AnonymousRecord_map_L507_C3")]
         public _data_e__Union data;
 
         [StructLayout(LayoutKind.Explicit)]
@@ -653,7 +654,7 @@ namespace Maplibre.Native.Internal.C
         [NativeTypeName("uint32_t")]
         public uint type;
 
-        [NativeTypeName("__AnonymousRecord_map_L549_C3")]
+        [NativeTypeName("__AnonymousRecord_map_L578_C3")]
         public _data_e__Union data;
 
         [StructLayout(LayoutKind.Explicit)]

--- a/bindings/dotnet/src/Maplibre.Native/Internal/Struct/MapStructs.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Internal/Struct/MapStructs.cs
@@ -241,10 +241,15 @@ internal static class MapStructs
     {
         ArgumentNullException.ThrowIfNull(options);
         var native = NativeMethods.mln_bound_options_default();
-        if (options.Bounds is { } bounds)
+        switch (options.Bounds)
         {
-            native.fields |= (uint)mln_bound_option_field.MLN_BOUND_OPTION_BOUNDS;
-            native.bounds = ToNative(bounds);
+            case BoundsConstraint.Bounded bounded:
+                native.fields |= (uint)mln_bound_option_field.MLN_BOUND_OPTION_BOUNDS;
+                native.bounds = ToNative(bounded.Bounds);
+                break;
+            case BoundsConstraint.Unbounded:
+                native.fields |= (uint)mln_bound_option_field.MLN_BOUND_OPTION_UNBOUNDED;
+                break;
         }
         if (options.MinimumZoom is { } minimumZoom)
         {
@@ -274,7 +279,11 @@ internal static class MapStructs
         var options = new BoundOptions();
         if (Has(native.fields, mln_bound_option_field.MLN_BOUND_OPTION_BOUNDS))
         {
-            options.Bounds = FromNative(native.bounds);
+            options.Bounds = new BoundsConstraint.Bounded(FromNative(native.bounds));
+        }
+        else if (Has(native.fields, mln_bound_option_field.MLN_BOUND_OPTION_UNBOUNDED))
+        {
+            options.Bounds = BoundsConstraint.Unbounded.Instance;
         }
         if (Has(native.fields, mln_bound_option_field.MLN_BOUND_OPTION_MIN_ZOOM))
         {

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/MapCameraOptionsTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/MapCameraOptionsTests.cs
@@ -100,7 +100,7 @@ public sealed class MapCameraOptionsTests
         map.SetBounds(
             new BoundOptions
             {
-                Bounds = bounds,
+                Bounds = new BoundsConstraint.Bounded(bounds),
                 MinimumZoom = 1,
                 MaximumZoom = 12,
                 MinimumPitch = 0,
@@ -117,7 +117,7 @@ public sealed class MapCameraOptionsTests
         );
 
         var copiedBounds = map.GetBounds();
-        Assert.Equal(bounds, copiedBounds.Bounds);
+        Assert.Equal(new BoundsConstraint.Bounded(bounds), copiedBounds.Bounds);
         Assert.NotNull(copiedBounds.MinimumZoom);
         Assert.Equal(1, copiedBounds.MinimumZoom.Value, 12);
         Assert.NotNull(copiedBounds.MaximumZoom);
@@ -142,6 +142,48 @@ public sealed class MapCameraOptionsTests
         );
         Assert.True(visibleBounds.Southwest.Latitude <= visibleBounds.Northeast.Latitude);
         Assert.True(unwrappedBounds.Southwest.Latitude <= unwrappedBounds.Northeast.Latitude);
+    }
+
+    // This verifies that the geographic constraint reports and applies the
+    // unbounded state distinctly from world bounds, which the southwest/northeast
+    // pair alone cannot express.
+    [BindingSpecTest("BND-102")]
+    [Fact]
+    public void CameraBoundsDistinguishUnboundedFromWorldBounds()
+    {
+        using var runtime = RuntimeHandle.Create(new RuntimeOptions());
+        using var map = MapHandle.Create(runtime, new MapOptions { Width = 512, Height = 512 });
+
+        double JumpedLongitude(double longitude)
+        {
+            map.JumpTo(new CameraOptions { Center = new LatLng(0, longitude), Zoom = 2 });
+            var camera = map.GetCamera();
+            Assert.NotNull(camera.Center);
+            return camera.Center.Value.Longitude;
+        }
+
+        Assert.Equal(BoundsConstraint.Unbounded.Instance, map.GetBounds().Bounds);
+        // An unbounded map wraps across the antimeridian.
+        Assert.Equal(-160, JumpedLongitude(200), 6);
+
+        map.SetBounds(
+            new BoundOptions
+            {
+                Bounds = new BoundsConstraint.Bounded(
+                    new LatLngBounds(new LatLng(-90, -180), new LatLng(90, 180))
+                ),
+            }
+        );
+
+        var world = Assert.IsType<BoundsConstraint.Bounded>(map.GetBounds().Bounds);
+        Assert.Equal(180, world.Bounds.Northeast.Longitude, 6);
+        // World bounds clamp at the antimeridian instead of wrapping.
+        Assert.Equal(180, JumpedLongitude(200), 6);
+
+        map.SetBounds(new BoundOptions { Bounds = BoundsConstraint.Unbounded.Instance });
+        Assert.Equal(BoundsConstraint.Unbounded.Instance, map.GetBounds().Bounds);
+        // Releasing the constraint restores antimeridian wrapping.
+        Assert.Equal(-160, JumpedLongitude(200), 6);
     }
 
     [BindingSpecTest("BND-104")]

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/OptionsValueSemanticsTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/OptionsValueSemanticsTests.cs
@@ -109,13 +109,15 @@ public sealed class OptionsValueSemanticsTests
             () =>
                 new BoundOptions
                 {
-                    Bounds = new LatLngBounds(new LatLng(0, 0), new LatLng(1, 1)),
+                    Bounds = new BoundsConstraint.Bounded(
+                        new LatLngBounds(new LatLng(0, 0), new LatLng(1, 1))
+                    ),
                     MinimumZoom = 2,
                     MaximumZoom = 3,
                     MinimumPitch = 4,
                     MaximumPitch = 5,
                 },
-            options => options.Bounds = new LatLngBounds(new LatLng(-1, -1), new LatLng(2, 2)),
+            options => options.Bounds = BoundsConstraint.Unbounded.Instance,
             options => options.MinimumZoom = 20,
             options => options.MaximumZoom = 30,
             options => options.MinimumPitch = 40,

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/PublicApiSurfaceTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/PublicApiSurfaceTests.cs
@@ -15,6 +15,9 @@ public sealed class PublicApiSurfaceTests
         {
             "Maplibre.Native.Camera.AnimationOptions",
             "Maplibre.Native.Camera.BoundOptions",
+            "Maplibre.Native.Camera.BoundsConstraint",
+            "Maplibre.Native.Camera.BoundsConstraint+Bounded",
+            "Maplibre.Native.Camera.BoundsConstraint+Unbounded",
             "Maplibre.Native.Camera.CameraFitOptions",
             "Maplibre.Native.Camera.CameraOptions",
             "Maplibre.Native.Camera.EdgeInsets",

--- a/bindings/go/camera.go
+++ b/bindings/go/camera.go
@@ -5,6 +5,8 @@ package maplibre
 */
 import "C"
 
+import "fmt"
+
 // CameraOptions configures map camera snapshots and commands.
 type CameraOptions struct {
 	Center         *LatLng
@@ -374,7 +376,7 @@ func (options BoundOptions) WithMaxPitch(maxPitch float64) BoundOptions {
 	return options
 }
 
-func cBoundOptions(options BoundOptions) C.mln_bound_options {
+func cBoundOptions(options BoundOptions) (C.mln_bound_options, error) {
 	raw := C.mln_bound_options_default()
 	if options.Bounds != nil {
 		switch options.Bounds.Kind {
@@ -383,6 +385,11 @@ func cBoundOptions(options BoundOptions) C.mln_bound_options {
 			raw.bounds = cLatLngBounds(options.Bounds.Bounds)
 		case BoundsConstraintUnbounded:
 			raw.fields |= C.MLN_BOUND_OPTION_UNBOUNDED
+		default:
+			// Neither constraint bit would be set, so the call would succeed
+			// while leaving the existing constraint untouched.
+			return raw, newBindingError(ErrInvalidArgument,
+				fmt.Sprintf("unknown BoundsConstraintKind %d", options.Bounds.Kind))
 		}
 	}
 	if options.MinZoom != nil {
@@ -401,7 +408,7 @@ func cBoundOptions(options BoundOptions) C.mln_bound_options {
 		raw.fields |= C.MLN_BOUND_OPTION_MAX_PITCH
 		raw.max_pitch = C.double(*options.MaxPitch)
 	}
-	return raw
+	return raw, nil
 }
 
 func goBoundOptions(raw C.mln_bound_options) BoundOptions {

--- a/bindings/go/camera.go
+++ b/bindings/go/camera.go
@@ -295,9 +295,28 @@ func cCameraFitOptionsPointer(options *CameraFitOptions) (C.mln_camera_fit_optio
 	return raw, &raw
 }
 
+// BoundsConstraintKind selects which case a BoundsConstraint carries.
+type BoundsConstraintKind int
+
+const (
+	// BoundsConstraintBounded keeps the camera center inside the constraint's bounds.
+	BoundsConstraintBounded BoundsConstraintKind = iota
+	// BoundsConstraintUnbounded leaves the camera center unconstrained.
+	BoundsConstraintUnbounded
+)
+
+// BoundsConstraint is the geographic constraint applied to the map camera center. An unbounded
+// constraint leaves the camera center free, so the map pans across the antimeridian. This differs
+// from world bounds of -90/-180 to 90/180, which clamp longitude to that range.
+type BoundsConstraint struct {
+	Kind BoundsConstraintKind
+	// Bounds is read when Kind is BoundsConstraintBounded.
+	Bounds LatLngBounds
+}
+
 // BoundOptions configures map camera constraints.
 type BoundOptions struct {
-	Bounds   *LatLngBounds
+	Bounds   *BoundsConstraint
 	MinZoom  *float64
 	MaxZoom  *float64
 	MinPitch *float64
@@ -307,17 +326,23 @@ type BoundOptions struct {
 // Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
 // compares the optional fields by pointer identity.
 func (options BoundOptions) Equal(other BoundOptions) bool {
-	return equalPointer(options.Bounds, other.Bounds) &&
+	return equalBoundsConstraint(options.Bounds, other.Bounds) &&
 		equalPointer(options.MinZoom, other.MinZoom) &&
 		equalPointer(options.MaxZoom, other.MaxZoom) &&
 		equalPointer(options.MinPitch, other.MinPitch) &&
 		equalPointer(options.MaxPitch, other.MaxPitch)
 }
 
-// WithBounds returns a copy that sets geographic camera constraints.
+// WithBounds returns a copy that keeps the camera center inside the given bounds.
 func (options BoundOptions) WithBounds(bounds LatLngBounds) BoundOptions {
-	options.Bounds = new(LatLngBounds)
-	*options.Bounds = bounds
+	options.Bounds = &BoundsConstraint{Kind: BoundsConstraintBounded, Bounds: bounds}
+	return options
+}
+
+// WithUnbounded returns a copy that leaves the camera center unconstrained, so the map pans across
+// the antimeridian.
+func (options BoundOptions) WithUnbounded() BoundOptions {
+	options.Bounds = &BoundsConstraint{Kind: BoundsConstraintUnbounded}
 	return options
 }
 
@@ -352,8 +377,13 @@ func (options BoundOptions) WithMaxPitch(maxPitch float64) BoundOptions {
 func cBoundOptions(options BoundOptions) C.mln_bound_options {
 	raw := C.mln_bound_options_default()
 	if options.Bounds != nil {
-		raw.fields |= C.MLN_BOUND_OPTION_BOUNDS
-		raw.bounds = cLatLngBounds(*options.Bounds)
+		switch options.Bounds.Kind {
+		case BoundsConstraintBounded:
+			raw.fields |= C.MLN_BOUND_OPTION_BOUNDS
+			raw.bounds = cLatLngBounds(options.Bounds.Bounds)
+		case BoundsConstraintUnbounded:
+			raw.fields |= C.MLN_BOUND_OPTION_UNBOUNDED
+		}
 	}
 	if options.MinZoom != nil {
 		raw.fields |= C.MLN_BOUND_OPTION_MIN_ZOOM
@@ -376,9 +406,11 @@ func cBoundOptions(options BoundOptions) C.mln_bound_options {
 
 func goBoundOptions(raw C.mln_bound_options) BoundOptions {
 	var options BoundOptions
-	if raw.fields&C.MLN_BOUND_OPTION_BOUNDS != 0 {
-		value := goLatLngBounds(raw.bounds)
-		options.Bounds = &value
+	switch {
+	case raw.fields&C.MLN_BOUND_OPTION_BOUNDS != 0:
+		options.Bounds = &BoundsConstraint{Kind: BoundsConstraintBounded, Bounds: goLatLngBounds(raw.bounds)}
+	case raw.fields&C.MLN_BOUND_OPTION_UNBOUNDED != 0:
+		options.Bounds = &BoundsConstraint{Kind: BoundsConstraintUnbounded}
 	}
 	if raw.fields&C.MLN_BOUND_OPTION_MIN_ZOOM != 0 {
 		value := float64(raw.min_zoom)

--- a/bindings/go/camera_test.go
+++ b/bindings/go/camera_test.go
@@ -2,6 +2,7 @@ package maplibre
 
 import (
 	"errors"
+	"math"
 	"testing"
 )
 
@@ -184,9 +185,88 @@ func TestMapCameraFitAndBoundsHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bounds(): %v", err)
 	}
-	if gotConstraints.Bounds == nil || *gotConstraints.Bounds != bounds {
-		t.Fatalf("Bounds().Bounds = %#v, want %#v", gotConstraints.Bounds, bounds)
+	if gotConstraints.Bounds == nil ||
+		gotConstraints.Bounds.Kind != BoundsConstraintBounded ||
+		gotConstraints.Bounds.Bounds != bounds {
+		t.Fatalf("Bounds().Bounds = %#v, want bounded %#v", gotConstraints.Bounds, bounds)
 	}
+}
+
+// The unbounded constraint is distinct from world bounds: an unbounded camera center pans across
+// the antimeridian, while world bounds clamp longitude to the -180..180 range.
+func TestMapBoundsSeparateUnboundedFromWorldBounds(t *testing.T) {
+	lockOSThreadForTest(t)
+
+	runtime, err := NewRuntime()
+	if err != nil {
+		t.Fatalf("NewRuntime(): %v", err)
+	}
+	m, err := runtime.NewMapWithOptions(NewMapOptions(512, 512, 1))
+	if err != nil {
+		_ = runtime.Close()
+		t.Fatalf("NewMapWithOptions(): %v", err)
+	}
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Errorf("Map Close(): %v", err)
+		}
+		if err := runtime.Close(); err != nil {
+			t.Errorf("Runtime Close(): %v", err)
+		}
+	}()
+
+	constraintKind := func(want BoundsConstraintKind) {
+		t.Helper()
+		got, err := m.Bounds()
+		if err != nil {
+			t.Fatalf("Bounds(): %v", err)
+		}
+		if got.Bounds == nil || got.Bounds.Kind != want {
+			t.Fatalf("Bounds().Bounds = %#v, want kind %v", got.Bounds, want)
+		}
+	}
+	jumpedLongitude := func(longitude float64) float64 {
+		t.Helper()
+		camera := CameraOptions{}.
+			WithCenter(LatLng{Latitude: 0, Longitude: longitude}).
+			WithZoom(2)
+		if err := m.JumpTo(camera); err != nil {
+			t.Fatalf("JumpTo(%v): %v", longitude, err)
+		}
+		snapshot, err := m.Camera()
+		if err != nil {
+			t.Fatalf("Camera(): %v", err)
+		}
+		if snapshot.Center == nil {
+			t.Fatalf("Camera() missing center: %#v", snapshot)
+		}
+		return snapshot.Center.Longitude
+	}
+	assertLongitude := func(got, want float64) {
+		t.Helper()
+		if math.Abs(got-want) > 1e-6 {
+			t.Fatalf("camera longitude = %v, want %v", got, want)
+		}
+	}
+
+	constraintKind(BoundsConstraintUnbounded)
+	assertLongitude(jumpedLongitude(200), -160)
+
+	world := LatLngBounds{
+		Southwest: LatLng{Latitude: -90, Longitude: -180},
+		Northeast: LatLng{Latitude: 90, Longitude: 180},
+	}
+	if err := m.SetBounds(BoundOptions{}.WithBounds(world)); err != nil {
+		t.Fatalf("SetBounds(world): %v", err)
+	}
+	constraintKind(BoundsConstraintBounded)
+	assertLongitude(jumpedLongitude(200), 180)
+
+	if err := m.SetBounds(BoundOptions{}.WithUnbounded()); err != nil {
+		t.Fatalf("SetBounds(unbounded): %v", err)
+	}
+	constraintKind(BoundsConstraintUnbounded)
+	assertLongitude(jumpedLongitude(200), -160)
 }
 
 func TestMapFreeCameraOptionsRoundTripCurrentValues(t *testing.T) {

--- a/bindings/go/camera_test.go
+++ b/bindings/go/camera_test.go
@@ -339,6 +339,12 @@ func TestMapCameraCommandsReportNativeValidation(t *testing.T) {
 	if err := m.SetBounds(invalidBounds); !errors.Is(err, ErrInvalidArgument) {
 		t.Fatalf("SetBounds(invalid min/max) error = %v, want ErrInvalidArgument", err)
 	}
+	// An unknown kind sets neither constraint bit, so without validation the
+	// call would report success and leave the existing constraint in place.
+	unknownKind := BoundOptions{Bounds: &BoundsConstraint{Kind: BoundsConstraintKind(99)}}
+	if err := m.SetBounds(unknownKind); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("SetBounds(unknown kind) error = %v, want ErrInvalidArgument", err)
+	}
 	invalidFreeCamera := FreeCameraOptions{}.WithOrientation(Quaternion{})
 	if err := m.SetFreeCameraOptions(invalidFreeCamera); !errors.Is(err, ErrInvalidArgument) {
 		t.Fatalf("SetFreeCameraOptions(invalid orientation) error = %v, want ErrInvalidArgument", err)

--- a/bindings/go/equal.go
+++ b/bindings/go/equal.go
@@ -36,6 +36,18 @@ func equalStrings(left, right []string) bool {
 	return true
 }
 
+// equalBoundsConstraint reports whether two optional camera center constraints are equal. The
+// bounds value is compared for the bounded case, which is the case that reads it.
+func equalBoundsConstraint(left, right *BoundsConstraint) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	if left.Kind != right.Kind {
+		return false
+	}
+	return left.Kind != BoundsConstraintBounded || left.Bounds == right.Bounds
+}
+
 // equalJSON reports whether two optional JSON filters are equal.
 func equalJSON(left, right *JSONValue) bool {
 	if left == nil || right == nil {

--- a/bindings/go/equal_test.go
+++ b/bindings/go/equal_test.go
@@ -112,9 +112,12 @@ func TestBoundOptionsEqualComparesFieldValues(t *testing.T) {
 		"BoundOptions",
 		func() BoundOptions {
 			return BoundOptions{
-				Bounds: optionPtr(LatLngBounds{
-					Southwest: LatLng{Latitude: 0, Longitude: 0},
-					Northeast: LatLng{Latitude: 1, Longitude: 1},
+				Bounds: optionPtr(BoundsConstraint{
+					Kind: BoundsConstraintBounded,
+					Bounds: LatLngBounds{
+						Southwest: LatLng{Latitude: 0, Longitude: 0},
+						Northeast: LatLng{Latitude: 1, Longitude: 1},
+					},
 				}),
 				MinZoom:  optionPtr(2.0),
 				MaxZoom:  optionPtr(3.0),
@@ -125,10 +128,16 @@ func TestBoundOptionsEqualComparesFieldValues(t *testing.T) {
 		BoundOptions.Equal,
 		[]func(*BoundOptions){
 			func(o *BoundOptions) {
-				o.Bounds = optionPtr(LatLngBounds{
-					Southwest: LatLng{Latitude: -1, Longitude: -1},
-					Northeast: LatLng{Latitude: 2, Longitude: 2},
+				o.Bounds = optionPtr(BoundsConstraint{
+					Kind: BoundsConstraintBounded,
+					Bounds: LatLngBounds{
+						Southwest: LatLng{Latitude: -1, Longitude: -1},
+						Northeast: LatLng{Latitude: 2, Longitude: 2},
+					},
 				})
+			},
+			func(o *BoundOptions) {
+				o.Bounds = optionPtr(BoundsConstraint{Kind: BoundsConstraintUnbounded})
 			},
 			func(o *BoundOptions) { o.MinZoom = optionPtr(20.0) },
 			func(o *BoundOptions) { o.MaxZoom = optionPtr(30.0) },

--- a/bindings/go/map.go
+++ b/bindings/go/map.go
@@ -675,7 +675,10 @@ func (m *MapHandle) SetBounds(options BoundOptions) error {
 	}
 	defer release()
 	defer m.state.KeepAlive()
-	rawOptions := cBoundOptions(options)
+	rawOptions, err := cBoundOptions(options)
+	if err != nil {
+		return err
+	}
 	return checkNative(func() int32 {
 		return int32(C.mln_map_set_bounds((*C.mln_map)(unsafe.Pointer(ptr)), &rawOptions))
 	})

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -8,6 +8,7 @@ import org.bytedeco.javacpp.SizeTPointer
 import org.maplibre.nativeffi.NativeAccess
 import org.maplibre.nativeffi.camera.AnimationOptions
 import org.maplibre.nativeffi.camera.BoundOptions
+import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.camera.EdgeInsets
@@ -1847,7 +1848,9 @@ private fun boundOptions(value: MaplibreNativeC.mln_bound_options): BoundOptions
   val fields = value.fields()
   return BoundOptions().apply {
     if ((fields and MaplibreNativeC.MLN_BOUND_OPTION_BOUNDS) != 0) {
-      bounds = latLngBounds(value.bounds())
+      bounds = BoundsConstraint.Bounded(latLngBounds(value.bounds()))
+    } else if ((fields and MaplibreNativeC.MLN_BOUND_OPTION_UNBOUNDED) != 0) {
+      bounds = BoundsConstraint.Unbounded
     }
     if ((fields and MaplibreNativeC.MLN_BOUND_OPTION_MIN_ZOOM) != 0) {
       minZoom = value.min_zoom()
@@ -2108,9 +2111,15 @@ private class BoundOptionsScope(value: BoundOptions) : AutoCloseable {
 
   init {
     var fields = 0
-    value.bounds?.let {
-      fields = fields or MaplibreNativeC.MLN_BOUND_OPTION_BOUNDS
-      options.bounds(latLngBounds(it))
+    when (val constraint = value.bounds) {
+      is BoundsConstraint.Bounded -> {
+        fields = fields or MaplibreNativeC.MLN_BOUND_OPTION_BOUNDS
+        options.bounds(latLngBounds(constraint.bounds))
+      }
+      BoundsConstraint.Unbounded -> {
+        fields = fields or MaplibreNativeC.MLN_BOUND_OPTION_UNBOUNDED
+      }
+      null -> {}
     }
     value.minZoom?.let {
       fields = fields or MaplibreNativeC.MLN_BOUND_OPTION_MIN_ZOOM

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/BoundOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/BoundOptions.kt
@@ -1,7 +1,5 @@
 package org.maplibre.nativeffi.camera
 
-import org.maplibre.nativeffi.geo.LatLngBounds
-
 /**
  * Mutable map bounds descriptor.
  *
@@ -9,7 +7,8 @@ import org.maplibre.nativeffi.geo.LatLngBounds
  * unmodified while it is a key in a hash-based collection.
  */
 public class BoundOptions {
-  public var bounds: LatLngBounds? = null
+  /** Camera center constraint, or `null` to leave the map's current constraint unchanged. */
+  public var bounds: BoundsConstraint? = null
 
   public var minZoom: Double? = null
 

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/BoundsConstraint.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/camera/BoundsConstraint.kt
@@ -1,0 +1,15 @@
+package org.maplibre.nativeffi.camera
+
+import org.maplibre.nativeffi.geo.LatLngBounds
+
+/** Geographic constraint applied to the map camera center. */
+public sealed interface BoundsConstraint {
+  /** Keeps the camera center inside [bounds]. */
+  public data class Bounded(public val bounds: LatLngBounds) : BoundsConstraint
+
+  /**
+   * Leaves the camera center unconstrained, so the map pans freely across the antimeridian. This
+   * differs from world bounds of -90/-180 to 90/180, which clamp longitude to that range.
+   */
+  public data object Unbounded : BoundsConstraint
+}

--- a/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/OptionsValueSemanticsTest.kt
+++ b/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/OptionsValueSemanticsTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotSame
 import org.maplibre.nativeffi.camera.AnimationOptions
 import org.maplibre.nativeffi.camera.BoundOptions
+import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.camera.EdgeInsets
@@ -123,7 +124,7 @@ class OptionsValueSemanticsTest {
     assertValueSemantics(
       baseline = {
         BoundOptions().apply {
-          bounds = LatLngBounds(LatLng(0.0, 0.0), LatLng(1.0, 1.0))
+          bounds = BoundsConstraint.Bounded(LatLngBounds(LatLng(0.0, 0.0), LatLng(1.0, 1.0)))
           minZoom = 2.0
           maxZoom = 3.0
           minPitch = 4.0
@@ -133,7 +134,8 @@ class OptionsValueSemanticsTest {
       copyOf = { it.copy() },
       mutators =
         listOf(
-          { bounds = LatLngBounds(LatLng(-1.0, -1.0), LatLng(2.0, 2.0)) },
+          { bounds = BoundsConstraint.Bounded(LatLngBounds(LatLng(-1.0, -1.0), LatLng(2.0, 2.0))) },
+          { bounds = BoundsConstraint.Unbounded },
           { minZoom = 20.0 },
           { maxZoom = 30.0 },
           { minPitch = 40.0 },

--- a/bindings/kotlin/src/jextract/maplibre-native-c.includes
+++ b/bindings/kotlin/src/jextract/maplibre-native-c.includes
@@ -110,6 +110,7 @@
 --include-constant MLN_BOUND_OPTION_MAX_ZOOM
 --include-constant MLN_BOUND_OPTION_MIN_PITCH
 --include-constant MLN_BOUND_OPTION_MIN_ZOOM
+--include-constant MLN_BOUND_OPTION_UNBOUNDED
 --include-constant MLN_CAMERA_FIT_OPTION_BEARING
 --include-constant MLN_CAMERA_FIT_OPTION_PADDING
 --include-constant MLN_CAMERA_FIT_OPTION_PITCH

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/loader/NativeAccess.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/loader/NativeAccess.kt
@@ -9,6 +9,7 @@ import java.nio.file.Path
 import java.util.NoSuchElementException
 import org.maplibre.nativeffi.camera.AnimationOptions
 import org.maplibre.nativeffi.camera.BoundOptions
+import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.camera.EdgeInsets
@@ -3535,9 +3536,15 @@ internal object NativeAccess {
   private fun boundOptions(arena: Arena, value: BoundOptions): MemorySegment {
     val segment = boundOptionsDefault(arena)
     var fields = 0
-    value.bounds?.let {
-      fields = fields or MapLibreNativeC.MLN_BOUND_OPTION_BOUNDS()
-      mln_bound_options.bounds(segment).copyFrom(latLngBounds(arena, it))
+    when (val constraint = value.bounds) {
+      is BoundsConstraint.Bounded -> {
+        fields = fields or MapLibreNativeC.MLN_BOUND_OPTION_BOUNDS()
+        mln_bound_options.bounds(segment).copyFrom(latLngBounds(arena, constraint.bounds))
+      }
+      BoundsConstraint.Unbounded -> {
+        fields = fields or MapLibreNativeC.MLN_BOUND_OPTION_UNBOUNDED()
+      }
+      null -> {}
     }
     value.minZoom?.let {
       fields = fields or MapLibreNativeC.MLN_BOUND_OPTION_MIN_ZOOM()
@@ -3563,7 +3570,9 @@ internal object NativeAccess {
     val fields = mln_bound_options.fields(segment)
     return BoundOptions().apply {
       if ((fields and MapLibreNativeC.MLN_BOUND_OPTION_BOUNDS()) != 0) {
-        bounds = latLngBounds(mln_bound_options.bounds(segment))
+        bounds = BoundsConstraint.Bounded(latLngBounds(mln_bound_options.bounds(segment)))
+      } else if ((fields and MapLibreNativeC.MLN_BOUND_OPTION_UNBOUNDED()) != 0) {
+        bounds = BoundsConstraint.Unbounded
       }
       if ((fields and MapLibreNativeC.MLN_BOUND_OPTION_MIN_ZOOM()) != 0) {
         minZoom = mln_bound_options.min_zoom(segment)

--- a/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/map/MapHandleTest.kt
+++ b/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/map/MapHandleTest.kt
@@ -8,6 +8,8 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.maplibre.nativeffi.Maplibre
 import org.maplibre.nativeffi.camera.AnimationOptions
+import org.maplibre.nativeffi.camera.BoundOptions
+import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.camera.EdgeInsets
@@ -638,15 +640,15 @@ class MapHandleTest {
       }
 
       map.bounds =
-        org.maplibre.nativeffi.camera.BoundOptions().apply {
-          this.bounds = bounds
+        BoundOptions().apply {
+          this.bounds = BoundsConstraint.Bounded(bounds)
           minZoom = 1.0
           maxZoom = 10.0
           minPitch = 0.0
           maxPitch = 45.0
         }
       val boundOptions = map.bounds
-      assertEquals(bounds, boundOptions.bounds)
+      assertEquals(BoundsConstraint.Bounded(bounds), boundOptions.bounds)
       assertEquals(1.0, boundOptions.minZoom ?: 0.0, 1e-6)
       assertEquals(10.0, boundOptions.maxZoom ?: 0.0, 1e-6)
       assertEquals(0.0, boundOptions.minPitch ?: -1.0, 1e-6)
@@ -659,6 +661,50 @@ class MapHandleTest {
         }
       assertTrue(map.freeCameraOptions.position != null)
       assertTrue(map.freeCameraOptions.orientation != null)
+    } finally {
+      map.close()
+      runtime.close()
+    }
+  }
+
+  @Test
+  fun boundsConstraintDistinguishesUnboundedFromWorldBounds() {
+    val runtime = RuntimeHandle.create(RuntimeOptions())
+    val map =
+      MapHandle.create(
+        runtime,
+        MapOptions().apply {
+          width = 128
+          height = 128
+          mapMode = MapMode.STATIC
+        },
+      )
+
+    fun jumpedLongitude(longitude: Double): Double {
+      map.jumpTo(
+        CameraOptions().apply {
+          center = LatLng(0.0, longitude)
+          zoom = 2.0
+        }
+      )
+      return requireNotNull(map.camera.center).longitude
+    }
+
+    try {
+      // An unbounded map wraps across the antimeridian.
+      assertEquals(BoundsConstraint.Unbounded, map.bounds.bounds)
+      assertEquals(-160.0, jumpedLongitude(200.0), 1e-6)
+
+      val world = LatLngBounds(LatLng(-90.0, -180.0), LatLng(90.0, 180.0))
+      map.bounds = BoundOptions().apply { bounds = BoundsConstraint.Bounded(world) }
+      assertEquals(BoundsConstraint.Bounded(world), map.bounds.bounds)
+      // World bounds clamp at the antimeridian instead of wrapping.
+      assertEquals(180.0, jumpedLongitude(200.0), 1e-6)
+
+      map.bounds = BoundOptions().apply { bounds = BoundsConstraint.Unbounded }
+      assertEquals(BoundsConstraint.Unbounded, map.bounds.bounds)
+      // Releasing the constraint restores antimeridian wrapping.
+      assertEquals(-160.0, jumpedLongitude(200.0), 1e-6)
     } finally {
       map.close()
       runtime.close()

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/internal/struct/MapStructs.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/internal/struct/MapStructs.kt
@@ -7,6 +7,7 @@ import kotlinx.cinterop.alloc
 import kotlinx.cinterop.ptr
 import org.maplibre.nativeffi.camera.AnimationOptions
 import org.maplibre.nativeffi.camera.BoundOptions
+import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.camera.FreeCameraOptions
@@ -19,6 +20,7 @@ import org.maplibre.nativeffi.internal.c.MLN_BOUND_OPTION_MAX_PITCH
 import org.maplibre.nativeffi.internal.c.MLN_BOUND_OPTION_MAX_ZOOM
 import org.maplibre.nativeffi.internal.c.MLN_BOUND_OPTION_MIN_PITCH
 import org.maplibre.nativeffi.internal.c.MLN_BOUND_OPTION_MIN_ZOOM
+import org.maplibre.nativeffi.internal.c.MLN_BOUND_OPTION_UNBOUNDED
 import org.maplibre.nativeffi.internal.c.MLN_CAMERA_FIT_OPTION_BEARING
 import org.maplibre.nativeffi.internal.c.MLN_CAMERA_FIT_OPTION_PADDING
 import org.maplibre.nativeffi.internal.c.MLN_CAMERA_FIT_OPTION_PITCH
@@ -170,12 +172,18 @@ internal object MapStructs {
   fun boundOptions(value: BoundOptions, scope: MemScope): CPointer<mln_bound_options> {
     val native = scope.alloc<mln_bound_options>()
     mln_bound_options_default().place(native.ptr)
-    value.bounds?.let {
-      native.fields = native.fields or MLN_BOUND_OPTION_BOUNDS
-      native.bounds.southwest.latitude = it.southwest.latitude
-      native.bounds.southwest.longitude = it.southwest.longitude
-      native.bounds.northeast.latitude = it.northeast.latitude
-      native.bounds.northeast.longitude = it.northeast.longitude
+    when (val constraint = value.bounds) {
+      is BoundsConstraint.Bounded -> {
+        native.fields = native.fields or MLN_BOUND_OPTION_BOUNDS
+        native.bounds.southwest.latitude = constraint.bounds.southwest.latitude
+        native.bounds.southwest.longitude = constraint.bounds.southwest.longitude
+        native.bounds.northeast.latitude = constraint.bounds.northeast.latitude
+        native.bounds.northeast.longitude = constraint.bounds.northeast.longitude
+      }
+      BoundsConstraint.Unbounded -> {
+        native.fields = native.fields or MLN_BOUND_OPTION_UNBOUNDED
+      }
+      null -> {}
     }
     value.minZoom?.let {
       native.fields = native.fields or MLN_BOUND_OPTION_MIN_ZOOM
@@ -199,7 +207,9 @@ internal object MapStructs {
   fun boundOptions(value: mln_bound_options): BoundOptions {
     val options = BoundOptions()
     if ((value.fields and MLN_BOUND_OPTION_BOUNDS) != 0U)
-      options.bounds = CoreStructs.latLngBounds(value.bounds)
+      options.bounds = BoundsConstraint.Bounded(CoreStructs.latLngBounds(value.bounds))
+    else if ((value.fields and MLN_BOUND_OPTION_UNBOUNDED) != 0U)
+      options.bounds = BoundsConstraint.Unbounded
     if ((value.fields and MLN_BOUND_OPTION_MIN_ZOOM) != 0U) options.minZoom = value.min_zoom
     if ((value.fields and MLN_BOUND_OPTION_MAX_ZOOM) != 0U) options.maxZoom = value.max_zoom
     if ((value.fields and MLN_BOUND_OPTION_MIN_PITCH) != 0U) options.minPitch = value.min_pitch

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/MapCameraControlsTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/MapCameraControlsTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.maplibre.nativeffi.camera.AnimationOptions
 import org.maplibre.nativeffi.camera.BoundOptions
+import org.maplibre.nativeffi.camera.BoundsConstraint
 import org.maplibre.nativeffi.camera.CameraFitOptions
 import org.maplibre.nativeffi.camera.CameraOptions
 import org.maplibre.nativeffi.camera.EdgeInsets
@@ -115,8 +116,10 @@ class MapCameraControlsTest : org.maplibre.nativeffi.NativeTestBase() {
         map.cameraForGeometry(Geometry.Point(LatLng(0.0, 0.0)), fitOptions)
         map.latLngBoundsForCamera(cameraOptions)
         map.latLngBoundsForCameraUnwrapped(cameraOptions)
-        map.bounds = BoundOptions().apply { this.bounds = bounds }
-        assertNotNull(map.bounds.bounds)
+        map.bounds = BoundOptions().apply { this.bounds = BoundsConstraint.Bounded(bounds) }
+        assertEquals(BoundsConstraint.Bounded(bounds), map.bounds.bounds)
+        map.bounds = BoundOptions().apply { this.bounds = BoundsConstraint.Unbounded }
+        assertEquals(BoundsConstraint.Unbounded, map.bounds.bounds)
         map.freeCameraOptions =
           FreeCameraOptions().apply {
             position = Vec3(0.0, 0.0, 0.0)

--- a/bindings/python/python/maplibre_native/_native.pyi
+++ b/bindings/python/python/maplibre_native/_native.pyi
@@ -178,6 +178,7 @@ class _MapHandle:
     def set_bounds(
         self,
         bounds: _Bounds | None,
+        unbounded: bool,
         min_zoom: float | None,
         max_zoom: float | None,
         min_pitch: float | None,

--- a/bindings/python/python/maplibre_native/camera.py
+++ b/bindings/python/python/maplibre_native/camera.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeAlias
 
 from .geo import LatLng, LatLngBounds
 
@@ -114,10 +115,29 @@ class CameraFitOptions:
 
 
 @dataclass(frozen=True, slots=True)
+class Bounded:
+    """Keeps the camera center inside the given bounds."""
+
+    bounds: LatLngBounds
+
+
+@dataclass(frozen=True, slots=True)
+class Unbounded:
+    """Leaves the camera center unconstrained.
+
+    The map pans freely across the antimeridian. This differs from world bounds
+    of -90/-180 to 90/180, which clamp longitude to that range.
+    """
+
+
+BoundsConstraint: TypeAlias = Bounded | Unbounded
+
+
+@dataclass(frozen=True, slots=True)
 class BoundOptions:
     """Optional map camera constraint fields."""
 
-    bounds: LatLngBounds | None = None
+    bounds: BoundsConstraint | None = None
     min_zoom: float | None = None
     max_zoom: float | None = None
     min_pitch: float | None = None
@@ -126,12 +146,17 @@ class BoundOptions:
     @classmethod
     def _from_native(cls, raw: dict[str, object]) -> "BoundOptions":
         """Build bound options from private native bridge values."""
-        bounds = raw["bounds"]
-        if isinstance(bounds, dict):
-            bounds = LatLngBounds(
-                southwest=LatLng(**bounds["southwest"]),
-                northeast=LatLng(**bounds["northeast"]),
+        raw_bounds = raw["bounds"]
+        bounds: BoundsConstraint | None
+        if isinstance(raw_bounds, dict):
+            bounds = Bounded(
+                LatLngBounds(
+                    southwest=LatLng(**raw_bounds["southwest"]),
+                    northeast=LatLng(**raw_bounds["northeast"]),
+                )
             )
+        elif raw["unbounded"]:
+            bounds = Unbounded()
         else:
             bounds = None
         return cls(
@@ -184,6 +209,8 @@ class ProjectionMode:
 __all__ = [
     "AnimationOptions",
     "BoundOptions",
+    "Bounded",
+    "BoundsConstraint",
     "CameraFitOptions",
     "CameraOptions",
     "EdgeInsets",
@@ -191,6 +218,7 @@ __all__ = [
     "ProjectionMode",
     "Quaternion",
     "ScreenPoint",
+    "Unbounded",
     "UnitBezier",
     "Vec3",
 ]

--- a/bindings/python/python/maplibre_native/map.py
+++ b/bindings/python/python/maplibre_native/map.py
@@ -13,12 +13,14 @@ from . import _native
 from .camera import (
     AnimationOptions,
     BoundOptions,
+    Bounded,
     CameraFitOptions,
     CameraOptions,
     EdgeInsets,
     FreeCameraOptions,
     ProjectionMode,
     ScreenPoint,
+    Unbounded,
 )
 from .geo import GeoJson, Geometry, LatLng, LatLngBounds
 from .json import JsonObject, JsonValue
@@ -240,21 +242,23 @@ def _bounds_parts(
     bounds: BoundOptions,
 ) -> tuple[
     tuple[tuple[float, float], tuple[float, float]] | None,
+    bool,
     float | None,
     float | None,
     float | None,
     float | None,
 ]:
-    raw_bounds = (
-        (
-            (bounds.bounds.southwest.latitude, bounds.bounds.southwest.longitude),
-            (bounds.bounds.northeast.latitude, bounds.bounds.northeast.longitude),
+    constraint = bounds.bounds
+    raw_bounds: tuple[tuple[float, float], tuple[float, float]] | None = None
+    if isinstance(constraint, Bounded):
+        box = constraint.bounds
+        raw_bounds = (
+            (box.southwest.latitude, box.southwest.longitude),
+            (box.northeast.latitude, box.northeast.longitude),
         )
-        if bounds.bounds is not None
-        else None
-    )
     return (
         raw_bounds,
+        isinstance(constraint, Unbounded),
         bounds.min_zoom,
         bounds.max_zoom,
         bounds.min_pitch,

--- a/bindings/python/python/maplibre_native/map.py
+++ b/bindings/python/python/maplibre_native/map.py
@@ -22,6 +22,7 @@ from .camera import (
     ScreenPoint,
     Unbounded,
 )
+from .errors import InvalidArgumentError
 from .geo import GeoJson, Geometry, LatLng, LatLngBounds
 from .json import JsonObject, JsonValue
 from .render import (
@@ -255,6 +256,14 @@ def _bounds_parts(
         raw_bounds = (
             (box.southwest.latitude, box.southwest.longitude),
             (box.northeast.latitude, box.northeast.longitude),
+        )
+    elif constraint is not None and not isinstance(constraint, Unbounded):
+        # Annotations do not bind at runtime, so an unsupported value would
+        # otherwise read as "leave the geographic constraint alone" and the
+        # caller would see a silent no-op instead of a rejection.
+        raise InvalidArgumentError(
+            "BoundOptions.bounds must be Bounded, Unbounded, or None, "
+            f"not {type(constraint).__name__}"
         )
     return (
         raw_bounds,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1731,13 +1731,15 @@ impl MapHandle {
     fn set_bounds(
         &self,
         bounds: Option<((f64, f64), (f64, f64))>,
+        unbounded: bool,
         min_zoom: Option<f64>,
         max_zoom: Option<f64>,
         min_pitch: Option<f64>,
         max_pitch: Option<f64>,
     ) -> PyResult<()> {
         let state = self.state();
-        let bounds = bound_options_from_parts(bounds, min_zoom, max_zoom, min_pitch, max_pitch);
+        let bounds =
+            bound_options_from_parts(bounds, unbounded, min_zoom, max_zoom, min_pitch, max_pitch);
         // SAFETY: The C API validates the map pointer and bounds fields.
         maplibre_core::check(unsafe { sys::mln_map_set_bounds(state.as_ptr(), &bounds) })
             .map_err(map_error)
@@ -4791,13 +4793,20 @@ fn camera_fit_options_from_parts(
 
 fn bound_options_from_parts(
     bounds: Option<((f64, f64), (f64, f64))>,
+    unbounded: bool,
     min_zoom: Option<f64>,
     max_zoom: Option<f64>,
     min_pitch: Option<f64>,
     max_pitch: Option<f64>,
 ) -> sys::mln_bound_options {
     let mut options = maplibre_core::BoundOptions::default();
-    options.bounds = bounds.map(lat_lng_bounds_core_from_tuple);
+    options.bounds = match bounds {
+        Some(bounds) => Some(maplibre_core::BoundsConstraint::Bounded(
+            lat_lng_bounds_core_from_tuple(bounds),
+        )),
+        None if unbounded => Some(maplibre_core::BoundsConstraint::Unbounded),
+        None => None,
+    };
     options.min_zoom = min_zoom;
     options.max_zoom = max_zoom;
     options.min_pitch = min_pitch;
@@ -4907,10 +4916,19 @@ fn free_camera_options_to_py(
 fn bound_options_to_py(py: Python<'_>, options: &sys::mln_bound_options) -> PyResult<Py<PyAny>> {
     let options = maplibre_core::camera::bound_options_from_native(*options);
     let dict = PyDict::new(py);
-    if let Some(bounds) = options.bounds {
-        dict.set_item("bounds", lat_lng_bounds_core_to_py(py, &bounds)?)?;
-    } else {
-        dict.set_item("bounds", py.None())?;
+    match options.bounds {
+        Some(maplibre_core::BoundsConstraint::Bounded(bounds)) => {
+            dict.set_item("bounds", lat_lng_bounds_core_to_py(py, &bounds)?)?;
+            dict.set_item("unbounded", false)?;
+        }
+        Some(maplibre_core::BoundsConstraint::Unbounded) => {
+            dict.set_item("bounds", py.None())?;
+            dict.set_item("unbounded", true)?;
+        }
+        None => {
+            dict.set_item("bounds", py.None())?;
+            dict.set_item("unbounded", false)?;
+        }
     }
     dict.set_item("min_zoom", options.min_zoom)?;
     dict.set_item("max_zoom", options.max_zoom)?;

--- a/bindings/python/tests/test_package.py
+++ b/bindings/python/tests/test_package.py
@@ -3185,3 +3185,20 @@ def test_custom_geometry_source_rejects_empty_queue_capacity() -> None:
                     "custom",
                     style.CustomGeometrySourceOptions(max_queued_events=0),
                 )
+
+
+def test_set_bounds_rejects_unsupported_constraint() -> None:
+    # Annotations do not bind at runtime, so a stale LatLngBounds would
+    # otherwise be treated as absent and silently leave the constraint alone.
+    world = geo.LatLngBounds(
+        southwest=geo.LatLng(-90.0, -180.0),
+        northeast=geo.LatLng(90.0, 180.0),
+    )
+
+    with mln.RuntimeHandle() as runtime:
+        with runtime.create_map() as map_handle:
+            with pytest.raises(mln.InvalidArgumentError):
+                map_handle.set_bounds(
+                    camera.BoundOptions(bounds=world)  # type: ignore[arg-type]
+                )
+            assert map_handle.get_bounds().bounds == camera.Unbounded()

--- a/bindings/python/tests/test_package.py
+++ b/bindings/python/tests/test_package.py
@@ -1356,7 +1356,11 @@ def test_camera_fit_bounds_and_constraints_public_api() -> None:
     with mln.RuntimeHandle() as runtime:
         with runtime.create_map() as map_handle:
             map_handle.set_bounds(
-                camera.BoundOptions(bounds=bounds, min_zoom=0.0, max_zoom=10.0)
+                camera.BoundOptions(
+                    bounds=camera.Bounded(bounds),
+                    min_zoom=0.0,
+                    max_zoom=10.0,
+                )
             )
             constraints = map_handle.get_bounds()
             fit_bounds = map_handle.camera_for_lat_lng_bounds(bounds, fit)
@@ -1374,7 +1378,7 @@ def test_camera_fit_bounds_and_constraints_public_api() -> None:
                 unwrapped=True,
             )
 
-            assert constraints.bounds == bounds
+            assert constraints.bounds == camera.Bounded(bounds)
             assert constraints.min_zoom == pytest.approx(0.0)
             assert constraints.max_zoom == pytest.approx(10.0)
             assert isinstance(fit_bounds, camera.CameraOptions)
@@ -1382,6 +1386,48 @@ def test_camera_fit_bounds_and_constraints_public_api() -> None:
             assert isinstance(fit_geometry, camera.CameraOptions)
             assert isinstance(visible_bounds, geo.LatLngBounds)
             assert isinstance(unwrapped_bounds, geo.LatLngBounds)
+
+
+def _jumped_longitude(map_handle: mln.MapHandle, longitude: float) -> float:
+    map_handle.jump_to(
+        camera.CameraOptions(center=geo.LatLng(0.0, longitude), zoom=2.0)
+    )
+    center = map_handle.get_camera().center
+    assert center is not None
+    return center.longitude
+
+
+def test_camera_bounds_distinguish_unbounded_from_world() -> None:
+    world = geo.LatLngBounds(
+        southwest=geo.LatLng(-90.0, -180.0),
+        northeast=geo.LatLng(90.0, 180.0),
+    )
+
+    with mln.RuntimeHandle() as runtime:
+        with runtime.create_map() as map_handle:
+            assert map_handle.get_bounds().bounds == camera.Unbounded()
+            # An unbounded map wraps across the antimeridian.
+            assert _jumped_longitude(map_handle, 200.0) == pytest.approx(
+                -160.0, abs=1e-6
+            )
+
+            map_handle.set_bounds(camera.BoundOptions(bounds=camera.Bounded(world)))
+
+            constrained = map_handle.get_bounds().bounds
+            assert isinstance(constrained, camera.Bounded)
+            assert constrained.bounds.northeast.longitude == pytest.approx(180.0)
+            # World bounds clamp at the antimeridian instead of wrapping.
+            assert _jumped_longitude(map_handle, 200.0) == pytest.approx(
+                180.0, abs=1e-6
+            )
+
+            map_handle.set_bounds(camera.BoundOptions(bounds=camera.Unbounded()))
+
+            assert map_handle.get_bounds().bounds == camera.Unbounded()
+            # Releasing the constraint restores antimeridian wrapping.
+            assert _jumped_longitude(map_handle, 200.0) == pytest.approx(
+                -160.0, abs=1e-6
+            )
 
 
 def test_camera_transition_commands_accept_public_values() -> None:

--- a/bindings/rust/crates/maplibre-native-core/src/camera.rs
+++ b/bindings/rust/crates/maplibre-native-core/src/camera.rs
@@ -154,11 +154,22 @@ impl CameraFitOptions {
     }
 }
 
+/// Geographic constraint applied to the map camera center.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BoundsConstraint {
+    /// Keeps the camera center inside the given bounds.
+    Bounded(LatLngBounds),
+    /// Leaves the camera center unconstrained, so the map pans freely across
+    /// the antimeridian. This differs from world bounds of -90/-180 to 90/180,
+    /// which clamp longitude to that range.
+    Unbounded,
+}
+
 /// Optional map camera constraint fields.
 #[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
 pub struct BoundOptions {
-    pub bounds: Option<LatLngBounds>,
+    pub bounds: Option<BoundsConstraint>,
     pub min_zoom: Option<f64>,
     pub max_zoom: Option<f64>,
     pub min_pitch: Option<f64>,
@@ -169,9 +180,15 @@ impl BoundOptions {
     fn to_native(&self) -> sys::mln_bound_options {
         // SAFETY: Default constructor takes no arguments and initializes size.
         let mut raw = unsafe { sys::mln_bound_options_default() };
-        if let Some(bounds) = self.bounds {
-            raw.fields |= sys::MLN_BOUND_OPTION_BOUNDS;
-            raw.bounds = lat_lng_bounds_to_native(bounds);
+        match self.bounds {
+            Some(BoundsConstraint::Bounded(bounds)) => {
+                raw.fields |= sys::MLN_BOUND_OPTION_BOUNDS;
+                raw.bounds = lat_lng_bounds_to_native(bounds);
+            }
+            Some(BoundsConstraint::Unbounded) => {
+                raw.fields |= sys::MLN_BOUND_OPTION_UNBOUNDED;
+            }
+            None => {}
         }
         if let Some(min_zoom) = self.min_zoom {
             raw.fields |= sys::MLN_BOUND_OPTION_MIN_ZOOM;
@@ -194,8 +211,15 @@ impl BoundOptions {
 
     fn from_native(raw: sys::mln_bound_options) -> Self {
         Self {
-            bounds: has(raw.fields, sys::MLN_BOUND_OPTION_BOUNDS)
-                .then(|| lat_lng_bounds_from_native(raw.bounds)),
+            bounds: if has(raw.fields, sys::MLN_BOUND_OPTION_BOUNDS) {
+                Some(BoundsConstraint::Bounded(lat_lng_bounds_from_native(
+                    raw.bounds,
+                )))
+            } else if has(raw.fields, sys::MLN_BOUND_OPTION_UNBOUNDED) {
+                Some(BoundsConstraint::Unbounded)
+            } else {
+                None
+            },
             min_zoom: has(raw.fields, sys::MLN_BOUND_OPTION_MIN_ZOOM).then_some(raw.min_zoom),
             max_zoom: has(raw.fields, sys::MLN_BOUND_OPTION_MAX_ZOOM).then_some(raw.max_zoom),
             min_pitch: has(raw.fields, sys::MLN_BOUND_OPTION_MIN_PITCH).then_some(raw.min_pitch),
@@ -487,10 +511,10 @@ mod tests {
     #[test]
     fn bound_free_camera_and_projection_modes_round_trip() {
         let bounds = BoundOptions {
-            bounds: Some(LatLngBounds::new(
+            bounds: Some(BoundsConstraint::Bounded(LatLngBounds::new(
                 LatLng::new(1.0, 2.0),
                 LatLng::new(3.0, 4.0),
-            )),
+            ))),
             min_zoom: Some(5.0),
             max_zoom: Some(6.0),
             min_pitch: Some(7.0),
@@ -502,6 +526,17 @@ mod tests {
             std::mem::size_of::<sys::mln_bound_options>() as u32
         );
         assert_eq!(bound_options_from_native(raw_bounds), bounds);
+        assert_ne!(raw_bounds.fields & sys::MLN_BOUND_OPTION_BOUNDS, 0);
+        assert_eq!(raw_bounds.fields & sys::MLN_BOUND_OPTION_UNBOUNDED, 0);
+
+        let unbounded = BoundOptions {
+            bounds: Some(BoundsConstraint::Unbounded),
+            ..BoundOptions::default()
+        };
+        let raw_unbounded = bound_options_to_native(&unbounded);
+        assert_ne!(raw_unbounded.fields & sys::MLN_BOUND_OPTION_UNBOUNDED, 0);
+        assert_eq!(raw_unbounded.fields & sys::MLN_BOUND_OPTION_BOUNDS, 0);
+        assert_eq!(bound_options_from_native(raw_unbounded), unbounded);
 
         let free = FreeCameraOptions {
             position: Some(Vec3::new(1.0, 2.0, 3.0)),

--- a/bindings/rust/crates/maplibre-native-core/src/lib.rs
+++ b/bindings/rust/crates/maplibre-native-core/src/lib.rs
@@ -33,8 +33,8 @@ pub mod values;
 
 pub use abi::{EXPECTED_C_ABI_VERSION, validate_abi_version, validate_abi_version_value};
 pub use camera::{
-    AnimationOptions, BoundOptions, CameraFitOptions, CameraOptions, FreeCameraOptions,
-    ProjectionMode,
+    AnimationOptions, BoundOptions, BoundsConstraint, CameraFitOptions, CameraOptions,
+    FreeCameraOptions, ProjectionMode,
 };
 pub use enums::{
     AmbientCacheOperation, ConstrainMode, LocationIndicatorImageKind, LogEvent, LogSeverity,

--- a/bindings/rust/crates/maplibre-native/src/camera.rs
+++ b/bindings/rust/crates/maplibre-native/src/camera.rs
@@ -1,6 +1,6 @@
 pub use maplibre_native_core::camera::{
-    AnimationOptions, BoundOptions, CameraFitOptions, CameraOptions, FreeCameraOptions,
-    ProjectionMode,
+    AnimationOptions, BoundOptions, BoundsConstraint, CameraFitOptions, CameraOptions,
+    FreeCameraOptions, ProjectionMode,
 };
 pub(crate) use maplibre_native_core::camera::{
     AnimationOptionsNativeExt, BoundOptionsNativeExt, CameraFitOptionsNativeExt,

--- a/bindings/rust/crates/maplibre-native/src/lib.rs
+++ b/bindings/rust/crates/maplibre-native/src/lib.rs
@@ -28,8 +28,8 @@ use maplibre_native_core as maplibre_core;
 use maplibre_native_sys as sys;
 
 pub use camera::{
-    AnimationOptions, BoundOptions, CameraFitOptions, CameraOptions, FreeCameraOptions,
-    ProjectionMode,
+    AnimationOptions, BoundOptions, BoundsConstraint, CameraFitOptions, CameraOptions,
+    FreeCameraOptions, ProjectionMode,
 };
 pub use custom_geometry::{CanonicalTileId, CustomGeometrySourceOptions};
 pub use events::{

--- a/bindings/rust/crates/maplibre-native/src/map/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/map/tests.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use crate::events::{RuntimeEventSource, RuntimeEventType, empty_runtime_event};
 use crate::{
-    CustomGeometrySourceOptions, EdgeInsets, ErrorKind, Feature, JsonMember, MapMode, ResourceKind,
-    ResourceProviderDecision, ResourceResponse, TextureImageInfo,
+    BoundsConstraint, CustomGeometrySourceOptions, EdgeInsets, ErrorKind, Feature, JsonMember,
+    MapMode, ResourceKind, ResourceProviderDecision, ResourceResponse, TextureImageInfo,
 };
 
 const VALID_STYLE_JSON: &str = r#"{"version":8,"sources":{},"layers":[]}"#;
@@ -658,6 +658,52 @@ fn empty_coordinate_slice_is_rejected_before_calling_c() {
     assert_eq!(error.kind(), ErrorKind::InvalidArgument);
     assert_eq!(error.raw_status(), None);
     assert!(error.diagnostic().contains("at least one coordinate"));
+
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
+// Spec coverage: BND-102, BND-103.
+fn unbounded_and_world_bounds_constrain_the_camera_differently() {
+    fn jumped_longitude(map: &MapHandle, longitude: f64) -> f64 {
+        let mut camera = CameraOptions::default();
+        camera.center = Some(LatLng::new(0.0, longitude));
+        camera.zoom = Some(2.0);
+        map.jump_to(&camera).unwrap();
+        map.camera().unwrap().center.unwrap().longitude
+    }
+
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::default()).unwrap();
+
+    // A pristine map reports the unbounded constraint, not world bounds.
+    assert_eq!(
+        map.bounds().unwrap().bounds,
+        Some(BoundsConstraint::Unbounded)
+    );
+    assert!((jumped_longitude(&map, 200.0) - -160.0).abs() < 1e-6);
+
+    let world = LatLngBounds::new(LatLng::new(-90.0, -180.0), LatLng::new(90.0, 180.0));
+    let mut options = BoundOptions::default();
+    options.bounds = Some(BoundsConstraint::Bounded(world));
+    map.set_bounds(&options).unwrap();
+    assert_eq!(
+        map.bounds().unwrap().bounds,
+        Some(BoundsConstraint::Bounded(world))
+    );
+    // World bounds clamp at the antimeridian instead of wrapping.
+    assert!((jumped_longitude(&map, 200.0) - 180.0).abs() < 1e-6);
+
+    let mut options = BoundOptions::default();
+    options.bounds = Some(BoundsConstraint::Unbounded);
+    map.set_bounds(&options).unwrap();
+    assert_eq!(
+        map.bounds().unwrap().bounds,
+        Some(BoundsConstraint::Unbounded)
+    );
+    // Releasing the constraint restores antimeridian wrapping.
+    assert!((jumped_longitude(&map, 200.0) - -160.0).abs() < 1e-6);
 
     map.close().unwrap();
     runtime.close().unwrap();

--- a/bindings/swift/Sources/MaplibreNative/CameraAdvanced.swift
+++ b/bindings/swift/Sources/MaplibreNative/CameraAdvanced.swift
@@ -25,15 +25,43 @@ public struct CameraFitOptions: Equatable, Sendable {
   }
 }
 
+/// Geographic constraint applied to the map camera center.
+public enum BoundsConstraint: Equatable, Sendable {
+  /// Keeps the camera center inside the given bounds.
+  case bounded(LatLngBounds)
+  /// Leaves the camera center unconstrained, so the map pans freely across
+  /// the antimeridian. This differs from world bounds of -90/-180 to 90/180,
+  /// which clamp longitude to that range.
+  case unbounded
+
+  init(native: NativeBoundsConstraintInput) {
+    switch native {
+    case let .bounded(bounds):
+      self = .bounded(LatLngBounds(native: bounds))
+    case .unbounded:
+      self = .unbounded
+    }
+  }
+
+  var nativeInput: NativeBoundsConstraintInput {
+    switch self {
+    case let .bounded(bounds):
+      .bounded(bounds.nativeInput)
+    case .unbounded:
+      .unbounded
+    }
+  }
+}
+
 public struct BoundOptions: Equatable, Sendable {
-  public var bounds: LatLngBounds?
+  public var bounds: BoundsConstraint?
   public var minZoom: Double?
   public var maxZoom: Double?
   public var minPitch: Double?
   public var maxPitch: Double?
 
   public init(
-    bounds: LatLngBounds? = nil,
+    bounds: BoundsConstraint? = nil,
     minZoom: Double? = nil,
     maxZoom: Double? = nil,
     minPitch: Double? = nil,
@@ -47,7 +75,7 @@ public struct BoundOptions: Equatable, Sendable {
   }
 
   init(native: NativeBoundOptionsInput) {
-    bounds = native.bounds.map(LatLngBounds.init(native:))
+    bounds = native.bounds.map(BoundsConstraint.init(native:))
     minZoom = native.minZoom
     maxZoom = native.maxZoom
     minPitch = native.minPitch

--- a/bindings/swift/Sources/MaplibreNative/Support/MapStructs.swift
+++ b/bindings/swift/Sources/MaplibreNative/Support/MapStructs.swift
@@ -301,15 +301,20 @@ struct NativeCameraFitOptionsInput: Equatable {
   }
 }
 
+enum NativeBoundsConstraintInput: Equatable {
+  case bounded(NativeLatLngBounds)
+  case unbounded
+}
+
 struct NativeBoundOptionsInput: Equatable {
-  var bounds: NativeLatLngBounds?
+  var bounds: NativeBoundsConstraintInput?
   var minZoom: Double?
   var maxZoom: Double?
   var minPitch: Double?
   var maxPitch: Double?
 
   init(
-    bounds: NativeLatLngBounds? = nil,
+    bounds: NativeBoundsConstraintInput? = nil,
     minZoom: Double? = nil,
     maxZoom: Double? = nil,
     minPitch: Double? = nil,
@@ -323,8 +328,13 @@ struct NativeBoundOptionsInput: Equatable {
   }
 
   init(_ raw: mln_bound_options) {
-    bounds = (raw.fields & MLN_BOUND_OPTION_BOUNDS.rawValue) != 0 ?
-      NativeLatLngBounds(raw.bounds) : nil
+    if (raw.fields & MLN_BOUND_OPTION_BOUNDS.rawValue) != 0 {
+      bounds = .bounded(NativeLatLngBounds(raw.bounds))
+    } else if (raw.fields & MLN_BOUND_OPTION_UNBOUNDED.rawValue) != 0 {
+      bounds = .unbounded
+    } else {
+      bounds = nil
+    }
     minZoom = (raw.fields & MLN_BOUND_OPTION_MIN_ZOOM.rawValue) != 0 ? raw
       .min_zoom : nil
     maxZoom = (raw.fields & MLN_BOUND_OPTION_MAX_ZOOM.rawValue) != 0 ? raw
@@ -341,9 +351,14 @@ struct NativeBoundOptionsInput: Equatable {
     -> Result) throws -> Result
   {
     var options = mln_bound_options_default()
-    if let bounds {
+    switch bounds {
+    case let .bounded(bounds):
       options.fields |= MLN_BOUND_OPTION_BOUNDS.rawValue
       options.bounds = bounds.native
+    case .unbounded:
+      options.fields |= MLN_BOUND_OPTION_UNBOUNDED.rawValue
+    case nil:
+      break
     }
     if let minZoom {
       options.fields |= MLN_BOUND_OPTION_MIN_ZOOM.rawValue

--- a/bindings/swift/Tests/MaplibreNativeTests/CameraAdvancedTests.swift
+++ b/bindings/swift/Tests/MaplibreNativeTests/CameraAdvancedTests.swift
@@ -21,20 +21,26 @@ import Testing
   }
 
   try BoundOptions(
-    bounds: LatLngBounds(
+    bounds: .bounded(LatLngBounds(
       southwest: LatLng(latitude: 1, longitude: 2),
       northeast: LatLng(latitude: 3, longitude: 4)
-    ),
+    )),
     minZoom: 1,
     maxZoom: 10,
     minPitch: 0,
     maxPitch: 60
   ).nativeInput.withNativeOptions { native in
     #expect((native.pointee.fields & MLN_BOUND_OPTION_BOUNDS.rawValue) != 0)
+    #expect((native.pointee.fields & MLN_BOUND_OPTION_UNBOUNDED.rawValue) == 0)
     #expect((native.pointee.fields & MLN_BOUND_OPTION_MAX_PITCH.rawValue) != 0)
     #expect(native.pointee.bounds.northeast.longitude == 4)
     #expect(native.pointee.max_pitch == 60)
   }
+
+  try BoundOptions(bounds: .unbounded).nativeInput
+    .withNativeOptions { native in
+      #expect(native.pointee.fields == MLN_BOUND_OPTION_UNBOUNDED.rawValue)
+    }
 
   try FreeCameraOptions(
     position: Vec3(x: 1, y: 2, z: 3),

--- a/bindings/swift/Tests/MaplibreNativeTests/MapHandleTests.swift
+++ b/bindings/swift/Tests/MaplibreNativeTests/MapHandleTests.swift
@@ -89,6 +89,50 @@ import Testing
   }
 }
 
+/// This verifies that the geographic constraint reports and applies the
+/// unbounded state distinctly from world bounds, which the southwest/northeast
+/// pair alone cannot express.
+@Test func cameraBoundsDistinguishUnboundedFromWorldBounds() throws {
+  let runtime =
+    try RuntimeHandle(options: RuntimeOptions(cachePath: ":memory:"))
+  defer { try? runtime.close() }
+  let map = try MapHandle(
+    runtime: runtime,
+    options: MapOptions(width: 256, height: 256)
+  )
+  defer { try? map.close() }
+
+  func longitudeAfterJump(to longitude: Double) throws -> Double {
+    try map.jump(to: CameraOptions(
+      center: LatLng(latitude: 0, longitude: longitude),
+      zoom: 2
+    ))
+    return try map.camera().center?.longitude ?? .nan
+  }
+
+  #expect(try map.bounds().bounds == .unbounded)
+  // An unbounded map wraps across the antimeridian.
+  #expect(try abs(longitudeAfterJump(to: 200) - -160) < 0.000001)
+
+  try map.setBounds(BoundOptions(bounds: .bounded(LatLngBounds(
+    southwest: LatLng(latitude: -90, longitude: -180),
+    northeast: LatLng(latitude: 90, longitude: 180)
+  ))))
+
+  if case let .bounded(reported) = try map.bounds().bounds {
+    #expect(abs(reported.northeast.longitude - 180) < 0.000001)
+  } else {
+    Issue.record("world bounds should report a bounded constraint")
+  }
+  // World bounds clamp at the antimeridian instead of wrapping.
+  #expect(try abs(longitudeAfterJump(to: 200) - 180) < 0.000001)
+
+  try map.setBounds(BoundOptions(bounds: .unbounded))
+  #expect(try map.bounds().bounds == .unbounded)
+  // Releasing the constraint restores antimeridian wrapping.
+  #expect(try abs(longitudeAfterJump(to: 200) - -160) < 0.000001)
+}
+
 @Test func closedMapReportsSwiftOwnedStateError() throws {
   let runtime =
     try RuntimeHandle(options: RuntimeOptions(cachePath: ":memory:"))

--- a/bindings/zig/src/maplibre_native.zig
+++ b/bindings/zig/src/maplibre_native.zig
@@ -133,6 +133,7 @@ pub const UnitBezier = values.UnitBezier;
 pub const CameraOptions = values.CameraOptions;
 pub const AnimationOptions = values.AnimationOptions;
 pub const CameraFitOptions = values.CameraFitOptions;
+pub const BoundsConstraint = values.BoundsConstraint;
 pub const BoundOptions = values.BoundOptions;
 pub const Vec3 = values.Vec3;
 pub const Quaternion = values.Quaternion;

--- a/bindings/zig/src/values.zig
+++ b/bindings/zig/src/values.zig
@@ -68,8 +68,16 @@ pub const CameraFitOptions = struct {
     pitch: ?f64 = null,
 };
 
+/// Geographic constraint applied to the map camera center. The unbounded case leaves the camera
+/// center free, so the map pans across the antimeridian. This differs from world bounds of
+/// -90/-180 to 90/180, which clamp longitude to that range.
+pub const BoundsConstraint = union(enum) {
+    bounded: LatLngBounds,
+    unbounded,
+};
+
 pub const BoundOptions = struct {
-    bounds: ?LatLngBounds = null,
+    bounds: ?BoundsConstraint = null,
     min_zoom: ?f64 = null,
     max_zoom: ?f64 = null,
     min_pitch: ?f64 = null,
@@ -772,10 +780,13 @@ pub fn cameraFitOptionsToNative(value: CameraFitOptions) c.mln_camera_fit_option
 
 pub fn boundOptionsToNative(value: BoundOptions) c.mln_bound_options {
     var raw = c.mln_bound_options_default();
-    if (value.bounds) |bounds| {
-        raw.fields |= c.MLN_BOUND_OPTION_BOUNDS;
-        raw.bounds = latLngBoundsToNative(bounds);
-    }
+    if (value.bounds) |constraint| switch (constraint) {
+        .bounded => |bounds| {
+            raw.fields |= c.MLN_BOUND_OPTION_BOUNDS;
+            raw.bounds = latLngBoundsToNative(bounds);
+        },
+        .unbounded => raw.fields |= c.MLN_BOUND_OPTION_UNBOUNDED,
+    };
     if (value.min_zoom) |min_zoom| {
         raw.fields |= c.MLN_BOUND_OPTION_MIN_ZOOM;
         raw.min_zoom = min_zoom;
@@ -797,7 +808,12 @@ pub fn boundOptionsToNative(value: BoundOptions) c.mln_bound_options {
 
 pub fn boundOptionsFromNative(raw: c.mln_bound_options) BoundOptions {
     return .{
-        .bounds = if ((raw.fields & c.MLN_BOUND_OPTION_BOUNDS) != 0) latLngBoundsFromNative(raw.bounds) else null,
+        .bounds = if ((raw.fields & c.MLN_BOUND_OPTION_BOUNDS) != 0)
+            .{ .bounded = latLngBoundsFromNative(raw.bounds) }
+        else if ((raw.fields & c.MLN_BOUND_OPTION_UNBOUNDED) != 0)
+            .unbounded
+        else
+            null,
         .min_zoom = if ((raw.fields & c.MLN_BOUND_OPTION_MIN_ZOOM) != 0) raw.min_zoom else null,
         .max_zoom = if ((raw.fields & c.MLN_BOUND_OPTION_MAX_ZOOM) != 0) raw.max_zoom else null,
         .min_pitch = if ((raw.fields & c.MLN_BOUND_OPTION_MIN_PITCH) != 0) raw.min_pitch else null,

--- a/bindings/zig/tests/camera.zig
+++ b/bindings/zig/tests/camera.zig
@@ -89,10 +89,10 @@ test "camera constraints and free camera options round-trip public values" {
     defer map.close() catch @panic("map close failed");
 
     const constraints = maplibre.BoundOptions{
-        .bounds = .{
+        .bounds = .{ .bounded = .{
             .southwest = .{ .latitude = -45.0, .longitude = -120.0 },
             .northeast = .{ .latitude = 45.0, .longitude = 120.0 },
-        },
+        } },
         .min_zoom = 1.0,
         .max_zoom = 12.0,
         .min_pitch = 0.0,
@@ -108,6 +108,42 @@ test "camera constraints and free camera options round-trip public values" {
     try testing.expect(free_camera.position != null);
     try testing.expect(free_camera.orientation != null);
     try map.setFreeCameraOptions(.{ .orientation = free_camera.orientation });
+}
+
+fn jumpedLongitude(map: *maplibre.MapHandle, longitude: f64) !f64 {
+    try map.jumpTo(.{ .center = .{ .latitude = 0, .longitude = longitude }, .zoom = 2.0 });
+    const snapshot = try map.getCamera();
+    return (snapshot.center orelse return error.MissingCameraCenter).longitude;
+}
+
+// The unbounded constraint is distinct from world bounds: an unbounded camera center pans across
+// the antimeridian, while world bounds clamp longitude to the -180..180 range.
+test "camera bounds separate the unbounded constraint from world bounds" {
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    defer map.close() catch @panic("map close failed");
+
+    const pristine = try map.getBounds();
+    try testing.expectEqual(.unbounded, std.meta.activeTag(pristine.bounds.?));
+    try testing.expectApproxEqAbs(@as(f64, -160.0), try jumpedLongitude(&map, 200.0), 1e-6);
+
+    try map.setBounds(.{ .bounds = .{ .bounded = .{
+        .southwest = .{ .latitude = -90.0, .longitude = -180.0 },
+        .northeast = .{ .latitude = 90.0, .longitude = 180.0 },
+    } } });
+
+    const world = try map.getBounds();
+    switch (world.bounds.?) {
+        .bounded => |bounds| try testing.expectApproxEqAbs(@as(f64, 180.0), bounds.northeast.longitude, 1e-6),
+        .unbounded => return error.TestExpectedBoundedConstraint,
+    }
+    try testing.expectApproxEqAbs(@as(f64, 180.0), try jumpedLongitude(&map, 200.0), 1e-6);
+
+    try map.setBounds(.{ .bounds = .unbounded });
+    const released = try map.getBounds();
+    try testing.expectEqual(.unbounded, std.meta.activeTag(released.bounds.?));
+    try testing.expectApproxEqAbs(@as(f64, -160.0), try jumpedLongitude(&map, 200.0), 1e-6);
 }
 
 test "camera public descriptors report invalid native arguments" {

--- a/include/maplibre_native_c/camera.h
+++ b/include/maplibre_native_c/camera.h
@@ -540,6 +540,9 @@ MLN_API mln_status mln_map_lat_lng_bounds_for_camera_unwrapped(
  * Copies map camera constraint options.
  *
  * On success, *out_options is overwritten and all known fields are marked.
+ * The geographic constraint is reported as exactly one of
+ * MLN_BOUND_OPTION_BOUNDS, which also fills out_options->bounds, or
+ * MLN_BOUND_OPTION_UNBOUNDED, which leaves out_options->bounds at its default.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -555,14 +558,17 @@ mln_map_get_bounds(mln_map* map, mln_bound_options* out_options) MLN_NOEXCEPT;
 /**
  * Applies selected map camera constraint options.
  *
- * Only fields indicated by options->fields affect the map.
+ * Only fields indicated by options->fields affect the map. Set
+ * MLN_BOUND_OPTION_BOUNDS to constrain the camera center to options->bounds,
+ * or MLN_BOUND_OPTION_UNBOUNDED to release the geographic constraint entirely.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, options is null,
- *   options->size is too small, options->fields contains unknown bits, bounds
- *   are invalid, a numeric field is non-finite, or paired min/max fields are
- *   inconsistent.
+ *   options->size is too small, options->fields contains unknown bits,
+ *   options->fields contains both MLN_BOUND_OPTION_BOUNDS and
+ *   MLN_BOUND_OPTION_UNBOUNDED, bounds are invalid, a numeric field is
+ *   non-finite, or paired min/max fields are inconsistent.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.

--- a/include/maplibre_native_c/map.h
+++ b/include/maplibre_native_c/map.h
@@ -51,11 +51,24 @@ typedef enum mln_camera_fit_option_field : uint32_t {
 
 /** Field mask values for mln_bound_options. */
 typedef enum mln_bound_option_field : uint32_t {
+  /**
+   * Selects mln_bound_options.bounds as a geographic constraint that the
+   * camera center stays inside. Mutually exclusive with
+   * MLN_BOUND_OPTION_UNBOUNDED.
+   */
   MLN_BOUND_OPTION_BOUNDS = 1U << 0U,
   MLN_BOUND_OPTION_MIN_ZOOM = 1U << 1U,
   MLN_BOUND_OPTION_MAX_ZOOM = 1U << 2U,
   MLN_BOUND_OPTION_MIN_PITCH = 1U << 3U,
   MLN_BOUND_OPTION_MAX_PITCH = 1U << 4U,
+  /**
+   * Selects the unbounded geographic constraint, which leaves every camera
+   * center unconstrained and lets the map pan freely across the antimeridian.
+   * This differs from world bounds of -90/-180 to 90/180, which clamp
+   * longitude to that range. Mutually exclusive with MLN_BOUND_OPTION_BOUNDS,
+   * and leaves mln_bound_options.bounds unread.
+   */
+  MLN_BOUND_OPTION_UNBOUNDED = 1U << 5U,
 } mln_bound_option_field;
 
 /** Field mask values for mln_free_camera_options. */
@@ -516,6 +529,7 @@ typedef struct mln_lat_lng_bounds {
 typedef struct mln_bound_options {
   uint32_t size;
   uint32_t fields;
+  /** Read when fields contains MLN_BOUND_OPTION_BOUNDS. */
   mln_lat_lng_bounds bounds;
   double min_zoom;
   double max_zoom;

--- a/src/c_api/tests/map_options_abi.c
+++ b/src/c_api/tests/map_options_abi.c
@@ -137,6 +137,83 @@ static void camera_bounds_constraints_reject_invalid_arguments(void) {
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_INVALID_ARGUMENT, mln_map_set_bounds(fixture.map, &options)
   );
+  options = mln_bound_options_default();
+  options.fields = MLN_BOUND_OPTION_BOUNDS | MLN_BOUND_OPTION_UNBOUNDED;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT, mln_map_set_bounds(fixture.map, &options)
+  );
+  destroy_map_fixture(fixture);
+}
+
+static bool near_longitude(double actual, double expected) {
+  const double delta = actual - expected;
+  return delta > -1e-6 && delta < 1e-6;
+}
+
+static double jumped_longitude(mln_map* map, double longitude) {
+  mln_camera_options camera = mln_camera_options_default();
+  camera.fields = MLN_CAMERA_OPTION_CENTER | MLN_CAMERA_OPTION_ZOOM;
+  camera.latitude = 0.0;
+  camera.longitude = longitude;
+  camera.zoom = 2.0;
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_jump_to(map, &camera));
+  mln_camera_options snapshot = mln_camera_options_default();
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_get_camera(map, &snapshot));
+  return snapshot.longitude;
+}
+
+// This verifies that the geographic constraint reports and applies the
+// unbounded state distinctly from world bounds, which the southwest/northeast
+// pair alone cannot express.
+static void camera_bounds_distinguish_unbounded_from_world(void) {
+  map_fixture fixture = create_map_fixture();
+
+  mln_bound_options snapshot = mln_bound_options_default();
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_get_bounds(fixture.map, &snapshot)
+  );
+  TEST_ASSERT_TRUE(snapshot.fields & MLN_BOUND_OPTION_UNBOUNDED);
+  TEST_ASSERT_FALSE(snapshot.fields & MLN_BOUND_OPTION_BOUNDS);
+  // An unbounded map wraps across the antimeridian.
+  TEST_ASSERT_TRUE(
+    near_longitude(jumped_longitude(fixture.map, 200.0), -160.0)
+  );
+
+  mln_bound_options world = mln_bound_options_default();
+  world.fields = MLN_BOUND_OPTION_BOUNDS;
+  world.bounds.southwest.latitude = -90.0;
+  world.bounds.southwest.longitude = -180.0;
+  world.bounds.northeast.latitude = 90.0;
+  world.bounds.northeast.longitude = 180.0;
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_set_bounds(fixture.map, &world));
+
+  snapshot = mln_bound_options_default();
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_get_bounds(fixture.map, &snapshot)
+  );
+  TEST_ASSERT_TRUE(snapshot.fields & MLN_BOUND_OPTION_BOUNDS);
+  TEST_ASSERT_FALSE(snapshot.fields & MLN_BOUND_OPTION_UNBOUNDED);
+  TEST_ASSERT_TRUE(near_longitude(snapshot.bounds.northeast.longitude, 180.0));
+  // World bounds clamp at the antimeridian instead of wrapping.
+  TEST_ASSERT_TRUE(near_longitude(jumped_longitude(fixture.map, 200.0), 180.0));
+
+  mln_bound_options unbounded = mln_bound_options_default();
+  unbounded.fields = MLN_BOUND_OPTION_UNBOUNDED;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_set_bounds(fixture.map, &unbounded)
+  );
+
+  snapshot = mln_bound_options_default();
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_get_bounds(fixture.map, &snapshot)
+  );
+  TEST_ASSERT_TRUE(snapshot.fields & MLN_BOUND_OPTION_UNBOUNDED);
+  TEST_ASSERT_FALSE(snapshot.fields & MLN_BOUND_OPTION_BOUNDS);
+  // Releasing the constraint restores antimeridian wrapping.
+  TEST_ASSERT_TRUE(
+    near_longitude(jumped_longitude(fixture.map, 200.0), -160.0)
+  );
+
   destroy_map_fixture(fixture);
 }
 
@@ -486,6 +563,7 @@ void run_map_options_abi_tests(void) {
   RUN_TEST(camera_rejects_invalid_arguments);
   RUN_TEST(camera_fitting_rejects_invalid_arguments);
   RUN_TEST(camera_bounds_constraints_reject_invalid_arguments);
+  RUN_TEST(camera_bounds_distinguish_unbounded_from_world);
   RUN_TEST(free_camera_options_reject_raw_invalid_arguments);
   RUN_TEST(map_projection_mode_rejects_invalid_arguments);
   RUN_TEST(map_coordinate_conversion_rejects_invalid_arguments);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1720,10 +1720,20 @@ auto validate_bound_options(const mln_bound_options* options) -> mln_status {
   constexpr auto known_fields =
     static_cast<uint32_t>(MLN_BOUND_OPTION_BOUNDS) | MLN_BOUND_OPTION_MIN_ZOOM |
     MLN_BOUND_OPTION_MAX_ZOOM | MLN_BOUND_OPTION_MIN_PITCH |
-    MLN_BOUND_OPTION_MAX_PITCH;
+    MLN_BOUND_OPTION_MAX_PITCH | MLN_BOUND_OPTION_UNBOUNDED;
   if ((options->fields & ~known_fields) != 0U) {
     mln::core::set_thread_error(
       "mln_bound_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    (options->fields & MLN_BOUND_OPTION_BOUNDS) != 0U &&
+    (options->fields & MLN_BOUND_OPTION_UNBOUNDED) != 0U
+  ) {
+    mln::core::set_thread_error(
+      "MLN_BOUND_OPTION_BOUNDS and MLN_BOUND_OPTION_UNBOUNDED are mutually "
+      "exclusive"
     );
     return MLN_STATUS_INVALID_ARGUMENT;
   }
@@ -2460,6 +2470,14 @@ auto from_native_lat_lng_bounds(const mbgl::LatLngBounds& bounds)
   };
 }
 
+// mbgl keeps the unbounded flag private, so compare against a
+// default-constructed value. mbgl::LatLngBounds::operator== treats any two
+// unbounded values as equal and an unbounded value as distinct from every
+// bounded one, which makes this an exact test for the flag.
+auto is_unbounded_lat_lng_bounds(const mbgl::LatLngBounds& bounds) -> bool {
+  return bounds == mbgl::LatLngBounds{};
+}
+
 auto to_native_lat_lngs(const mln_lat_lng* coordinates, size_t coordinate_count)
   -> std::vector<mbgl::LatLng> {
   auto result = std::vector<mbgl::LatLng>{};
@@ -2505,6 +2523,11 @@ auto to_native_bound_options(const mln_bound_options& options)
   if ((options.fields & MLN_BOUND_OPTION_BOUNDS) != 0U) {
     result.withLatLngBounds(to_native_lat_lng_bounds(options.bounds));
   }
+  if ((options.fields & MLN_BOUND_OPTION_UNBOUNDED) != 0U) {
+    // A default-constructed LatLngBounds is the mbgl unbounded constraint:
+    // constrain() returns its input unchanged.
+    result.withLatLngBounds(mbgl::LatLngBounds{});
+  }
   if ((options.fields & MLN_BOUND_OPTION_MIN_ZOOM) != 0U) {
     result.withMinZoom(options.min_zoom);
   }
@@ -2524,8 +2547,12 @@ auto from_native_bound_options(const mbgl::BoundOptions& options)
   -> mln_bound_options {
   auto result = mln::core::bound_options_default();
   if (options.bounds) {
-    result.fields |= MLN_BOUND_OPTION_BOUNDS;
-    result.bounds = from_native_lat_lng_bounds(*options.bounds);
+    if (is_unbounded_lat_lng_bounds(*options.bounds)) {
+      result.fields |= MLN_BOUND_OPTION_UNBOUNDED;
+    } else {
+      result.fields |= MLN_BOUND_OPTION_BOUNDS;
+      result.bounds = from_native_lat_lng_bounds(*options.bounds);
+    }
   }
   if (options.minZoom) {
     result.fields |= MLN_BOUND_OPTION_MIN_ZOOM;


### PR DESCRIPTION
## Summary

`mln_map_get_bounds` now distinguishes mbgl's unbounded camera constraint from world bounds through a new `MLN_BOUND_OPTION_UNBOUNDED` field-mask bit that `mln_map_set_bounds` also accepts.

## Test plan

`mise run test` plus the go, zig, rust, python, swift, dotnet, and kotlin jvm suites, each with a new test asserting that an unbounded map wraps a jump to longitude 200 to -160 while world bounds clamp it to 180.

## Notes

**Depends on #346** (`agent/document-c-api-contracts`), which edits the same header regions; this PR is based on that branch.

**Design.** `MLN_BOUND_OPTION_UNBOUNDED = 1U << 5` is mutually exclusive with `MLN_BOUND_OPTION_BOUNDS`; `validate_bound_options` rejects both bits with `MLN_STATUS_INVALID_ARGUMENT` and a thread error, and `mln_map_get_bounds` reports exactly one of the two. `mln_lat_lng_bounds` is unchanged, since it is shared with tileset bounds, custom-source invalidation, and camera fits where "unbounded" has no meaning. A mask bit costs no struct layout change and reuses the existing field-mask validation.

**The `bounded` accessor problem.** `mbgl::LatLngBounds::bounded` is private with no accessor, but neither a behavioral probe nor an upstream patch turned out to be necessary. `operator==` is a hidden friend, so it is reachable via ADL regardless of the `private:` section it is declared in, and its body is `(!a.bounded && !b.bounded) || (a.bounded && b.bounded && ...)`. That makes `bounds == mbgl::LatLngBounds{}` exactly equivalent to `!bounds.bounded` — an exact, public, allocation-free test. This matters because `third_party/maplibre-native` is a clean shallow submodule tracking upstream `main`, which would be disruptive to fork.

**Tests assert behavior, not just the bit.** Each suite drives a real map: a pristine map reports unbounded and a jump to longitude 200 wraps to -160; after world bounds the same jump clamps to 180; after setting unbounded it wraps to -160 again. The C test additionally covers the raw both-bits-set rejection, which the bindings make unrepresentable.

**Bindings.** All seven model the geographic constraint as a two-case value (`Bounded(bounds)` / `Unbounded`) so the mutually exclusive pair cannot be constructed: sum types in rust, zig, swift, kotlin, python and dotnet, and a tagged struct plus `WithUnbounded()` in go. The dotnet interop was regenerated with `//bindings/dotnet:generate` (the diff also shows unrelated `__AnonymousRecord_map_L###` line-number churn from `map.h` growing), and kotlin's hand-maintained jextract allowlist gained the new constant.

**Compatibility.** `mln_map_get_bounds` starts returning a bit that older binding builds treat as unknown, so the binding and native halves ship together. That is acceptable while prerelease.

**Not verified locally.** Kotlin androidMain and nativeMain need an Android SDK/NDK and a macOS host respectively, so those converter edits are unverified by execution and left to CI. Every other suite ran green here: c-api 38, rust 100 + 85, python 110, dotnet 177, kotlin jvm 97, swift 77, and go and zig full suites.

## AI assistance

- **Tools:** Claude Code
- **Context:** Claude wrote the C API change, the seven binding changes, and the tests, and ran the suites listed above.
