### PR TITLE
Accept GeoJSON source options on the typed adders

### DIFF
--- a/bindings/dotnet/src/Maplibre.Native/Generated/style.g.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Generated/style.g.cs
@@ -55,6 +55,22 @@ namespace Maplibre.Native.Internal.C
     }
 
     [NativeTypeName("uint32_t")]
+    internal enum mln_geojson_source_option_field : uint
+    {
+        MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM = 1U << 0,
+        MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM = 1U << 1,
+        MLN_GEOJSON_SOURCE_OPTION_TOLERANCE = 1U << 2,
+        MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM = 1U << 3,
+        MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES = 1U << 4,
+        MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE = 1U << 5,
+        MLN_GEOJSON_SOURCE_OPTION_BUFFER = 1U << 6,
+        MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS = 1U << 7,
+        MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS = 1U << 8,
+        MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS = 1U << 9,
+        MLN_GEOJSON_SOURCE_OPTION_CLUSTER = 1U << 10,
+    }
+
+    [NativeTypeName("uint32_t")]
     internal enum mln_custom_geometry_source_option_field : uint
     {
         MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MIN_ZOOM = 1U << 0,
@@ -129,6 +145,44 @@ namespace Maplibre.Native.Internal.C
 
         [NativeTypeName("uint32_t")]
         public uint raster_encoding;
+    }
+
+    internal unsafe partial struct mln_geojson_source_options
+    {
+        [NativeTypeName("uint32_t")]
+        public uint size;
+
+        [NativeTypeName("uint32_t")]
+        public uint fields;
+
+        public double min_zoom;
+
+        public double max_zoom;
+
+        public double tolerance;
+
+        public double cluster_max_zoom;
+
+        [NativeTypeName("const mln_json_value *")]
+        public mln_json_value* cluster_properties;
+
+        [NativeTypeName("uint32_t")]
+        public uint tile_size;
+
+        [NativeTypeName("uint32_t")]
+        public uint buffer;
+
+        [NativeTypeName("uint32_t")]
+        public uint cluster_radius;
+
+        [NativeTypeName("uint32_t")]
+        public uint cluster_min_points;
+
+        [NativeTypeName("bool")]
+        public byte line_metrics;
+
+        [NativeTypeName("bool")]
+        public byte cluster;
     }
 
     internal partial struct mln_canonical_tile_id
@@ -242,6 +296,9 @@ namespace Maplibre.Native.Internal.C
         public static extern mln_style_tile_source_options mln_style_tile_source_options_default();
 
         [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern mln_geojson_source_options mln_geojson_source_options_default();
+
+        [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern mln_custom_geometry_source_options mln_custom_geometry_source_options_default();
 
         [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -284,10 +341,10 @@ namespace Maplibre.Native.Internal.C
         public static extern mln_status mln_map_list_style_source_ids(mln_map* map, mln_style_id_list** out_source_ids);
 
         [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern mln_status mln_map_add_geojson_source_url(mln_map* map, mln_string_view source_id, mln_string_view url);
+        public static extern mln_status mln_map_add_geojson_source_url(mln_map* map, mln_string_view source_id, mln_string_view url, [NativeTypeName("const mln_geojson_source_options *")] mln_geojson_source_options* options);
 
         [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern mln_status mln_map_add_geojson_source_data(mln_map* map, mln_string_view source_id, [NativeTypeName("const mln_geojson *")] mln_geojson* data);
+        public static extern mln_status mln_map_add_geojson_source_data(mln_map* map, mln_string_view source_id, [NativeTypeName("const mln_geojson *")] mln_geojson* data, [NativeTypeName("const mln_geojson_source_options *")] mln_geojson_source_options* options);
 
         [DllImport("maplibre-native-c", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern mln_status mln_map_set_geojson_source_url(mln_map* map, mln_string_view source_id, mln_string_view url);

--- a/bindings/dotnet/src/Maplibre.Native/Internal/Struct/StyleStructs.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Internal/Struct/StyleStructs.cs
@@ -94,6 +94,111 @@ internal sealed unsafe class NativeTileSourceOptions : IDisposable
     }
 }
 
+internal sealed unsafe class NativeGeoJsonSourceOptions : IDisposable
+{
+    private readonly NativeJsonValue? clusterProperties;
+
+    private NativeGeoJsonSourceOptions(
+        mln_geojson_source_options value,
+        NativeJsonValue? clusterProperties
+    )
+    {
+        Value = value;
+        this.clusterProperties = clusterProperties;
+    }
+
+    internal mln_geojson_source_options Value { get; }
+
+    internal static NativeGeoJsonSourceOptions From(GeoJsonSourceOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        NativeJsonValue? clusterProperties = null;
+        try
+        {
+            var native = NativeMethods.mln_geojson_source_options_default();
+            if (options.MinimumZoom is { } minimumZoom)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM;
+                native.min_zoom = minimumZoom;
+            }
+            if (options.MaximumZoom is { } maximumZoom)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM;
+                native.max_zoom = maximumZoom;
+            }
+            if (options.Tolerance is { } tolerance)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_TOLERANCE;
+                native.tolerance = tolerance;
+            }
+            if (options.ClusterMaximumZoom is { } clusterMaximumZoom)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM;
+                native.cluster_max_zoom = clusterMaximumZoom;
+            }
+            if (options.ClusterProperties is { } clusterPropertiesValue)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES;
+                clusterProperties = NativeJsonValue.From(clusterPropertiesValue);
+                native.cluster_properties = clusterProperties.Pointer;
+            }
+            if (options.TileSize is { } tileSize)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE;
+                native.tile_size = tileSize;
+            }
+            if (options.Buffer is { } buffer)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_BUFFER;
+                native.buffer = buffer;
+            }
+            if (options.ClusterRadius is { } clusterRadius)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS;
+                native.cluster_radius = clusterRadius;
+            }
+            if (options.ClusterMinimumPoints is { } clusterMinimumPoints)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS;
+                native.cluster_min_points = clusterMinimumPoints;
+            }
+            if (options.LineMetrics is { } lineMetrics)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS;
+                native.line_metrics = lineMetrics ? (byte)1 : (byte)0;
+            }
+            if (options.Cluster is { } cluster)
+            {
+                native.fields |= (uint)
+                    mln_geojson_source_option_field.MLN_GEOJSON_SOURCE_OPTION_CLUSTER;
+                native.cluster = cluster ? (byte)1 : (byte)0;
+            }
+
+            return new NativeGeoJsonSourceOptions(native, clusterProperties);
+        }
+        catch
+        {
+            clusterProperties?.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        clusterProperties?.Dispose();
+    }
+}
+
 internal sealed unsafe class NativeStyleImage : IDisposable
 {
     private readonly nint pixels;

--- a/bindings/dotnet/src/Maplibre.Native/Map/MapHandle.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Map/MapHandle.cs
@@ -751,15 +751,23 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Adds a GeoJSON source that loads data from a URL.</summary>
-    public void AddGeoJsonSourceUrl(string sourceId, string url)
+    /// <remarks>
+    /// <paramref name="options" /> is fixed when the source is created;
+    /// <see cref="SetGeoJsonSourceUrl" /> and <see cref="SetGeoJsonSourceData" /> keep the options
+    /// the source was added with.
+    /// </remarks>
+    public void AddGeoJsonSourceUrl(string sourceId, string url, GeoJsonSourceOptions? options)
     {
         using var nativeSourceId = NativeStringView.From(sourceId, nameof(sourceId));
         using var nativeUrl = NativeStringView.From(url, nameof(url));
+        using var nativeOptions = options is null ? null : NativeGeoJsonSourceOptions.From(options);
+        var optionsValue = nativeOptions?.Value ?? default;
         NativeStatus.Check(
             NativeMethods.mln_map_add_geojson_source_url(
                 Pointer,
                 nativeSourceId.Value,
-                nativeUrl.Value
+                nativeUrl.Value,
+                nativeOptions is null ? null : &optionsValue
             )
         );
     }
@@ -779,15 +787,23 @@ public sealed unsafe class MapHandle : IDisposable
     }
 
     /// <summary>Adds a GeoJSON source with inline data.</summary>
-    public void AddGeoJsonSourceData(string sourceId, GeoJson data)
+    /// <remarks>
+    /// <paramref name="options" /> is fixed when the source is created;
+    /// <see cref="SetGeoJsonSourceUrl" /> and <see cref="SetGeoJsonSourceData" /> keep the options
+    /// the source was added with.
+    /// </remarks>
+    public void AddGeoJsonSourceData(string sourceId, GeoJson data, GeoJsonSourceOptions? options)
     {
         using var nativeSourceId = NativeStringView.From(sourceId, nameof(sourceId));
         using var nativeData = NativeGeoJson.From(data);
+        using var nativeOptions = options is null ? null : NativeGeoJsonSourceOptions.From(options);
+        var optionsValue = nativeOptions?.Value ?? default;
         NativeStatus.Check(
             NativeMethods.mln_map_add_geojson_source_data(
                 Pointer,
                 nativeSourceId.Value,
-                nativeData.Pointer
+                nativeData.Pointer,
+                nativeOptions is null ? null : &optionsValue
             )
         );
     }

--- a/bindings/dotnet/src/Maplibre.Native/Style/StyleTypes.cs
+++ b/bindings/dotnet/src/Maplibre.Native/Style/StyleTypes.cs
@@ -1,4 +1,5 @@
 using Maplibre.Native.Geo;
+using Maplibre.Native.Json;
 using Maplibre.Native.Render;
 
 namespace Maplibre.Native.Style;
@@ -63,6 +64,33 @@ public sealed record TileSourceOptions
     public VectorTileEncoding? VectorEncoding { get; set; }
     public RasterDemEncoding? RasterEncoding { get; set; }
     public LatLngBounds? Bounds { get; set; }
+}
+
+/// <remarks>
+/// MapLibre Native fixes these options when the source is created, so
+/// <see cref="Map.MapHandle.SetGeoJsonSourceUrl" /> and
+/// <see cref="Map.MapHandle.SetGeoJsonSourceData" /> keep the options the source was added with.
+/// Compares and hashes by property value; <c>with</c> returns an independent instance. Keep an
+/// instance unmodified while it is a key in a hash-based collection.
+/// </remarks>
+public sealed record GeoJsonSourceOptions
+{
+    public double? MinimumZoom { get; set; }
+    public double? MaximumZoom { get; set; }
+    public uint? TileSize { get; set; }
+    public uint? Buffer { get; set; }
+    public double? Tolerance { get; set; }
+    public bool? LineMetrics { get; set; }
+    public bool? Cluster { get; set; }
+    public uint? ClusterRadius { get; set; }
+    public double? ClusterMaximumZoom { get; set; }
+    public uint? ClusterMinimumPoints { get; set; }
+
+    /// <summary>
+    /// Cluster aggregation expressions keyed by property name, as a JSON object whose members
+    /// follow the MapLibre Style Spec <c>clusterProperties</c> form.
+    /// </summary>
+    public JsonValue? ClusterProperties { get; set; }
 }
 
 public sealed class CustomGeometrySourceOptions

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/GeoJsonSourceTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/GeoJsonSourceTests.cs
@@ -1,3 +1,4 @@
+using Maplibre.Native.Error;
 using Maplibre.Native.Geo;
 using Maplibre.Native.Internal.C;
 using Maplibre.Native.Internal.Struct;
@@ -45,7 +46,7 @@ public sealed unsafe class GeoJsonSourceTests
         using var map = MapHandle.Create(runtime, new MapOptions { Width = 512, Height = 512 });
         map.SetStyleJson("{\"version\":8,\"sources\":{},\"layers\":[]}");
 
-        map.AddGeoJsonSourceData("geo-data", EmptyFeatureCollection());
+        map.AddGeoJsonSourceData("geo-data", EmptyFeatureCollection(), null);
         map.SetGeoJsonSourceData(
             "geo-data",
             new GeoJson.GeometryValue(new Geometry.Point(new LatLng(1, 2)))
@@ -54,6 +55,69 @@ public sealed unsafe class GeoJsonSourceTests
         Assert.True(map.StyleSourceExists("geo-data"));
         Assert.Equal(SourceType.GeoJson, map.StyleSourceType("geo-data"));
     }
+
+    [BindingSpecTest("BND-060", "BND-105")]
+    [Fact]
+    public void ClusteredGeoJsonSourceOptionsParseThroughNativeMap()
+    {
+        using var runtime = RuntimeHandle.Create(new RuntimeOptions());
+        using var map = MapHandle.Create(runtime, new MapOptions { Width = 512, Height = 512 });
+        map.SetStyleJson("{\"version\":8,\"sources\":{},\"layers\":[]}");
+
+        map.AddGeoJsonSourceData("clustered", NearbyPoints(), ClusterOptions());
+
+        Assert.True(map.StyleSourceExists("clustered"));
+        Assert.Equal(SourceType.GeoJson, map.StyleSourceType("clustered"));
+
+        // The cluster aggregation graph is borrowed for the call and parsed by
+        // MapLibre Native, so an unparseable expression fails the add.
+        var options = ClusterOptions();
+        options.ClusterProperties = new JsonValue.Object([
+            new JsonMember("weight_sum", new JsonValue.String("not-an-expression")),
+        ]);
+
+        var error = Assert.Throws<InvalidArgumentException>(() =>
+            map.AddGeoJsonSourceData("clustered-invalid", NearbyPoints(), options)
+        );
+
+        Assert.Equal(MaplibreStatus.InvalidArgument, error.Status);
+        Assert.False(map.StyleSourceExists("clustered-invalid"));
+    }
+
+    private static GeoJsonSourceOptions ClusterOptions() =>
+        new()
+        {
+            Cluster = true,
+            ClusterRadius = 60,
+            ClusterMinimumPoints = 2,
+            ClusterMaximumZoom = 17,
+            ClusterProperties = new JsonValue.Object([
+                new JsonMember(
+                    "weight_sum",
+                    new JsonValue.Array([
+                        new JsonValue.String("+"),
+                        new JsonValue.Array([
+                            new JsonValue.String("get"),
+                            new JsonValue.String("weight"),
+                        ]),
+                    ])
+                ),
+            ]),
+        };
+
+    private static GeoJson NearbyPoints() =>
+        new GeoJson.FeatureCollection([
+            NearbyPoint(0.000, 1),
+            NearbyPoint(0.001, 2),
+            NearbyPoint(0.002, 3),
+        ]);
+
+    private static Feature NearbyPoint(double offset, ulong weight) =>
+        new(
+            new Geometry.Point(new LatLng(offset, offset)),
+            [new JsonMember("weight", new JsonValue.UInt(weight))],
+            FeatureIdentifier.Null.Instance
+        );
 
     private static GeoJson EmptyFeatureCollection() => new GeoJson.FeatureCollection([]);
 }

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/OptionsValueSemanticsTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/OptionsValueSemanticsTests.cs
@@ -269,6 +269,64 @@ public sealed class OptionsValueSemanticsTests
 
     [BindingSpecTest("BND-070")]
     [Fact]
+    public void GeoJsonSourceOptionsComparesByPropertyValue()
+    {
+        AssertValueSemantics(
+            () =>
+                new GeoJsonSourceOptions
+                {
+                    MinimumZoom = 1,
+                    MaximumZoom = 2,
+                    TileSize = 256,
+                    Buffer = 64,
+                    Tolerance = 0.5,
+                    LineMetrics = true,
+                    Cluster = true,
+                    ClusterRadius = 60,
+                    ClusterMaximumZoom = 15,
+                    ClusterMinimumPoints = 3,
+                    ClusterProperties = new JsonValue.Object([
+                        new JsonMember("sum", new JsonValue.Int(1)),
+                    ]),
+                },
+            options => options.MinimumZoom = 10,
+            options => options.MaximumZoom = 20,
+            options => options.TileSize = 512,
+            options => options.Buffer = 128,
+            options => options.Tolerance = 0.375,
+            options => options.LineMetrics = false,
+            options => options.Cluster = false,
+            options => options.ClusterRadius = 50,
+            options => options.ClusterMaximumZoom = 17,
+            options => options.ClusterMinimumPoints = 2,
+            options =>
+                options.ClusterProperties = new JsonValue.Object([
+                    new JsonMember("sum", new JsonValue.Int(2)),
+                ])
+        );
+
+        // A present zero-valued field stays distinguishable from an absent one.
+        Assert.NotEqual(new GeoJsonSourceOptions { ClusterRadius = 0 }, new GeoJsonSourceOptions());
+
+        // Distinct cluster-property trees holding equal contents compare equal.
+        Assert.Equal(
+            new GeoJsonSourceOptions
+            {
+                ClusterProperties = new JsonValue.Object([
+                    new JsonMember("sum", new JsonValue.Int(1)),
+                ]),
+            },
+            new GeoJsonSourceOptions
+            {
+                ClusterProperties = new JsonValue.Object([
+                    new JsonMember("sum", new JsonValue.Int(1)),
+                ]),
+            }
+        );
+    }
+
+    [BindingSpecTest("BND-070")]
+    [Fact]
     public void StyleImageOptionsComparesByPropertyValue()
     {
         AssertValueSemantics(

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/PublicApiSurfaceTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/PublicApiSurfaceTests.cs
@@ -172,6 +172,7 @@ public sealed class PublicApiSurfaceTests
             "Maplibre.Native.Runtime.RuntimeOptions",
             "Maplibre.Native.Style.CustomGeometrySourceCallback",
             "Maplibre.Native.Style.CustomGeometrySourceOptions",
+            "Maplibre.Native.Style.GeoJsonSourceOptions",
             "Maplibre.Native.Style.LocationIndicatorImageKind",
             "Maplibre.Native.Style.RasterDemEncoding",
             "Maplibre.Native.Style.SourceInfo",

--- a/bindings/dotnet/tests/Maplibre.Native.Tests/StyleJsonTests.cs
+++ b/bindings/dotnet/tests/Maplibre.Native.Tests/StyleJsonTests.cs
@@ -98,7 +98,7 @@ public sealed unsafe class StyleJsonTests
         using var map = MapHandle.Create(runtime, new MapOptions { Width = 512, Height = 512 });
         map.SetStyleJson("{\"version\":8,\"sources\":{},\"layers\":[]}");
 
-        map.AddGeoJsonSourceUrl("geo-url", "https://example.test/data.geojson");
+        map.AddGeoJsonSourceUrl("geo-url", "https://example.test/data.geojson", null);
         map.SetGeoJsonSourceUrl("geo-url", "https://example.test/other.geojson");
         map.AddVectorSourceTiles(
             "vector-tiles",

--- a/bindings/go/equal.go
+++ b/bindings/go/equal.go
@@ -13,6 +13,15 @@ func equalPointer[T comparable](left, right *T) bool {
 	return *left == *right
 }
 
+func clonePointer[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	cloned := new(T)
+	*cloned = *value
+	return cloned
+}
+
 // equalStrings reports whether two optional string lists are equal. A nil list marks an absent
 // field and is never equal to an empty list, matching how the field masks are populated.
 func equalStrings(left, right []string) bool {

--- a/bindings/go/equal_test.go
+++ b/bindings/go/equal_test.go
@@ -288,6 +288,48 @@ func TestStyleTileSourceOptionsEqualComparesFieldValues(t *testing.T) {
 	)
 }
 
+func TestStyleGeoJSONSourceOptionsEqualComparesFieldValues(t *testing.T) {
+	assertValueSemantics(
+		t,
+		"StyleGeoJSONSourceOptions",
+		func() StyleGeoJSONSourceOptions {
+			return StyleGeoJSONSourceOptions{
+				MinZoom:        optionPtr(1.0),
+				MaxZoom:        optionPtr(2.0),
+				Tolerance:      optionPtr(0.5),
+				ClusterMaxZoom: optionPtr(14.0),
+				ClusterProperties: optionPtr(JSONObject(
+					JSONMember{Name: "total", Value: JSONArray(JSONString("+"), JSONArray(JSONString("get"), JSONString("rank")))},
+				)),
+				TileSize:         optionPtr(uint32(256)),
+				Buffer:           optionPtr(uint32(64)),
+				ClusterRadius:    optionPtr(uint32(0)),
+				ClusterMinPoints: optionPtr(uint32(2)),
+				LineMetrics:      optionPtr(true),
+				Cluster:          optionPtr(true),
+			}
+		},
+		StyleGeoJSONSourceOptions.Equal,
+		[]func(*StyleGeoJSONSourceOptions){
+			func(o *StyleGeoJSONSourceOptions) { o.MinZoom = optionPtr(10.0) },
+			func(o *StyleGeoJSONSourceOptions) { o.MaxZoom = optionPtr(20.0) },
+			func(o *StyleGeoJSONSourceOptions) { o.Tolerance = optionPtr(0.25) },
+			func(o *StyleGeoJSONSourceOptions) { o.ClusterMaxZoom = optionPtr(15.0) },
+			func(o *StyleGeoJSONSourceOptions) {
+				o.ClusterProperties = optionPtr(JSONObject(
+					JSONMember{Name: "total", Value: JSONArray(JSONString("+"), JSONArray(JSONString("get"), JSONString("score")))},
+				))
+			},
+			func(o *StyleGeoJSONSourceOptions) { o.TileSize = optionPtr(uint32(512)) },
+			func(o *StyleGeoJSONSourceOptions) { o.Buffer = optionPtr(uint32(128)) },
+			func(o *StyleGeoJSONSourceOptions) { o.ClusterRadius = optionPtr(uint32(50)) },
+			func(o *StyleGeoJSONSourceOptions) { o.ClusterMinPoints = optionPtr(uint32(3)) },
+			func(o *StyleGeoJSONSourceOptions) { o.LineMetrics = optionPtr(false) },
+			func(o *StyleGeoJSONSourceOptions) { o.Cluster = optionPtr(false) },
+		},
+	)
+}
+
 func TestStyleImageOptionsEqualComparesFieldValues(t *testing.T) {
 	assertValueSemantics(
 		t,

--- a/bindings/go/equal_test.go
+++ b/bindings/go/equal_test.go
@@ -330,6 +330,26 @@ func TestStyleGeoJSONSourceOptionsEqualComparesFieldValues(t *testing.T) {
 	)
 }
 
+func TestStyleGeoJSONSourceOptionsBuildersDeepCopyRetainedFields(t *testing.T) {
+	original := StyleGeoJSONSourceOptions{}.
+		WithMinZoom(1).
+		WithClusterProperties(JSONObject(JSONMember{
+			Name:  "total",
+			Value: JSONArray(JSONString("+"), JSONInt(1)),
+		}))
+	updated := original.WithMaxZoom(2)
+
+	*updated.MinZoom = 9
+	updated.ClusterProperties.Object[0].Value.Array[1] = JSONInt(7)
+
+	if *original.MinZoom != 1 {
+		t.Fatalf("original MinZoom = %v, want 1", *original.MinZoom)
+	}
+	if got := original.ClusterProperties.Object[0].Value.Array[1]; !got.Equal(JSONInt(1)) {
+		t.Fatalf("original nested cluster property = %#v, want JSON int 1", got)
+	}
+}
+
 func TestStyleImageOptionsEqualComparesFieldValues(t *testing.T) {
 	assertValueSemantics(
 		t,

--- a/bindings/go/json.go
+++ b/bindings/go/json.go
@@ -83,6 +83,27 @@ func (v JSONValue) Equal(other JSONValue) bool {
 	}
 }
 
+// Clone returns an independent deep copy of this JSON value.
+func (v JSONValue) Clone() JSONValue {
+	cloned := v
+	if v.Array != nil {
+		cloned.Array = make([]JSONValue, len(v.Array))
+		for index := range v.Array {
+			cloned.Array[index] = v.Array[index].Clone()
+		}
+	}
+	if v.Object != nil {
+		cloned.Object = make(JSONMembers, len(v.Object))
+		for index := range v.Object {
+			cloned.Object[index] = JSONMember{
+				Name:  v.Object[index].Name,
+				Value: v.Object[index].Value.Clone(),
+			}
+		}
+	}
+	return cloned
+}
+
 // JSONNull returns a null JSON value.
 func JSONNull() JSONValue {
 	return JSONValue{Type: JSONValueTypeNull}

--- a/bindings/go/style.go
+++ b/bindings/go/style.go
@@ -199,8 +199,29 @@ func (options StyleGeoJSONSourceOptions) Equal(other StyleGeoJSONSourceOptions) 
 		equalPointer(options.Cluster, other.Cluster)
 }
 
+// Clone returns an independent deep copy of this descriptor.
+func (options StyleGeoJSONSourceOptions) Clone() StyleGeoJSONSourceOptions {
+	cloned := options
+	cloned.MinZoom = clonePointer(options.MinZoom)
+	cloned.MaxZoom = clonePointer(options.MaxZoom)
+	cloned.Tolerance = clonePointer(options.Tolerance)
+	cloned.ClusterMaxZoom = clonePointer(options.ClusterMaxZoom)
+	if options.ClusterProperties != nil {
+		value := options.ClusterProperties.Clone()
+		cloned.ClusterProperties = &value
+	}
+	cloned.TileSize = clonePointer(options.TileSize)
+	cloned.Buffer = clonePointer(options.Buffer)
+	cloned.ClusterRadius = clonePointer(options.ClusterRadius)
+	cloned.ClusterMinPoints = clonePointer(options.ClusterMinPoints)
+	cloned.LineMetrics = clonePointer(options.LineMetrics)
+	cloned.Cluster = clonePointer(options.Cluster)
+	return cloned
+}
+
 // WithMinZoom returns a copy that sets the minimum tiling zoom.
 func (options StyleGeoJSONSourceOptions) WithMinZoom(minZoom float64) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.MinZoom = new(float64)
 	*options.MinZoom = minZoom
 	return options
@@ -208,6 +229,7 @@ func (options StyleGeoJSONSourceOptions) WithMinZoom(minZoom float64) StyleGeoJS
 
 // WithMaxZoom returns a copy that sets the maximum tiling zoom.
 func (options StyleGeoJSONSourceOptions) WithMaxZoom(maxZoom float64) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.MaxZoom = new(float64)
 	*options.MaxZoom = maxZoom
 	return options
@@ -215,6 +237,7 @@ func (options StyleGeoJSONSourceOptions) WithMaxZoom(maxZoom float64) StyleGeoJS
 
 // WithTolerance returns a copy that sets the Douglas-Peucker simplification tolerance.
 func (options StyleGeoJSONSourceOptions) WithTolerance(tolerance float64) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.Tolerance = new(float64)
 	*options.Tolerance = tolerance
 	return options
@@ -222,6 +245,7 @@ func (options StyleGeoJSONSourceOptions) WithTolerance(tolerance float64) StyleG
 
 // WithClusterMaxZoom returns a copy that sets the highest zoom that clusters points.
 func (options StyleGeoJSONSourceOptions) WithClusterMaxZoom(clusterMaxZoom float64) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.ClusterMaxZoom = new(float64)
 	*options.ClusterMaxZoom = clusterMaxZoom
 	return options
@@ -229,13 +253,15 @@ func (options StyleGeoJSONSourceOptions) WithClusterMaxZoom(clusterMaxZoom float
 
 // WithClusterProperties returns a copy that sets cluster aggregation expressions.
 func (options StyleGeoJSONSourceOptions) WithClusterProperties(clusterProperties JSONValue) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.ClusterProperties = new(JSONValue)
-	*options.ClusterProperties = clusterProperties
+	*options.ClusterProperties = clusterProperties.Clone()
 	return options
 }
 
 // WithTileSize returns a copy that sets the tile extent in pixels.
 func (options StyleGeoJSONSourceOptions) WithTileSize(tileSize uint32) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.TileSize = new(uint32)
 	*options.TileSize = tileSize
 	return options
@@ -243,6 +269,7 @@ func (options StyleGeoJSONSourceOptions) WithTileSize(tileSize uint32) StyleGeoJ
 
 // WithBuffer returns a copy that sets the tile buffer in pixels.
 func (options StyleGeoJSONSourceOptions) WithBuffer(buffer uint32) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.Buffer = new(uint32)
 	*options.Buffer = buffer
 	return options
@@ -250,6 +277,7 @@ func (options StyleGeoJSONSourceOptions) WithBuffer(buffer uint32) StyleGeoJSONS
 
 // WithClusterRadius returns a copy that sets the cluster radius in pixels.
 func (options StyleGeoJSONSourceOptions) WithClusterRadius(clusterRadius uint32) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.ClusterRadius = new(uint32)
 	*options.ClusterRadius = clusterRadius
 	return options
@@ -257,6 +285,7 @@ func (options StyleGeoJSONSourceOptions) WithClusterRadius(clusterRadius uint32)
 
 // WithClusterMinPoints returns a copy that sets the points required to form a cluster.
 func (options StyleGeoJSONSourceOptions) WithClusterMinPoints(clusterMinPoints uint32) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.ClusterMinPoints = new(uint32)
 	*options.ClusterMinPoints = clusterMinPoints
 	return options
@@ -264,6 +293,7 @@ func (options StyleGeoJSONSourceOptions) WithClusterMinPoints(clusterMinPoints u
 
 // WithLineMetrics returns a copy that sets whether line distance metrics are added.
 func (options StyleGeoJSONSourceOptions) WithLineMetrics(lineMetrics bool) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.LineMetrics = new(bool)
 	*options.LineMetrics = lineMetrics
 	return options
@@ -271,6 +301,7 @@ func (options StyleGeoJSONSourceOptions) WithLineMetrics(lineMetrics bool) Style
 
 // WithCluster returns a copy that sets whether point features cluster.
 func (options StyleGeoJSONSourceOptions) WithCluster(cluster bool) StyleGeoJSONSourceOptions {
+	options = options.Clone()
 	options.Cluster = new(bool)
 	*options.Cluster = cluster
 	return options

--- a/bindings/go/style.go
+++ b/bindings/go/style.go
@@ -164,6 +164,205 @@ func (options cStyleTileSourceOptions) free() {
 	options.attribution.free()
 }
 
+// StyleGeoJSONSourceOptions configures GeoJSON sources. MapLibre Native fixes these options when
+// the source is created, so SetGeoJSONSourceURL and SetGeoJSONSourceData keep the options the
+// source was added with.
+type StyleGeoJSONSourceOptions struct {
+	MinZoom        *float64
+	MaxZoom        *float64
+	Tolerance      *float64
+	ClusterMaxZoom *float64
+	// ClusterProperties holds cluster aggregation expressions keyed by property name, as a JSON
+	// object whose members follow the MapLibre Style Spec clusterProperties form.
+	ClusterProperties *JSONValue
+	TileSize          *uint32
+	Buffer            *uint32
+	ClusterRadius     *uint32
+	ClusterMinPoints  *uint32
+	LineMetrics       *bool
+	Cluster           *bool
+}
+
+// Equal reports whether two descriptors hold the same field values. Use this instead of ==, which
+// does not compile for structs holding JSON values.
+func (options StyleGeoJSONSourceOptions) Equal(other StyleGeoJSONSourceOptions) bool {
+	return equalPointer(options.MinZoom, other.MinZoom) &&
+		equalPointer(options.MaxZoom, other.MaxZoom) &&
+		equalPointer(options.Tolerance, other.Tolerance) &&
+		equalPointer(options.ClusterMaxZoom, other.ClusterMaxZoom) &&
+		equalJSON(options.ClusterProperties, other.ClusterProperties) &&
+		equalPointer(options.TileSize, other.TileSize) &&
+		equalPointer(options.Buffer, other.Buffer) &&
+		equalPointer(options.ClusterRadius, other.ClusterRadius) &&
+		equalPointer(options.ClusterMinPoints, other.ClusterMinPoints) &&
+		equalPointer(options.LineMetrics, other.LineMetrics) &&
+		equalPointer(options.Cluster, other.Cluster)
+}
+
+// WithMinZoom returns a copy that sets the minimum tiling zoom.
+func (options StyleGeoJSONSourceOptions) WithMinZoom(minZoom float64) StyleGeoJSONSourceOptions {
+	options.MinZoom = new(float64)
+	*options.MinZoom = minZoom
+	return options
+}
+
+// WithMaxZoom returns a copy that sets the maximum tiling zoom.
+func (options StyleGeoJSONSourceOptions) WithMaxZoom(maxZoom float64) StyleGeoJSONSourceOptions {
+	options.MaxZoom = new(float64)
+	*options.MaxZoom = maxZoom
+	return options
+}
+
+// WithTolerance returns a copy that sets the Douglas-Peucker simplification tolerance.
+func (options StyleGeoJSONSourceOptions) WithTolerance(tolerance float64) StyleGeoJSONSourceOptions {
+	options.Tolerance = new(float64)
+	*options.Tolerance = tolerance
+	return options
+}
+
+// WithClusterMaxZoom returns a copy that sets the highest zoom that clusters points.
+func (options StyleGeoJSONSourceOptions) WithClusterMaxZoom(clusterMaxZoom float64) StyleGeoJSONSourceOptions {
+	options.ClusterMaxZoom = new(float64)
+	*options.ClusterMaxZoom = clusterMaxZoom
+	return options
+}
+
+// WithClusterProperties returns a copy that sets cluster aggregation expressions.
+func (options StyleGeoJSONSourceOptions) WithClusterProperties(clusterProperties JSONValue) StyleGeoJSONSourceOptions {
+	options.ClusterProperties = new(JSONValue)
+	*options.ClusterProperties = clusterProperties
+	return options
+}
+
+// WithTileSize returns a copy that sets the tile extent in pixels.
+func (options StyleGeoJSONSourceOptions) WithTileSize(tileSize uint32) StyleGeoJSONSourceOptions {
+	options.TileSize = new(uint32)
+	*options.TileSize = tileSize
+	return options
+}
+
+// WithBuffer returns a copy that sets the tile buffer in pixels.
+func (options StyleGeoJSONSourceOptions) WithBuffer(buffer uint32) StyleGeoJSONSourceOptions {
+	options.Buffer = new(uint32)
+	*options.Buffer = buffer
+	return options
+}
+
+// WithClusterRadius returns a copy that sets the cluster radius in pixels.
+func (options StyleGeoJSONSourceOptions) WithClusterRadius(clusterRadius uint32) StyleGeoJSONSourceOptions {
+	options.ClusterRadius = new(uint32)
+	*options.ClusterRadius = clusterRadius
+	return options
+}
+
+// WithClusterMinPoints returns a copy that sets the points required to form a cluster.
+func (options StyleGeoJSONSourceOptions) WithClusterMinPoints(clusterMinPoints uint32) StyleGeoJSONSourceOptions {
+	options.ClusterMinPoints = new(uint32)
+	*options.ClusterMinPoints = clusterMinPoints
+	return options
+}
+
+// WithLineMetrics returns a copy that sets whether line distance metrics are added.
+func (options StyleGeoJSONSourceOptions) WithLineMetrics(lineMetrics bool) StyleGeoJSONSourceOptions {
+	options.LineMetrics = new(bool)
+	*options.LineMetrics = lineMetrics
+	return options
+}
+
+// WithCluster returns a copy that sets whether point features cluster.
+func (options StyleGeoJSONSourceOptions) WithCluster(cluster bool) StyleGeoJSONSourceOptions {
+	options.Cluster = new(bool)
+	*options.Cluster = cluster
+	return options
+}
+
+// cStyleGeoJSONSourceOptions keeps the native options struct in C storage because the descriptor
+// carries the cluster property tree owned by a Go-side materializer.
+type cStyleGeoJSONSourceOptions struct {
+	raw          *C.mln_geojson_source_options
+	materializer *cJSONMaterializer
+}
+
+func newCStyleGeoJSONSourceOptions(options *StyleGeoJSONSourceOptions) (*cStyleGeoJSONSourceOptions, error) {
+	if options == nil {
+		return nil, nil
+	}
+	raw := &cStyleGeoJSONSourceOptions{
+		raw: (*C.mln_geojson_source_options)(C.malloc(C.size_t(unsafe.Sizeof(C.mln_geojson_source_options{})))),
+	}
+	*raw.raw = C.mln_geojson_source_options_default()
+	if options.MinZoom != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM
+		raw.raw.min_zoom = C.double(*options.MinZoom)
+	}
+	if options.MaxZoom != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM
+		raw.raw.max_zoom = C.double(*options.MaxZoom)
+	}
+	if options.Tolerance != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_TOLERANCE
+		raw.raw.tolerance = C.double(*options.Tolerance)
+	}
+	if options.ClusterMaxZoom != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM
+		raw.raw.cluster_max_zoom = C.double(*options.ClusterMaxZoom)
+	}
+	if options.ClusterProperties != nil {
+		raw.materializer = newCJSONMaterializer()
+		clusterProperties, err := raw.materializer.valuePtr(*options.ClusterProperties)
+		if err != nil {
+			raw.free()
+			return nil, err
+		}
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+		raw.raw.cluster_properties = clusterProperties
+	}
+	if options.TileSize != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE
+		raw.raw.tile_size = C.uint32_t(*options.TileSize)
+	}
+	if options.Buffer != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_BUFFER
+		raw.raw.buffer = C.uint32_t(*options.Buffer)
+	}
+	if options.ClusterRadius != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS
+		raw.raw.cluster_radius = C.uint32_t(*options.ClusterRadius)
+	}
+	if options.ClusterMinPoints != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+		raw.raw.cluster_min_points = C.uint32_t(*options.ClusterMinPoints)
+	}
+	if options.LineMetrics != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS
+		raw.raw.line_metrics = C.bool(*options.LineMetrics)
+	}
+	if options.Cluster != nil {
+		raw.raw.fields |= C.MLN_GEOJSON_SOURCE_OPTION_CLUSTER
+		raw.raw.cluster = C.bool(*options.Cluster)
+	}
+	return raw, nil
+}
+
+func (options *cStyleGeoJSONSourceOptions) ptr() *C.mln_geojson_source_options {
+	if options == nil {
+		return nil
+	}
+	return options.raw
+}
+
+func (options *cStyleGeoJSONSourceOptions) free() {
+	if options == nil {
+		return
+	}
+	if options.materializer != nil {
+		options.materializer.free()
+	}
+	if options.raw != nil {
+		C.free(unsafe.Pointer(options.raw))
+	}
+}
+
 // CustomGeometryTileCallback receives custom geometry tile requests. Native
 // code may invoke it on worker threads and may race it with owner-thread map
 // calls. The callback must be thread-safe, must not call MapLibre map APIs
@@ -327,8 +526,10 @@ func styleSourceInfoFromC(info C.mln_style_source_info) StyleSourceInfo {
 	}
 }
 
-// AddGeoJSONSourceURL adds a GeoJSON source that loads from a URL.
-func (m *MapHandle) AddGeoJSONSourceURL(sourceID string, url string) error {
+// AddGeoJSONSourceURL adds a GeoJSON source that loads from a URL. MapLibre Native fixes options
+// when the source is created, so later SetGeoJSONSourceURL and SetGeoJSONSourceData calls keep the
+// options passed here.
+func (m *MapHandle) AddGeoJSONSourceURL(sourceID string, url string, options *StyleGeoJSONSourceOptions) error {
 	ptr, release, err := m.ptr()
 	if err != nil {
 		return err
@@ -339,8 +540,13 @@ func (m *MapHandle) AddGeoJSONSourceURL(sourceID string, url string) error {
 	defer sourceView.free()
 	urlView := newCStringView(url)
 	defer urlView.free()
+	rawOptions, err := newCStyleGeoJSONSourceOptions(options)
+	if err != nil {
+		return newBindingError(ErrInvalidArgument, err.Error())
+	}
+	defer rawOptions.free()
 	return checkNative(func() int32 {
-		return int32(C.mln_map_add_geojson_source_url((*C.mln_map)(unsafe.Pointer(ptr)), sourceView.raw(), urlView.raw()))
+		return int32(C.mln_map_add_geojson_source_url((*C.mln_map)(unsafe.Pointer(ptr)), sourceView.raw(), urlView.raw(), rawOptions.ptr()))
 	})
 }
 
@@ -362,8 +568,10 @@ func (m *MapHandle) SetGeoJSONSourceURL(sourceID string, url string) error {
 }
 
 // AddGeoJSONSourceData adds a GeoJSON source with inline data. Accepted data is
-// copied into MapLibre Native before the call returns.
-func (m *MapHandle) AddGeoJSONSourceData(sourceID string, data GeoJSON) error {
+// copied into MapLibre Native before the call returns. MapLibre Native fixes options when the
+// source is created, so later SetGeoJSONSourceData and SetGeoJSONSourceURL calls keep the options
+// passed here.
+func (m *MapHandle) AddGeoJSONSourceData(sourceID string, data GeoJSON, options *StyleGeoJSONSourceOptions) error {
 	ptr, release, err := m.ptr()
 	if err != nil {
 		return err
@@ -378,8 +586,13 @@ func (m *MapHandle) AddGeoJSONSourceData(sourceID string, data GeoJSON) error {
 	if err != nil {
 		return newBindingError(ErrInvalidArgument, err.Error())
 	}
+	rawOptions, err := newCStyleGeoJSONSourceOptions(options)
+	if err != nil {
+		return newBindingError(ErrInvalidArgument, err.Error())
+	}
+	defer rawOptions.free()
 	return checkNative(func() int32 {
-		return int32(C.mln_map_add_geojson_source_data((*C.mln_map)(unsafe.Pointer(ptr)), sourceView.raw(), &rawData))
+		return int32(C.mln_map_add_geojson_source_data((*C.mln_map)(unsafe.Pointer(ptr)), sourceView.raw(), &rawData, rawOptions.ptr()))
 	})
 }
 

--- a/bindings/go/style_sources_test.go
+++ b/bindings/go/style_sources_test.go
@@ -104,7 +104,11 @@ func TestStyleSourceURLAndTileBindings(t *testing.T) {
 	if err := m.SetStyleJSON(`{"version":8,"sources":{},"layers":[]}`); err != nil {
 		t.Fatalf("SetStyleJSON(empty style): %v", err)
 	}
-	if err := m.AddGeoJSONSourceURL("geojson-url", "asset://fixtures/points.geojson"); err != nil {
+	geoJSONOptions := StyleGeoJSONSourceOptions{}.
+		WithMinZoom(1).
+		WithTolerance(0.5).
+		WithBuffer(64)
+	if err := m.AddGeoJSONSourceURL("geojson-url", "asset://fixtures/points.geojson", &geoJSONOptions); err != nil {
 		t.Fatalf("AddGeoJSONSourceURL(): %v", err)
 	}
 	if err := m.SetGeoJSONSourceURL("geojson-url", "asset://fixtures/points-2.geojson"); err != nil {
@@ -143,7 +147,7 @@ func TestStyleSourceURLAndTileBindings(t *testing.T) {
 	if err := m.AddVectorSourceTiles("bad-vector", nil, nil); !errors.Is(err, ErrInvalidArgument) {
 		t.Fatalf("AddVectorSourceTiles(nil) error = %v, want ErrInvalidArgument", err)
 	}
-	if err := m.AddGeoJSONSourceURL("", "asset://fixtures/points.geojson"); !errors.Is(err, ErrInvalidArgument) {
+	if err := m.AddGeoJSONSourceURL("", "asset://fixtures/points.geojson", nil); !errors.Is(err, ErrInvalidArgument) {
 		t.Fatalf("AddGeoJSONSourceURL(empty id) error = %v, want ErrInvalidArgument", err)
 	}
 }
@@ -182,7 +186,14 @@ func TestGeoJSONSourceDataDescriptors(t *testing.T) {
 		Properties: properties,
 		Identifier: "feature-1",
 	}})
-	if err := m.AddGeoJSONSourceData("geojson-data", data); err != nil {
+	options := StyleGeoJSONSourceOptions{}.
+		WithMinZoom(1).
+		WithMaxZoom(16).
+		WithTolerance(0.5).
+		WithBuffer(0).
+		WithLineMetrics(true).
+		WithTileSize(256)
+	if err := m.AddGeoJSONSourceData("geojson-data", data, &options); err != nil {
 		t.Fatalf("AddGeoJSONSourceData(): %v", err)
 	}
 	points[0] = LatLng{Latitude: 90, Longitude: 90}
@@ -198,12 +209,88 @@ func TestGeoJSONSourceDataDescriptors(t *testing.T) {
 		t.Fatalf("StyleSourceType(geojson-data) = (%v, %v), want GeoJSON true", sourceType, found)
 	}
 	badID := GeoJSONFeatureCollection([]Feature{{Geometry: PointGeometry(LatLng{}), Identifier: struct{}{}}})
-	if err := m.AddGeoJSONSourceData("bad-geojson-data", badID); !errors.Is(err, ErrInvalidArgument) {
+	if err := m.AddGeoJSONSourceData("bad-geojson-data", badID, nil); !errors.Is(err, ErrInvalidArgument) {
 		t.Fatalf("AddGeoJSONSourceData(unsupported id) error = %v, want ErrInvalidArgument", err)
 	}
 	badGeometry := GeoJSON{Type: GeoJSONTypeGeometry, Geometry: Geometry{Type: GeometryType(999)}}
-	if err := m.AddGeoJSONSourceData("bad-geometry", badGeometry); !errors.Is(err, ErrInvalidArgument) {
+	if err := m.AddGeoJSONSourceData("bad-geometry", badGeometry, nil); !errors.Is(err, ErrInvalidArgument) {
 		t.Fatalf("AddGeoJSONSourceData(unsupported geometry) error = %v, want ErrInvalidArgument", err)
+	}
+	badClusterProperties := StyleGeoJSONSourceOptions{}.
+		WithCluster(true).
+		WithClusterProperties(JSONObject(JSONMember{Name: "total", Value: JSONDouble(math.Inf(1))}))
+	if err := m.AddGeoJSONSourceData("bad-cluster-properties", data, &badClusterProperties); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("AddGeoJSONSourceData(non-finite cluster property) error = %v, want ErrInvalidArgument", err)
+	}
+	exists, err := m.StyleSourceExists("bad-cluster-properties")
+	if err != nil {
+		t.Fatalf("StyleSourceExists(bad-cluster-properties): %v", err)
+	}
+	if exists {
+		t.Fatalf("StyleSourceExists(bad-cluster-properties) = true, want false")
+	}
+}
+
+func TestGeoJSONSourceClusterOptions(t *testing.T) {
+	lockOSThreadForTest(t)
+
+	runtime, err := NewRuntime()
+	if err != nil {
+		t.Fatalf("NewRuntime(): %v", err)
+	}
+	m, err := runtime.NewMap()
+	if err != nil {
+		_ = runtime.Close()
+		t.Fatalf("NewMap(): %v", err)
+	}
+	defer func() {
+		if err := m.Close(); err != nil {
+			t.Errorf("Map Close(): %v", err)
+		}
+		if err := runtime.Close(); err != nil {
+			t.Errorf("Runtime Close(): %v", err)
+		}
+	}()
+
+	if err := m.SetStyleJSON(`{"version":8,"sources":{},"layers":[]}`); err != nil {
+		t.Fatalf("SetStyleJSON(empty style): %v", err)
+	}
+	points := GeoJSONFeatureCollection([]Feature{
+		{Geometry: PointGeometry(LatLng{Latitude: 0, Longitude: 0}), Properties: JSONMembers{{Name: "rank", Value: JSONInt(1)}}},
+		{Geometry: PointGeometry(LatLng{Latitude: 0.001, Longitude: 0.001}), Properties: JSONMembers{{Name: "rank", Value: JSONInt(2)}}},
+		{Geometry: PointGeometry(LatLng{Latitude: 0.002, Longitude: 0.002}), Properties: JSONMembers{{Name: "rank", Value: JSONInt(3)}}},
+	})
+	// MapLibre Native parses the aggregation expressions while the descriptor is borrowed, so a
+	// source that adds successfully proves the nested cluster property tree crossed the boundary.
+	clusterProperties := JSONMembers{
+		{Name: "total", Value: JSONArray(JSONString("+"), JSONArray(JSONString("get"), JSONString("rank")))},
+	}
+	options := StyleGeoJSONSourceOptions{}.
+		WithCluster(true).
+		WithClusterRadius(50).
+		WithClusterMinPoints(2).
+		WithClusterMaxZoom(14).
+		WithClusterProperties(JSONValue{Type: JSONValueTypeObject, Object: clusterProperties})
+	if err := m.AddGeoJSONSourceData("cluster-source", points, &options); err != nil {
+		t.Fatalf("AddGeoJSONSourceData(clustered): %v", err)
+	}
+	clusterProperties[0].Value = JSONString("mutated-after-call")
+	sourceType, found, err := m.StyleSourceType("cluster-source")
+	if err != nil {
+		t.Fatalf("StyleSourceType(cluster-source): %v", err)
+	}
+	if !found || sourceType != StyleSourceTypeGeoJSON {
+		t.Fatalf("StyleSourceType(cluster-source) = (%v, %v), want GeoJSON true", sourceType, found)
+	}
+	// Options are fixed at creation, so updating the data keeps the clustered source usable.
+	if err := m.SetGeoJSONSourceData("cluster-source", points); err != nil {
+		t.Fatalf("SetGeoJSONSourceData(clustered): %v", err)
+	}
+	malformed := StyleGeoJSONSourceOptions{}.
+		WithCluster(true).
+		WithClusterProperties(JSONObject(JSONMember{Name: "total", Value: JSONArray(JSONString("+"))}))
+	if err := m.AddGeoJSONSourceData("malformed-cluster-source", points, &malformed); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("AddGeoJSONSourceData(malformed cluster properties) error = %v, want ErrInvalidArgument", err)
 	}
 }
 

--- a/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/androidMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -41,6 +41,7 @@ import org.maplibre.nativeffi.render.VulkanOwnedTextureDescriptor
 import org.maplibre.nativeffi.render.VulkanSurfaceDescriptor
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.style.CustomGeometrySourceOptions
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.LocationIndicatorImageKind
 import org.maplibre.nativeffi.style.SourceInfo
 import org.maplibre.nativeffi.style.SourceType
@@ -176,32 +177,46 @@ private constructor(private val runtime: RuntimeHandle, private val handleAddres
     }
   }
 
-  public actual fun addGeoJsonSourceUrl(sourceId: String, url: String) {
+  public actual fun addGeoJsonSourceUrl(
+    sourceId: String,
+    url: String,
+    options: GeoJsonSourceOptions?,
+  ) {
     NativeAccess.ensureLoaded()
     StringViewScope(sourceId).use { nativeSourceId ->
       StringViewScope(url).use { nativeUrl ->
-        Status.check(
-          MaplibreNativeC.mln_map_add_geojson_source_url(
-            map(requireLiveAddress()),
-            nativeSourceId.view,
-            nativeUrl.view,
+        GeoJsonSourceOptionsScope(options).use { nativeOptions ->
+          Status.check(
+            MaplibreNativeC.mln_map_add_geojson_source_url(
+              map(requireLiveAddress()),
+              nativeSourceId.view,
+              nativeUrl.view,
+              nativeOptions.options,
+            )
           )
-        )
+        }
       }
     }
   }
 
-  public actual fun addGeoJsonSourceData(sourceId: String, data: GeoJson) {
+  public actual fun addGeoJsonSourceData(
+    sourceId: String,
+    data: GeoJson,
+    options: GeoJsonSourceOptions?,
+  ) {
     NativeAccess.ensureLoaded()
     StringViewScope(sourceId).use { nativeSourceId ->
       GeoJsonScope(data).use { nativeData ->
-        Status.check(
-          MaplibreNativeC.mln_map_add_geojson_source_data(
-            map(requireLiveAddress()),
-            nativeSourceId.view,
-            nativeData.value,
+        GeoJsonSourceOptionsScope(options).use { nativeOptions ->
+          Status.check(
+            MaplibreNativeC.mln_map_add_geojson_source_data(
+              map(requireLiveAddress()),
+              nativeSourceId.view,
+              nativeData.value,
+              nativeOptions.options,
+            )
           )
-        )
+        }
       }
     }
   }
@@ -2604,6 +2619,66 @@ private class TileSourceOptionsScope(value: TileSourceOptions?) : AutoCloseable 
   override fun close() {
     options.close()
     attribution?.close()
+  }
+}
+
+private class GeoJsonSourceOptionsScope(value: GeoJsonSourceOptions?) : AutoCloseable {
+  private val clusterProperties: JsonScope? = value?.clusterProperties?.let(::JsonScope)
+  val options: MaplibreNativeC.mln_geojson_source_options =
+    MaplibreNativeC.mln_geojson_source_options_default()
+
+  init {
+    var fields = 0
+    value?.minZoom?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM
+      options.min_zoom(it)
+    }
+    value?.maxZoom?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM
+      options.max_zoom(it)
+    }
+    value?.tolerance?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_TOLERANCE
+      options.tolerance(it)
+    }
+    value?.clusterMaxZoom?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM
+      options.cluster_max_zoom(it)
+    }
+    clusterProperties?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+      options.cluster_properties(it.value)
+    }
+    value?.tileSize?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE
+      options.tile_size(it)
+    }
+    value?.buffer?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_BUFFER
+      options.buffer(it)
+    }
+    value?.clusterRadius?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS
+      options.cluster_radius(it)
+    }
+    value?.clusterMinPoints?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+      options.cluster_min_points(it)
+    }
+    value?.lineMetrics?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS
+      options.line_metrics(it)
+    }
+    value?.cluster?.let {
+      fields = fields or MaplibreNativeC.MLN_GEOJSON_SOURCE_OPTION_CLUSTER
+      options.cluster(it)
+    }
+    options.fields(fields)
+  }
+
+  override fun close() {
+    options.close()
+    clusterProperties?.close()
   }
 }
 

--- a/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
+++ b/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
@@ -31,6 +31,9 @@ import org.maplibre.nativeffi.error.MaplibreStatus
 import org.maplibre.nativeffi.error.UnsupportedFeatureException
 import org.maplibre.nativeffi.error.WrongThreadException
 import org.maplibre.nativeffi.geo.Feature
+import org.maplibre.nativeffi.geo.FeatureIdentifier
+import org.maplibre.nativeffi.geo.GeoJson
+import org.maplibre.nativeffi.geo.Geometry
 import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.ScreenBox
 import org.maplibre.nativeffi.geo.ScreenPoint
@@ -47,6 +50,7 @@ import org.maplibre.nativeffi.query.RenderedQueryGeometry
 import org.maplibre.nativeffi.query.SourceFeatureQueryOptions
 import org.maplibre.nativeffi.runtime.RuntimeEventType
 import org.maplibre.nativeffi.runtime.RuntimeHandle
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import platform.CoreGraphics.CGSizeMake
 import platform.Metal.MTLCreateSystemDefaultDevice
 import platform.Metal.MTLDeviceProtocol
@@ -464,6 +468,8 @@ class RenderSessionHandleTest {
             }
           )
           map.setStyleJson(CLUSTER_STYLE_JSON)
+          map.addGeoJsonSourceData("cluster-source", clusterPoints(), clusterSourceOptions())
+          map.addStyleLayerJson(clusterCircleLayer(), "")
           assertTrue(waitForMapEvent(runtime, map, RuntimeEventType.MAP_RENDER_UPDATE_AVAILABLE))
           assertTrue(session.renderUpdate())
 
@@ -486,6 +492,12 @@ class RenderSessionHandleTest {
           // feature must keep the unsigned alternative to resolve on the way
           // back in.
           assertTrue(member(cluster, "cluster_id") is JsonValue.UInt)
+
+          // The rendered cluster exists only because the typed GeoJSON adder
+          // passed GeoJsonSourceOptions.cluster, and weightSum comes from the
+          // clusterProperties aggregation lowered through the same options.
+          assertEquals(3.0, numericMember(cluster, "point_count"))
+          assertEquals(6.0, numericMember(cluster, "weightSum"))
 
           val children =
             featureCollectionResult(
@@ -632,6 +644,78 @@ class RenderSessionHandleTest {
     return leaves.first()
   }
 
+  /** Point features close enough together to collapse into one cluster at zoom 0. */
+  private fun clusterPoints(): GeoJson =
+    GeoJson.FeatureCollection(
+      listOf(clusterPoint("one", 0.0), clusterPoint("two", 0.001), clusterPoint("three", 0.002))
+    )
+
+  private fun clusterPoint(name: String, offset: Double): Feature =
+    Feature(
+      Geometry.Point(LatLng(offset, offset)),
+      listOf(
+        JsonValue.Member("name", JsonValue.StringValue(name)),
+        JsonValue.Member("weight", JsonValue.UInt(2)),
+      ),
+      FeatureIdentifier.Null,
+    )
+
+  private fun clusterSourceOptions(): GeoJsonSourceOptions =
+    GeoJsonSourceOptions().apply {
+      cluster = true
+      clusterRadius = 50
+      clusterMaxZoom = 14.0
+      clusterMinPoints = 2
+      clusterProperties =
+        JsonValue.ObjectValue(
+          listOf(
+            JsonValue.Member(
+              "weightSum",
+              JsonValue.Array(
+                listOf(
+                  JsonValue.StringValue("+"),
+                  JsonValue.Array(
+                    listOf(JsonValue.StringValue("get"), JsonValue.StringValue("weight"))
+                  ),
+                )
+              ),
+            )
+          )
+        )
+    }
+
+  private fun clusterCircleLayer(): JsonValue =
+    JsonValue.ObjectValue(
+      listOf(
+        JsonValue.Member("id", JsonValue.StringValue("cluster-circle")),
+        JsonValue.Member("type", JsonValue.StringValue("circle")),
+        JsonValue.Member("source", JsonValue.StringValue("cluster-source")),
+        JsonValue.Member(
+          "filter",
+          JsonValue.Array(
+            listOf(JsonValue.StringValue("has"), JsonValue.StringValue("point_count"))
+          ),
+        ),
+        JsonValue.Member(
+          "paint",
+          JsonValue.ObjectValue(
+            listOf(
+              JsonValue.Member("circle-color", JsonValue.StringValue("#2563eb")),
+              JsonValue.Member("circle-radius", JsonValue.UInt(20)),
+            )
+          ),
+        ),
+      )
+    )
+
+  private fun numericMember(feature: QueriedFeature, key: String): Double? =
+    when (val value = member(feature, key)) {
+      is JsonValue.UInt -> value.value.toDouble()
+      is JsonValue.Int -> value.value.toDouble()
+      is JsonValue.DoubleValue -> value.value
+      else -> null
+    }
+
   private fun member(feature: Feature, key: String): JsonValue? =
     feature.properties.firstOrNull { it.key == key }?.value
 
@@ -754,28 +838,18 @@ class RenderSessionHandleTest {
       }
       """
 
+    /**
+     * The clustered source and its layer are added afterwards through the typed GeoJSON adder, so
+     * clustering comes from [GeoJsonSourceOptions] rather than from style JSON.
+     */
     private const val CLUSTER_STYLE_JSON =
       """
       {
         "version": 8,
         "name": "kotlin-cluster-query-test",
-        "sources": {
-          "cluster-source": {
-            "type": "geojson",
-            "cluster": true,
-            "data": {
-              "type": "FeatureCollection",
-              "features": [
-                {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.0, 0.0]}, "properties": {"name": "one"}},
-                {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.001, 0.001]}, "properties": {"name": "two"}},
-                {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.002, 0.002]}, "properties": {"name": "three"}}
-              ]
-            }
-          }
-        },
+        "sources": {},
         "layers": [
-          {"id": "background", "type": "background", "paint": {"background-color": "#ffffff"}},
-          {"id": "cluster-circle", "type": "circle", "source": "cluster-source", "filter": ["has", "point_count"], "paint": {"circle-color": "#2563eb", "circle-radius": 20}}
+          {"id": "background", "type": "background", "paint": {"background-color": "#ffffff"}}
         ]
       }
       """

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -25,6 +25,7 @@ import org.maplibre.nativeffi.render.VulkanOwnedTextureDescriptor
 import org.maplibre.nativeffi.render.VulkanSurfaceDescriptor
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.style.CustomGeometrySourceOptions
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.LocationIndicatorImageKind
 import org.maplibre.nativeffi.style.SourceInfo
 import org.maplibre.nativeffi.style.SourceType
@@ -55,9 +56,9 @@ public expect class MapHandle : AutoCloseable {
 
   public fun styleSourceIds(): List<String>
 
-  public fun addGeoJsonSourceUrl(sourceId: String, url: String)
+  public fun addGeoJsonSourceUrl(sourceId: String, url: String, options: GeoJsonSourceOptions?)
 
-  public fun addGeoJsonSourceData(sourceId: String, data: GeoJson)
+  public fun addGeoJsonSourceData(sourceId: String, data: GeoJson, options: GeoJsonSourceOptions?)
 
   public fun setGeoJsonSourceUrl(sourceId: String, url: String)
 

--- a/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/style/GeoJsonSourceOptions.kt
+++ b/bindings/kotlin/src/commonMain/kotlin/org/maplibre/nativeffi/style/GeoJsonSourceOptions.kt
@@ -1,0 +1,96 @@
+package org.maplibre.nativeffi.style
+
+import org.maplibre.nativeffi.internal.status.Status
+import org.maplibre.nativeffi.json.JsonValue
+
+/**
+ * Mutable descriptor for GeoJSON style sources.
+ *
+ * MapLibre Native fixes these options when the source is created, so the update APIs keep the
+ * options the source was added with.
+ *
+ * Compares and hashes by field value; [copy] returns an independent instance. Keep an instance
+ * unmodified while it is a key in a hash-based collection.
+ */
+public class GeoJsonSourceOptions {
+  public var minZoom: Double? = null
+
+  public var maxZoom: Double? = null
+
+  public var tolerance: Double? = null
+
+  public var clusterMaxZoom: Double? = null
+
+  /**
+   * Cluster aggregation expressions keyed by property name, as a JSON object whose members follow
+   * the MapLibre Style Spec `clusterProperties` form.
+   */
+  public var clusterProperties: JsonValue? = null
+
+  public var tileSize: Int? = null
+    set(value) {
+      value?.let { Status.requireArgument(it >= 0) { "tileSize must be non-negative" } }
+      field = value
+    }
+
+  public var buffer: Int? = null
+    set(value) {
+      value?.let { Status.requireArgument(it >= 0) { "buffer must be non-negative" } }
+      field = value
+    }
+
+  public var clusterRadius: Int? = null
+    set(value) {
+      value?.let { Status.requireArgument(it >= 0) { "clusterRadius must be non-negative" } }
+      field = value
+    }
+
+  public var clusterMinPoints: Int? = null
+    set(value) {
+      value?.let { Status.requireArgument(it >= 0) { "clusterMinPoints must be non-negative" } }
+      field = value
+    }
+
+  public var lineMetrics: Boolean? = null
+
+  public var cluster: Boolean? = null
+
+  /** Returns an independent copy of this descriptor with [block] applied to the copy. */
+  public fun copy(block: GeoJsonSourceOptions.() -> Unit = {}): GeoJsonSourceOptions =
+    GeoJsonSourceOptions()
+      .also {
+        it.minZoom = minZoom
+        it.maxZoom = maxZoom
+        it.tolerance = tolerance
+        it.clusterMaxZoom = clusterMaxZoom
+        it.clusterProperties = clusterProperties
+        it.tileSize = tileSize
+        it.buffer = buffer
+        it.clusterRadius = clusterRadius
+        it.clusterMinPoints = clusterMinPoints
+        it.lineMetrics = lineMetrics
+        it.cluster = cluster
+      }
+      .apply(block)
+
+  private val fields: List<Any?>
+    get() =
+      listOf(
+        minZoom,
+        maxZoom,
+        tolerance,
+        clusterMaxZoom,
+        clusterProperties,
+        tileSize,
+        buffer,
+        clusterRadius,
+        clusterMinPoints,
+        lineMetrics,
+        cluster,
+      )
+
+  override fun equals(other: Any?): Boolean =
+    other is GeoJsonSourceOptions && fields == other.fields
+
+  override fun hashCode(): Int = fields.hashCode()
+}

--- a/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/OptionsValueSemanticsTest.kt
+++ b/bindings/kotlin/src/commonTest/kotlin/org/maplibre/nativeffi/OptionsValueSemanticsTest.kt
@@ -29,6 +29,7 @@ import org.maplibre.nativeffi.map.ViewportOptions
 import org.maplibre.nativeffi.query.RenderedFeatureQueryOptions
 import org.maplibre.nativeffi.query.SourceFeatureQueryOptions
 import org.maplibre.nativeffi.runtime.RuntimeOptions
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.RasterDemEncoding
 import org.maplibre.nativeffi.style.StyleImageOptions
 import org.maplibre.nativeffi.style.TileScheme
@@ -300,6 +301,58 @@ class OptionsValueSemanticsTest {
         ),
     )
   }
+
+  @Test
+  fun geoJsonSourceOptionsComparesByFieldValue() {
+    assertValueSemantics(
+      baseline = {
+        GeoJsonSourceOptions().apply {
+          minZoom = 1.0
+          maxZoom = 2.0
+          tolerance = 0.5
+          clusterMaxZoom = 14.0
+          clusterProperties = clusterProperties("sum")
+          tileSize = 256
+          buffer = 64
+          clusterRadius = 40
+          clusterMinPoints = 3
+          lineMetrics = true
+          cluster = true
+        }
+      },
+      copyOf = { it.copy() },
+      mutators =
+        listOf(
+          { minZoom = 10.0 },
+          { maxZoom = 20.0 },
+          { tolerance = 0.25 },
+          { clusterMaxZoom = 12.0 },
+          { clusterProperties = clusterProperties("max") },
+          { tileSize = 512 },
+          { buffer = 128 },
+          { clusterRadius = 50 },
+          { clusterMinPoints = 2 },
+          { lineMetrics = false },
+          { cluster = false },
+        ),
+    )
+  }
+
+  /** Builds a `clusterProperties` object whose aggregation operator is [operator]. */
+  private fun clusterProperties(operator: String): JsonValue =
+    JsonValue.ObjectValue(
+      listOf(
+        JsonValue.Member(
+          "weight",
+          JsonValue.Array(
+            listOf(
+              JsonValue.StringValue(operator),
+              JsonValue.Array(listOf(JsonValue.StringValue("get"), JsonValue.StringValue("weight"))),
+            )
+          ),
+        )
+      )
+    )
 
   @Test
   fun styleImageOptionsComparesByFieldValue() {

--- a/bindings/kotlin/src/jextract/maplibre-native-c.includes
+++ b/bindings/kotlin/src/jextract/maplibre-native-c.includes
@@ -472,6 +472,17 @@
 --include-constant MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TILE_SIZE
 --include-constant MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_TOLERANCE
 --include-constant MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_WRAP
+--include-constant MLN_GEOJSON_SOURCE_OPTION_BUFFER
+--include-constant MLN_GEOJSON_SOURCE_OPTION_CLUSTER
+--include-constant MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM
+--include-constant MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+--include-constant MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+--include-constant MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS
+--include-constant MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS
+--include-constant MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM
+--include-constant MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM
+--include-constant MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE
+--include-constant MLN_GEOJSON_SOURCE_OPTION_TOLERANCE
 --include-constant MLN_LOCATION_INDICATOR_IMAGE_KIND_BEARING
 --include-constant MLN_LOCATION_INDICATOR_IMAGE_KIND_SHADOW
 --include-constant MLN_LOCATION_INDICATOR_IMAGE_KIND_TOP
@@ -501,6 +512,7 @@
 --include-constant MLN_STYLE_VECTOR_TILE_ENCODING_MLT
 --include-constant MLN_STYLE_VECTOR_TILE_ENCODING_MVT
 --include-function mln_custom_geometry_source_options_default
+--include-function mln_geojson_source_options_default
 --include-function mln_map_add_color_relief_layer
 --include-function mln_map_add_custom_geometry_source
 --include-function mln_map_add_geojson_source_data
@@ -563,6 +575,7 @@
 --include-function mln_style_tile_source_options_default
 --include-struct mln_canonical_tile_id
 --include-struct mln_custom_geometry_source_options
+--include-struct mln_geojson_source_options
 --include-struct mln_premultiplied_rgba8_image
 --include-struct mln_style_image_info
 --include-struct mln_style_image_options

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/loader/NativeAccess.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/internal/loader/NativeAccess.kt
@@ -44,6 +44,7 @@ import org.maplibre.nativeffi.internal.c.mln_feature_extension_result_info
 import org.maplibre.nativeffi.internal.c.mln_feature_state_selector
 import org.maplibre.nativeffi.internal.c.mln_free_camera_options
 import org.maplibre.nativeffi.internal.c.mln_geojson
+import org.maplibre.nativeffi.internal.c.mln_geojson_source_options
 import org.maplibre.nativeffi.internal.c.mln_geometry
 import org.maplibre.nativeffi.internal.c.mln_geometry_collection
 import org.maplibre.nativeffi.internal.c.mln_json_member
@@ -172,6 +173,7 @@ import org.maplibre.nativeffi.runtime.OfflineOperationResultKind
 import org.maplibre.nativeffi.runtime.RuntimeEventPayload
 import org.maplibre.nativeffi.runtime.RuntimeOptions
 import org.maplibre.nativeffi.style.CustomGeometrySourceOptions
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.LocationIndicatorImageKind
 import org.maplibre.nativeffi.style.SourceInfo
 import org.maplibre.nativeffi.style.SourceType
@@ -599,20 +601,40 @@ internal object NativeAccess {
       styleIdList(outList.get(ValueLayout.ADDRESS, 0))
     }
 
-  internal fun addGeoJsonSourceUrl(map: MemorySegment, sourceId: String, url: String) {
+  internal fun addGeoJsonSourceUrl(
+    map: MemorySegment,
+    sourceId: String,
+    url: String,
+    options: GeoJsonSourceOptions?,
+  ) {
     Arena.ofConfined().use { arena ->
       Status.check(
-        mapTwoStringViewsStatusFunction("mln_map_add_geojson_source_url")
-          .invokeWithArguments(map, stringView(arena, sourceId), stringView(arena, url)) as Int
+        mapTwoStringViewsAddressStatusFunction("mln_map_add_geojson_source_url")
+          .invokeWithArguments(
+            map,
+            stringView(arena, sourceId),
+            stringView(arena, url),
+            geoJsonSourceOptions(arena, options),
+          ) as Int
       )
     }
   }
 
-  internal fun addGeoJsonSourceData(map: MemorySegment, sourceId: String, data: GeoJson) {
+  internal fun addGeoJsonSourceData(
+    map: MemorySegment,
+    sourceId: String,
+    data: GeoJson,
+    options: GeoJsonSourceOptions?,
+  ) {
     Arena.ofConfined().use { arena ->
       Status.check(
-        mapStringViewAddressStatusFunction("mln_map_add_geojson_source_data")
-          .invokeWithArguments(map, stringView(arena, sourceId), geoJson(arena, data)) as Int
+        mapStringViewTwoAddressStatusFunction("mln_map_add_geojson_source_data")
+          .invokeWithArguments(
+            map,
+            stringView(arena, sourceId),
+            geoJson(arena, data),
+            geoJsonSourceOptions(arena, options),
+          ) as Int
       )
     }
   }
@@ -3111,6 +3133,69 @@ internal object NativeAccess {
     return segment
   }
 
+  private fun geoJsonSourceOptions(arena: Arena, value: GeoJsonSourceOptions?): MemorySegment {
+    if (value == null) {
+      return MemorySegment.NULL
+    }
+    val segment = arena.allocate(GEOJSON_SOURCE_OPTIONS_SIZE)
+    var fields = 0
+    segment.set(
+      ValueLayout.JAVA_INT,
+      GEOJSON_SOURCE_OPTIONS_SIZE_OFFSET,
+      GEOJSON_SOURCE_OPTIONS_SIZE.toInt(),
+    )
+    value.minZoom?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_MIN_ZOOM
+      segment.set(ValueLayout.JAVA_DOUBLE, GEOJSON_SOURCE_OPTIONS_MIN_ZOOM_OFFSET, it)
+    }
+    value.maxZoom?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_MAX_ZOOM
+      segment.set(ValueLayout.JAVA_DOUBLE, GEOJSON_SOURCE_OPTIONS_MAX_ZOOM_OFFSET, it)
+    }
+    value.tolerance?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_TOLERANCE
+      segment.set(ValueLayout.JAVA_DOUBLE, GEOJSON_SOURCE_OPTIONS_TOLERANCE_OFFSET, it)
+    }
+    value.clusterMaxZoom?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM
+      segment.set(ValueLayout.JAVA_DOUBLE, GEOJSON_SOURCE_OPTIONS_CLUSTER_MAX_ZOOM_OFFSET, it)
+    }
+    value.clusterProperties?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+      segment.set(
+        ValueLayout.ADDRESS,
+        GEOJSON_SOURCE_OPTIONS_CLUSTER_PROPERTIES_OFFSET,
+        jsonValue(arena, it),
+      )
+    }
+    value.tileSize?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_TILE_SIZE
+      segment.set(ValueLayout.JAVA_INT, GEOJSON_SOURCE_OPTIONS_TILE_SIZE_OFFSET, it)
+    }
+    value.buffer?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_BUFFER
+      segment.set(ValueLayout.JAVA_INT, GEOJSON_SOURCE_OPTIONS_BUFFER_OFFSET, it)
+    }
+    value.clusterRadius?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS
+      segment.set(ValueLayout.JAVA_INT, GEOJSON_SOURCE_OPTIONS_CLUSTER_RADIUS_OFFSET, it)
+    }
+    value.clusterMinPoints?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+      segment.set(ValueLayout.JAVA_INT, GEOJSON_SOURCE_OPTIONS_CLUSTER_MIN_POINTS_OFFSET, it)
+    }
+    value.lineMetrics?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_LINE_METRICS
+      segment.set(ValueLayout.JAVA_BOOLEAN, GEOJSON_SOURCE_OPTIONS_LINE_METRICS_OFFSET, it)
+    }
+    value.cluster?.let {
+      fields = fields or GEOJSON_SOURCE_OPTION_CLUSTER
+      segment.set(ValueLayout.JAVA_BOOLEAN, GEOJSON_SOURCE_OPTIONS_CLUSTER_OFFSET, it)
+    }
+    segment.set(ValueLayout.JAVA_INT, GEOJSON_SOURCE_OPTIONS_FIELDS_OFFSET, fields)
+    return segment
+  }
+
   private fun edgeInsets(segment: MemorySegment): EdgeInsets =
     EdgeInsets(
       segment.get(ValueLayout.JAVA_DOUBLE, EDGE_INSETS_TOP_OFFSET),
@@ -5313,6 +5398,45 @@ internal object NativeAccess {
     mln_style_tile_source_options.`vector_encoding$offset`()
   private val TILE_SOURCE_OPTIONS_RASTER_ENCODING_OFFSET: Long =
     mln_style_tile_source_options.`raster_encoding$offset`()
+
+  private const val GEOJSON_SOURCE_OPTION_MIN_ZOOM: Int = 1 shl 0
+  private const val GEOJSON_SOURCE_OPTION_MAX_ZOOM: Int = 1 shl 1
+  private const val GEOJSON_SOURCE_OPTION_TOLERANCE: Int = 1 shl 2
+  private const val GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM: Int = 1 shl 3
+  private const val GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES: Int = 1 shl 4
+  private const val GEOJSON_SOURCE_OPTION_TILE_SIZE: Int = 1 shl 5
+  private const val GEOJSON_SOURCE_OPTION_BUFFER: Int = 1 shl 6
+  private const val GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS: Int = 1 shl 7
+  private const val GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS: Int = 1 shl 8
+  private const val GEOJSON_SOURCE_OPTION_LINE_METRICS: Int = 1 shl 9
+  private const val GEOJSON_SOURCE_OPTION_CLUSTER: Int = 1 shl 10
+
+  private val GEOJSON_SOURCE_OPTIONS_SIZE: Long = mln_geojson_source_options.sizeof()
+  private val GEOJSON_SOURCE_OPTIONS_SIZE_OFFSET: Long = mln_geojson_source_options.`size$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_FIELDS_OFFSET: Long =
+    mln_geojson_source_options.`fields$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_MIN_ZOOM_OFFSET: Long =
+    mln_geojson_source_options.`min_zoom$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_MAX_ZOOM_OFFSET: Long =
+    mln_geojson_source_options.`max_zoom$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_TOLERANCE_OFFSET: Long =
+    mln_geojson_source_options.`tolerance$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_CLUSTER_MAX_ZOOM_OFFSET: Long =
+    mln_geojson_source_options.`cluster_max_zoom$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_CLUSTER_PROPERTIES_OFFSET: Long =
+    mln_geojson_source_options.`cluster_properties$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_TILE_SIZE_OFFSET: Long =
+    mln_geojson_source_options.`tile_size$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_BUFFER_OFFSET: Long =
+    mln_geojson_source_options.`buffer$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_CLUSTER_RADIUS_OFFSET: Long =
+    mln_geojson_source_options.`cluster_radius$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_CLUSTER_MIN_POINTS_OFFSET: Long =
+    mln_geojson_source_options.`cluster_min_points$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_LINE_METRICS_OFFSET: Long =
+    mln_geojson_source_options.`line_metrics$offset`()
+  private val GEOJSON_SOURCE_OPTIONS_CLUSTER_OFFSET: Long =
+    mln_geojson_source_options.`cluster$offset`()
 
   private const val CUSTOM_GEOMETRY_SOURCE_OPTION_MIN_ZOOM: Int = 1 shl 0
   private const val CUSTOM_GEOMETRY_SOURCE_OPTION_MAX_ZOOM: Int = 1 shl 1

--- a/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/jvmMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -27,6 +27,7 @@ import org.maplibre.nativeffi.render.VulkanOwnedTextureDescriptor
 import org.maplibre.nativeffi.render.VulkanSurfaceDescriptor
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.style.CustomGeometrySourceOptions
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.LocationIndicatorImageKind
 import org.maplibre.nativeffi.style.SourceInfo
 import org.maplibre.nativeffi.style.SourceType
@@ -93,14 +94,22 @@ private constructor(
     return NativeAccess.styleSourceIds(requireLiveHandle())
   }
 
-  public actual fun addGeoJsonSourceUrl(sourceId: String, url: String) {
+  public actual fun addGeoJsonSourceUrl(
+    sourceId: String,
+    url: String,
+    options: GeoJsonSourceOptions?,
+  ) {
     NativeAccess.ensureLoaded()
-    NativeAccess.addGeoJsonSourceUrl(requireLiveHandle(), sourceId, url)
+    NativeAccess.addGeoJsonSourceUrl(requireLiveHandle(), sourceId, url, options)
   }
 
-  public actual fun addGeoJsonSourceData(sourceId: String, data: GeoJson) {
+  public actual fun addGeoJsonSourceData(
+    sourceId: String,
+    data: GeoJson,
+    options: GeoJsonSourceOptions?,
+  ) {
     NativeAccess.ensureLoaded()
-    NativeAccess.addGeoJsonSourceData(requireLiveHandle(), sourceId, data)
+    NativeAccess.addGeoJsonSourceData(requireLiveHandle(), sourceId, data, options)
   }
 
   public actual fun setGeoJsonSourceUrl(sourceId: String, url: String) {

--- a/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/map/MapHandleTest.kt
+++ b/bindings/kotlin/src/jvmTest/kotlin/org/maplibre/nativeffi/map/MapHandleTest.kt
@@ -37,6 +37,7 @@ import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.runtime.RuntimeOptions
 import org.maplibre.nativeffi.style.CustomGeometrySourceCallback
 import org.maplibre.nativeffi.style.CustomGeometrySourceOptions
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.RasterDemEncoding
 import org.maplibre.nativeffi.style.SourceType
 import org.maplibre.nativeffi.style.StyleImageOptions
@@ -150,16 +151,52 @@ class MapHandleTest {
 
     try {
       map.setStyleJson("""{"version":8,"sources":{},"layers":[]}""")
-      map.addGeoJsonSourceUrl("remote-places", "https://example.com/places.geojson")
+      map.addGeoJsonSourceUrl("remote-places", "https://example.com/places.geojson", null)
       assertEquals(SourceType.GEOJSON, map.styleSourceType("remote-places"))
       map.setGeoJsonSourceUrl("remote-places", "https://example.com/updated.geojson")
 
-      map.addGeoJsonSourceData("inline-places", geoJsonData())
+      map.addGeoJsonSourceData(
+        "inline-places",
+        geoJsonData(),
+        GeoJsonSourceOptions().apply {
+          minZoom = 0.0
+          maxZoom = 14.0
+          tolerance = 0.5
+          tileSize = 256
+          buffer = 64
+          lineMetrics = true
+        },
+      )
       assertEquals(SourceType.GEOJSON, map.styleSourceType("inline-places"))
       map.setGeoJsonSourceData(
         "inline-places",
         GeoJson.GeometryValue(Geometry.LineString(listOf(LatLng(0.0, 0.0), LatLng(1.0, 1.0)))),
       )
+
+      map.addGeoJsonSourceData("clustered-places", nearbyPoints(), clusterOptions())
+      assertEquals(SourceType.GEOJSON, map.styleSourceType("clustered-places"))
+
+      // Option values reach native validation rather than being dropped by the binding.
+      assertFailsWith<InvalidArgumentException> {
+        map.addGeoJsonSourceUrl(
+          "invalid-zooms",
+          "https://example.com/places.geojson",
+          GeoJsonSourceOptions().apply {
+            minZoom = 12.0
+            maxZoom = 4.0
+          },
+        )
+      }
+      assertFalse(map.styleSourceExists("invalid-zooms"))
+      assertFailsWith<InvalidArgumentException> {
+        map.addGeoJsonSourceUrl(
+          "invalid-cluster-properties",
+          "https://example.com/places.geojson",
+          GeoJsonSourceOptions().apply {
+            clusterProperties = JsonValue.StringValue("not an object")
+          },
+        )
+      }
     } finally {
       map.close()
       runtime.close()
@@ -714,6 +751,42 @@ class MapHandleTest {
         ),
       )
     )
+
+  /** Point features close enough together to collapse into one cluster at low zoom. */
+  private fun nearbyPoints(): GeoJson =
+    GeoJson.FeatureCollection(
+      List(4) { index ->
+        Feature(
+          Geometry.Point(LatLng(index * 0.001, index * 0.001)),
+          listOf(JsonValue.Member("weight", JsonValue.UInt(1))),
+          FeatureIdentifier.UInt(index.toLong()),
+        )
+      }
+    )
+
+  private fun clusterOptions(): GeoJsonSourceOptions =
+    GeoJsonSourceOptions().apply {
+      cluster = true
+      clusterRadius = 50
+      clusterMaxZoom = 14.0
+      clusterMinPoints = 2
+      clusterProperties =
+        JsonValue.ObjectValue(
+          listOf(
+            JsonValue.Member(
+              "total",
+              JsonValue.Array(
+                listOf(
+                  JsonValue.StringValue("+"),
+                  JsonValue.Array(
+                    listOf(JsonValue.StringValue("get"), JsonValue.StringValue("weight"))
+                  ),
+                )
+              ),
+            )
+          )
+        )
+    }
 
   private fun geoJsonData(): GeoJson =
     GeoJson.FeatureCollection(

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/internal/struct/StyleStructs.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/internal/struct/StyleStructs.kt
@@ -15,6 +15,17 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.toCValues
 import kotlinx.cinterop.value
 import org.maplibre.nativeffi.geo.CanonicalTileId
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_BUFFER
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_TOLERANCE
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_IMAGE_OPTION_PIXEL_RATIO
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_IMAGE_OPTION_SDF
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_TILE_SOURCE_OPTION_ATTRIBUTION
@@ -26,6 +37,8 @@ import org.maplibre.nativeffi.internal.c.MLN_STYLE_TILE_SOURCE_OPTION_SCHEME
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_TILE_SOURCE_OPTION_VECTOR_ENCODING
 import org.maplibre.nativeffi.internal.c.mln_canonical_tile_id
+import org.maplibre.nativeffi.internal.c.mln_geojson_source_options
+import org.maplibre.nativeffi.internal.c.mln_geojson_source_options_default
 import org.maplibre.nativeffi.internal.c.mln_premultiplied_rgba8_image
 import org.maplibre.nativeffi.internal.c.mln_premultiplied_rgba8_image_default
 import org.maplibre.nativeffi.internal.c.mln_string_view
@@ -40,6 +53,7 @@ import org.maplibre.nativeffi.internal.c.mln_style_tile_source_options
 import org.maplibre.nativeffi.internal.c.mln_style_tile_source_options_default
 import org.maplibre.nativeffi.internal.status.Status
 import org.maplibre.nativeffi.render.PremultipliedRgba8Image
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.SourceInfo
 import org.maplibre.nativeffi.style.SourceType
 import org.maplibre.nativeffi.style.StyleImageInfo
@@ -158,6 +172,60 @@ internal object StyleStructs {
     value.rasterDemEncoding?.let {
       native.fields = native.fields or MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING
       native.raster_encoding = it.nativeValue.toUInt()
+    }
+    return native.ptr
+  }
+
+  fun geoJsonSourceOptions(
+    value: GeoJsonSourceOptions?,
+    scope: MemScope,
+  ): CPointer<mln_geojson_source_options>? {
+    if (value == null) return null
+    val native = scope.alloc<mln_geojson_source_options>()
+    mln_geojson_source_options_default().place(native.ptr)
+    value.minZoom?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM
+      native.min_zoom = it
+    }
+    value.maxZoom?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM
+      native.max_zoom = it
+    }
+    value.tolerance?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_TOLERANCE
+      native.tolerance = it
+    }
+    value.clusterMaxZoom?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM
+      native.cluster_max_zoom = it
+    }
+    value.clusterProperties?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+      native.cluster_properties = ValueStructs.jsonValue(it, scope)
+    }
+    value.tileSize?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE
+      native.tile_size = it.toUInt()
+    }
+    value.buffer?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_BUFFER
+      native.buffer = it.toUInt()
+    }
+    value.clusterRadius?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS
+      native.cluster_radius = it.toUInt()
+    }
+    value.clusterMinPoints?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+      native.cluster_min_points = it.toUInt()
+    }
+    value.lineMetrics?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS
+      native.line_metrics = it
+    }
+    value.cluster?.let {
+      native.fields = native.fields or MLN_GEOJSON_SOURCE_OPTION_CLUSTER
+      native.cluster = it
     }
     return native.ptr
   }

--- a/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
+++ b/bindings/kotlin/src/nativeMain/kotlin/org/maplibre/nativeffi/map/MapHandle.kt
@@ -169,6 +169,7 @@ import org.maplibre.nativeffi.render.VulkanOwnedTextureDescriptor
 import org.maplibre.nativeffi.render.VulkanSurfaceDescriptor
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.style.CustomGeometrySourceOptions
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.LocationIndicatorImageKind
 import org.maplibre.nativeffi.style.SourceInfo
 import org.maplibre.nativeffi.style.SourceType
@@ -272,25 +273,35 @@ private constructor(private val runtime: RuntimeHandle, handle: CPointer<mln_map
     StyleStructs.styleIdList(requireNotNull(outList.value))
   }
 
-  public actual fun addGeoJsonSourceUrl(sourceId: String, url: String) {
+  public actual fun addGeoJsonSourceUrl(
+    sourceId: String,
+    url: String,
+    options: GeoJsonSourceOptions?,
+  ) {
     memScoped {
       Status.check(
         mln_map_add_geojson_source_url(
           state.requireLive(),
           CoreStructs.stringView(sourceId, this),
           CoreStructs.stringView(url, this),
+          StyleStructs.geoJsonSourceOptions(options, this),
         )
       )
     }
   }
 
-  public actual fun addGeoJsonSourceData(sourceId: String, data: GeoJson) {
+  public actual fun addGeoJsonSourceData(
+    sourceId: String,
+    data: GeoJson,
+    options: GeoJsonSourceOptions?,
+  ) {
     memScoped {
       Status.check(
         mln_map_add_geojson_source_data(
           state.requireLive(),
           CoreStructs.stringView(sourceId, this),
           ValueStructs.geoJson(data, this),
+          StyleStructs.geoJsonSourceOptions(options, this),
         )
       )
     }

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/internal/struct/StyleStructsTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/internal/struct/StyleStructsTest.kt
@@ -3,6 +3,7 @@ package org.maplibre.nativeffi.internal.struct
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
@@ -15,15 +16,23 @@ import kotlinx.cinterop.sizeOf
 import org.maplibre.nativeffi.error.MaplibreStatus
 import org.maplibre.nativeffi.geo.LatLng
 import org.maplibre.nativeffi.geo.LatLngBounds
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+import org.maplibre.nativeffi.internal.c.MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_IMAGE_OPTION_PIXEL_RATIO
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_IMAGE_OPTION_SDF
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_TILE_SOURCE_OPTION_BOUNDS
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_TILE_SOURCE_OPTION_MIN_ZOOM
 import org.maplibre.nativeffi.internal.c.MLN_STYLE_TILE_SOURCE_OPTION_TILE_SIZE
+import org.maplibre.nativeffi.internal.c.mln_geojson_source_options
+import org.maplibre.nativeffi.internal.c.mln_geojson_source_options_default
 import org.maplibre.nativeffi.internal.c.mln_style_image_info
 import org.maplibre.nativeffi.internal.c.mln_style_image_options
 import org.maplibre.nativeffi.internal.c.mln_style_source_info
 import org.maplibre.nativeffi.internal.c.mln_style_tile_source_options
+import org.maplibre.nativeffi.json.JsonValue
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.SourceType
 import org.maplibre.nativeffi.style.StyleImageOptions
 import org.maplibre.nativeffi.style.TileSourceOptions
@@ -73,6 +82,62 @@ class StyleStructsTest : org.maplibre.nativeffi.NativeTestBase() {
       assertEquals(0U, source.tile_size)
       assertEquals(0.0, source.bounds.southwest.latitude)
       assertEquals(0.0, source.bounds.northeast.longitude)
+    }
+  }
+
+  @Test
+  fun geoJsonSourceOptionsKeepNativeDefaultsAndMaskPresentZeroValues() {
+    memScoped {
+      assertNull(StyleStructs.geoJsonSourceOptions(null, this))
+
+      val clusterProperties =
+        JsonValue.ObjectValue(
+          listOf(
+            JsonValue.Member(
+              "weight",
+              JsonValue.Array(
+                listOf(
+                  JsonValue.StringValue("+"),
+                  JsonValue.Array(
+                    listOf(JsonValue.StringValue("get"), JsonValue.StringValue("weight"))
+                  ),
+                )
+              ),
+            )
+          )
+        )
+      val options =
+        StyleStructs.geoJsonSourceOptions(
+            GeoJsonSourceOptions().apply {
+              minZoom = 0.0
+              clusterMinPoints = 0
+              cluster = false
+              this.clusterProperties = clusterProperties
+            },
+            this,
+          )!!
+          .pointed
+
+      assertEquals(sizeOf<mln_geojson_source_options>().toUInt(), options.size)
+      assertEquals(
+        MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM or
+          MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS or
+          MLN_GEOJSON_SOURCE_OPTION_CLUSTER or
+          MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES,
+        options.fields,
+      )
+      assertEquals(0.0, options.min_zoom)
+      assertEquals(0U, options.cluster_min_points)
+      assertEquals(false, options.cluster)
+      assertEquals(clusterProperties, ValueStructs.jsonSnapshot(options.cluster_properties))
+
+      // Fields left absent keep the values mln_geojson_source_options_default() wrote.
+      val defaults = alloc<mln_geojson_source_options>()
+      mln_geojson_source_options_default().place(defaults.ptr)
+      assertEquals(defaults.max_zoom, options.max_zoom)
+      assertEquals(defaults.tolerance, options.tolerance)
+      assertEquals(defaults.tile_size, options.tile_size)
+      assertEquals(defaults.cluster_radius, options.cluster_radius)
     }
   }
 

--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/StyleHandleTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/StyleHandleTest.kt
@@ -29,6 +29,7 @@ import org.maplibre.nativeffi.runtime.RuntimeEventType
 import org.maplibre.nativeffi.runtime.RuntimeHandle
 import org.maplibre.nativeffi.style.CustomGeometrySourceCallback
 import org.maplibre.nativeffi.style.CustomGeometrySourceOptions
+import org.maplibre.nativeffi.style.GeoJsonSourceOptions
 import org.maplibre.nativeffi.style.LocationIndicatorImageKind
 import org.maplibre.nativeffi.style.RasterDemEncoding
 import org.maplibre.nativeffi.style.SourceType
@@ -527,9 +528,51 @@ class StyleHandleTest : org.maplibre.nativeffi.NativeTestBase() {
             )
           )
         ),
+        GeoJsonSourceOptions().apply {
+          minZoom = 0.0
+          maxZoom = 14.0
+          tolerance = 0.5
+          tileSize = 256
+          buffer = 64
+          lineMetrics = true
+          cluster = true
+          clusterRadius = 40
+          clusterMaxZoom = 13.0
+          clusterMinPoints = 2
+          clusterProperties =
+            JsonValue.ObjectValue(
+              listOf(
+                JsonValue.Member(
+                  "total",
+                  JsonValue.Array(
+                    listOf(
+                      JsonValue.StringValue("+"),
+                      JsonValue.Array(
+                        listOf(JsonValue.StringValue("get"), JsonValue.StringValue("weight"))
+                      ),
+                    )
+                  ),
+                )
+              )
+            )
+        },
       )
       assertEquals(SourceType.GEOJSON, map.styleSourceType("points"))
       map.setGeoJsonSourceData("points", GeoJson.GeometryValue(Geometry.Point(LatLng(1.0, 1.0))))
+
+      // Option values reach native validation rather than being dropped by the binding.
+      assertFailsWith<InvalidArgumentException> {
+        map.addGeoJsonSourceUrl(
+          "invalid-zooms",
+          "https://example.com/places.geojson",
+          GeoJsonSourceOptions().apply {
+            minZoom = 12.0
+            maxZoom = 4.0
+          },
+        )
+      }
+      assertFalse(map.styleSourceExists("invalid-zooms"))
+
       assertTrue(map.removeStyleSource("points"))
     } finally {
       map.close()

--- a/bindings/python/python/maplibre_native/_native.pyi
+++ b/bindings/python/python/maplibre_native/_native.pyi
@@ -211,8 +211,38 @@ class _MapHandle:
     def pixels_for_lat_lngs(self, coordinates: Sequence[_Point]) -> list[_WireDict]: ...
     def lat_lngs_for_pixels(self, points: Sequence[_Point]) -> list[_WireDict]: ...
     def add_style_source_json(self, source_id: str, source_json: object) -> None: ...
-    def add_geojson_source_url(self, source_id: str, url: str) -> None: ...
-    def add_geojson_source_data(self, source_id: str, data: object) -> None: ...
+    def add_geojson_source_url(
+        self,
+        source_id: str,
+        url: str,
+        min_zoom: float | None,
+        max_zoom: float | None,
+        tolerance: float | None,
+        cluster_max_zoom: float | None,
+        cluster_properties: object | None,
+        tile_size: int | None,
+        buffer: int | None,
+        cluster_radius: int | None,
+        cluster_min_points: int | None,
+        line_metrics: bool | None,
+        cluster: bool | None,
+    ) -> None: ...
+    def add_geojson_source_data(
+        self,
+        source_id: str,
+        data: object,
+        min_zoom: float | None,
+        max_zoom: float | None,
+        tolerance: float | None,
+        cluster_max_zoom: float | None,
+        cluster_properties: object | None,
+        tile_size: int | None,
+        buffer: int | None,
+        cluster_radius: int | None,
+        cluster_min_points: int | None,
+        line_metrics: bool | None,
+        cluster: bool | None,
+    ) -> None: ...
     def set_geojson_source_url(self, source_id: str, url: str) -> None: ...
     def set_geojson_source_data(self, source_id: str, data: object) -> None: ...
     def add_vector_source_url(

--- a/bindings/python/python/maplibre_native/map.py
+++ b/bindings/python/python/maplibre_native/map.py
@@ -41,6 +41,7 @@ from .style import (
     CanonicalTileId,
     CustomGeometrySourceHandle,
     CustomGeometrySourceOptions,
+    GeoJsonSourceOptions,
     LocationIndicatorImageKind,
     StyleImage,
     StyleImageInfo,
@@ -333,6 +334,50 @@ def _tile_source_parts(
     )
 
 
+def _geojson_source_parts(
+    options: GeoJsonSourceOptions | None,
+) -> tuple[
+    float | None,
+    float | None,
+    float | None,
+    float | None,
+    JsonValue | None,
+    int | None,
+    int | None,
+    int | None,
+    int | None,
+    bool | None,
+    bool | None,
+]:
+    if options is None:
+        return (
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    return (
+        options.min_zoom,
+        options.max_zoom,
+        options.tolerance,
+        options.cluster_max_zoom,
+        options.cluster_properties,
+        options.tile_size,
+        options.buffer,
+        options.cluster_radius,
+        options.cluster_min_points,
+        options.line_metrics,
+        options.cluster,
+    )
+
+
 def projected_meters_for_lat_lng(coordinate: LatLng) -> ProjectedMeters:
     """Convert a geographic coordinate to spherical Mercator projected meters."""
     raw = _native.projected_meters_for_lat_lng(
@@ -577,13 +622,27 @@ class MapHandle(NativeHandleMixin):
         """Add one style source from a style-spec source JSON object."""
         self._native.add_style_source_json(source_id, source_json)
 
-    def add_geojson_source_url(self, source_id: str, url: str) -> None:
+    def add_geojson_source_url(
+        self,
+        source_id: str,
+        url: str,
+        options: GeoJsonSourceOptions | None = None,
+    ) -> None:
         """Add a GeoJSON source that loads data from a URL."""
-        self._native.add_geojson_source_url(source_id, url)
+        self._native.add_geojson_source_url(
+            source_id, url, *_geojson_source_parts(options)
+        )
 
-    def add_geojson_source_data(self, source_id: str, data: GeoJson) -> None:
+    def add_geojson_source_data(
+        self,
+        source_id: str,
+        data: GeoJson,
+        options: GeoJsonSourceOptions | None = None,
+    ) -> None:
         """Add a GeoJSON source with inline data."""
-        self._native.add_geojson_source_data(source_id, data)
+        self._native.add_geojson_source_data(
+            source_id, data, *_geojson_source_parts(options)
+        )
 
     def set_geojson_source_url(self, source_id: str, url: str) -> None:
         """Update one GeoJSON source to load data from a URL."""

--- a/bindings/python/python/maplibre_native/style.py
+++ b/bindings/python/python/maplibre_native/style.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from .geo import LatLngBounds
+from .errors import InvalidArgumentError
 from .json import JsonValue
 from .render import PremultipliedRgba8Image, TextureImageInfo
 
@@ -70,6 +71,14 @@ class GeoJsonSourceOptions:
     cluster_min_points: int | None = None
     line_metrics: bool | None = None
     cluster: bool | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("tile_size", "buffer", "cluster_radius", "cluster_min_points"):
+            value = getattr(self, name)
+            if value is not None and not 0 <= value <= 0xFFFF_FFFF:
+                raise InvalidArgumentError(
+                    None, f"{name} must be within [0, 4294967295]"
+                )
 
 
 class StyleSourceType(UnknownIntEnum):

--- a/bindings/python/python/maplibre_native/style.py
+++ b/bindings/python/python/maplibre_native/style.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from .geo import LatLngBounds
+from .json import JsonValue
 from .render import PremultipliedRgba8Image, TextureImageInfo
 
 _CUSTOM_GEOMETRY_SOURCE_HANDLE_CREATE_KEY = object()
@@ -46,6 +47,29 @@ class TileSourceOptions:
     tile_size: int | None = None
     vector_encoding: VectorTileEncoding | None = None
     raster_dem_encoding: RasterDemEncoding | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GeoJsonSourceOptions:
+    """Options for GeoJSON sources.
+
+    MapLibre Native fixes these options when the source is created, so updating
+    a GeoJSON source's URL or data keeps the options it was added with.
+    """
+
+    min_zoom: float | None = None
+    max_zoom: float | None = None
+    tolerance: float | None = None
+    cluster_max_zoom: float | None = None
+    cluster_properties: JsonValue | None = None
+    """Cluster aggregation expressions keyed by property name, as a JSON object
+    whose members follow the MapLibre Style Spec `clusterProperties` form."""
+    tile_size: int | None = None
+    buffer: int | None = None
+    cluster_radius: int | None = None
+    cluster_min_points: int | None = None
+    line_metrics: bool | None = None
+    cluster: bool | None = None
 
 
 class StyleSourceType(UnknownIntEnum):
@@ -228,6 +252,7 @@ __all__ = [
     "CustomGeometrySourceEventType",
     "CustomGeometrySourceHandle",
     "CustomGeometrySourceOptions",
+    "GeoJsonSourceOptions",
     "LocationIndicatorImageKind",
     "RasterDemEncoding",
     "StyleImage",

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2048,25 +2048,97 @@ impl MapHandle {
         .map_err(map_error)
     }
 
-    fn add_geojson_source_url(&self, source_id: String, url: String) -> PyResult<()> {
+    #[allow(clippy::too_many_arguments)]
+    fn add_geojson_source_url(
+        &self,
+        source_id: String,
+        url: String,
+        min_zoom: Option<f64>,
+        max_zoom: Option<f64>,
+        tolerance: Option<f64>,
+        cluster_max_zoom: Option<f64>,
+        cluster_properties: Option<Bound<'_, PyAny>>,
+        tile_size: Option<u32>,
+        buffer: Option<u32>,
+        cluster_radius: Option<u32>,
+        cluster_min_points: Option<u32>,
+        line_metrics: Option<bool>,
+        cluster: Option<bool>,
+    ) -> PyResult<()> {
         let state = self.state();
         let source_id = maplibre_core::string::string_view(&source_id);
         let url = maplibre_core::string::string_view(&url);
-        // SAFETY: The C API validates the map pointer and borrowed string views.
+        let options = geojson_source_options_from_parts(
+            min_zoom,
+            max_zoom,
+            tolerance,
+            cluster_max_zoom,
+            cluster_properties,
+            tile_size,
+            buffer,
+            cluster_radius,
+            cluster_min_points,
+            line_metrics,
+            cluster,
+        )?;
+        let options =
+            maplibre_core::style::geojson_source_options_to_native(&options).map_err(map_error)?;
+        // SAFETY: The C API validates the map pointer, borrowed string views, and options.
         maplibre_core::check(unsafe {
-            sys::mln_map_add_geojson_source_url(state.as_ptr(), source_id.raw(), url.raw())
+            sys::mln_map_add_geojson_source_url(
+                state.as_ptr(),
+                source_id.raw(),
+                url.raw(),
+                options.as_ptr(),
+            )
         })
         .map_err(map_error)
     }
 
-    fn add_geojson_source_data(&self, source_id: String, data: &Bound<'_, PyAny>) -> PyResult<()> {
+    #[allow(clippy::too_many_arguments)]
+    fn add_geojson_source_data(
+        &self,
+        source_id: String,
+        data: &Bound<'_, PyAny>,
+        min_zoom: Option<f64>,
+        max_zoom: Option<f64>,
+        tolerance: Option<f64>,
+        cluster_max_zoom: Option<f64>,
+        cluster_properties: Option<Bound<'_, PyAny>>,
+        tile_size: Option<u32>,
+        buffer: Option<u32>,
+        cluster_radius: Option<u32>,
+        cluster_min_points: Option<u32>,
+        line_metrics: Option<bool>,
+        cluster: Option<bool>,
+    ) -> PyResult<()> {
         let state = self.state();
         let source_id = maplibre_core::string::string_view(&source_id);
         let data = geojson_from_wire(data)?;
         let data = maplibre_core::geojson::geojson_try_to_native(&data).map_err(map_error)?;
-        // SAFETY: The C API validates the map pointer, source ID, and GeoJSON descriptor.
+        let options = geojson_source_options_from_parts(
+            min_zoom,
+            max_zoom,
+            tolerance,
+            cluster_max_zoom,
+            cluster_properties,
+            tile_size,
+            buffer,
+            cluster_radius,
+            cluster_min_points,
+            line_metrics,
+            cluster,
+        )?;
+        let options =
+            maplibre_core::style::geojson_source_options_to_native(&options).map_err(map_error)?;
+        // SAFETY: The C API validates the map pointer, source ID, GeoJSON descriptor, and options.
         maplibre_core::check(unsafe {
-            sys::mln_map_add_geojson_source_data(state.as_ptr(), source_id.raw(), data.as_ptr())
+            sys::mln_map_add_geojson_source_data(
+                state.as_ptr(),
+                source_id.raw(),
+                data.as_ptr(),
+                options.as_ptr(),
+            )
         })
         .map_err(map_error)
     }
@@ -4534,6 +4606,57 @@ fn tile_source_options_from_parts(
                 )));
             }
         });
+    }
+    Ok(options)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn geojson_source_options_from_parts(
+    min_zoom: Option<f64>,
+    max_zoom: Option<f64>,
+    tolerance: Option<f64>,
+    cluster_max_zoom: Option<f64>,
+    cluster_properties: Option<Bound<'_, PyAny>>,
+    tile_size: Option<u32>,
+    buffer: Option<u32>,
+    cluster_radius: Option<u32>,
+    cluster_min_points: Option<u32>,
+    line_metrics: Option<bool>,
+    cluster: Option<bool>,
+) -> PyResult<maplibre_core::GeoJsonSourceOptions> {
+    let mut options = maplibre_core::GeoJsonSourceOptions::default();
+    if let Some(min_zoom) = min_zoom {
+        options.min_zoom = Some(min_zoom);
+    }
+    if let Some(max_zoom) = max_zoom {
+        options.max_zoom = Some(max_zoom);
+    }
+    if let Some(tolerance) = tolerance {
+        options.tolerance = Some(tolerance);
+    }
+    if let Some(cluster_max_zoom) = cluster_max_zoom {
+        options.cluster_max_zoom = Some(cluster_max_zoom);
+    }
+    if let Some(cluster_properties) = cluster_properties {
+        options.cluster_properties = Some(json_value_from_py(&cluster_properties)?);
+    }
+    if let Some(tile_size) = tile_size {
+        options.tile_size = Some(tile_size);
+    }
+    if let Some(buffer) = buffer {
+        options.buffer = Some(buffer);
+    }
+    if let Some(cluster_radius) = cluster_radius {
+        options.cluster_radius = Some(cluster_radius);
+    }
+    if let Some(cluster_min_points) = cluster_min_points {
+        options.cluster_min_points = Some(cluster_min_points);
+    }
+    if let Some(line_metrics) = line_metrics {
+        options.line_metrics = Some(line_metrics);
+    }
+    if let Some(cluster) = cluster {
+        options.cluster = Some(cluster);
     }
     Ok(options)
 }

--- a/bindings/python/tests/render_backend_helpers/runtime.py
+++ b/bindings/python/tests/render_backend_helpers/runtime.py
@@ -5,9 +5,26 @@ import time
 import pytest
 
 import maplibre_native as mln
-from maplibre_native import camera, geo, json, query, render
+from maplibre_native import camera, geo, json, query, render, style
 
 EMPTY_STYLE_JSON = '{"version":8,"sources":{},"layers":[]}'
+
+CLUSTER_POINTS = geo.FeatureCollection(
+    tuple(
+        geo.Feature(
+            geometry=geo.Point(geo.LatLng(offset, offset)),
+            properties=(
+                json.JsonMember("name", name),
+                json.JsonMember("weight", json.JsonInt(weight)),
+            ),
+        )
+        for offset, name, weight in (
+            (0.0, "one", 1),
+            (0.001, "two", 2),
+            (0.002, "three", 3),
+        )
+    )
+)
 
 CLUSTER_STYLE_JSON = (
     '{"version":8,"name":"python-cluster-query-test",'
@@ -98,16 +115,15 @@ def request_still_image_if_needed(map_handle: mln.MapHandle) -> None:
             raise
 
 
-def wait_for_rendered_cluster(
+def wait_for_rendered_layer_feature(
     runtime: mln.RuntimeHandle,
     map_handle: mln.MapHandle,
     session: render.RenderSessionHandle,
+    layer_id: str,
     *,
     iterations: int = 5000,
 ) -> query.QueriedFeature:
-    """Load the cluster style and return the first rendered cluster feature."""
-    map_handle.jump_to(camera.CameraOptions(center=geo.LatLng(0.0, 0.0), zoom=0.0))
-    map_handle.set_style_json(CLUSTER_STYLE_JSON)
+    """Render until one feature of `layer_id` covers the map center."""
     query_point = map_handle.pixel_for_lat_lng(geo.LatLng(0.0, 0.0))
     geometry = query.RenderedQueryGeometry.box_geometry(
         query.ScreenBox(
@@ -115,7 +131,7 @@ def wait_for_rendered_cluster(
             camera.ScreenPoint(query_point.x + 30.0, query_point.y + 30.0),
         )
     )
-    options = query.RenderedFeatureQueryOptions(layer_ids=("cluster-circle",))
+    options = query.RenderedFeatureQueryOptions(layer_ids=(layer_id,))
     for _ in range(iterations):
         request_still_image_if_needed(map_handle)
         runtime.run_once()
@@ -132,7 +148,26 @@ def wait_for_rendered_cluster(
         if features:
             return features[0]
         time.sleep(0.001)
-    raise AssertionError("cluster feature query returned no features")
+    raise AssertionError(f"rendered feature query for {layer_id} returned no features")
+
+
+def wait_for_rendered_cluster(
+    runtime: mln.RuntimeHandle,
+    map_handle: mln.MapHandle,
+    session: render.RenderSessionHandle,
+    *,
+    iterations: int = 5000,
+) -> query.QueriedFeature:
+    """Load the cluster style and return the first rendered cluster feature."""
+    map_handle.jump_to(camera.CameraOptions(center=geo.LatLng(0.0, 0.0), zoom=0.0))
+    map_handle.set_style_json(CLUSTER_STYLE_JSON)
+    return wait_for_rendered_layer_feature(
+        runtime,
+        map_handle,
+        session,
+        "cluster-circle",
+        iterations=iterations,
+    )
 
 
 def feature_member(feature: geo.Feature, key: str) -> json.JsonValue:
@@ -162,6 +197,51 @@ def single_cluster_leaf(
     assert leaves.feature_collection is not None
     assert len(leaves.feature_collection) == 1
     return leaves.feature_collection[0]
+
+
+def assert_typed_geojson_cluster_source(
+    runtime: mln.RuntimeHandle,
+    map_handle: mln.MapHandle,
+    session: render.RenderSessionHandle,
+) -> None:
+    """Cluster nearby points added through the typed GeoJSON source adder."""
+    map_handle.jump_to(camera.CameraOptions(center=geo.LatLng(0.0, 0.0), zoom=0.0))
+    map_handle.set_style_json(EMPTY_STYLE_JSON)
+    map_handle.add_geojson_source_data(
+        "typed-cluster-source",
+        CLUSTER_POINTS,
+        style.GeoJsonSourceOptions(
+            cluster=True,
+            cluster_radius=60,
+            cluster_min_points=2,
+            cluster_max_zoom=20.0,
+            # ["+", <map expression>] accumulates the mapped value per cluster.
+            cluster_properties=json.from_python(
+                {"weight_sum": ["+", ["get", "weight"]]}
+            ),
+        ),
+    )
+    map_handle.add_style_layer_json(
+        json.from_python(
+            {
+                "id": "typed-cluster-circle",
+                "type": "circle",
+                "source": "typed-cluster-source",
+                "filter": ["has", "point_count"],
+                "paint": {"circle-color": "#2563eb", "circle-radius": 20},
+            }
+        )
+    )
+
+    queried = wait_for_rendered_layer_feature(
+        runtime, map_handle, session, "typed-cluster-circle"
+    )
+    # The three source points only collapse into one feature when the options
+    # reach MapLibre Native, and weight_sum only appears with cluster
+    # properties.
+    assert json.to_python(feature_member(queried.feature, "cluster")) is True
+    assert json.to_python(feature_member(queried.feature, "point_count")) == 3
+    assert json.to_python(feature_member(queried.feature, "weight_sum")) == 6
 
 
 def assert_cluster_feature_extensions(

--- a/bindings/python/tests/test_package.py
+++ b/bindings/python/tests/test_package.py
@@ -869,6 +869,19 @@ def test_style_url_rejects_embedded_nul_before_native_call() -> None:
     assert raised.value.diagnostic != stale
 
 
+@pytest.mark.parametrize(
+    "field",
+    ("tile_size", "buffer", "cluster_radius", "cluster_min_points"),
+)
+def test_geojson_source_options_reject_negative_unsigned_fields(field: str) -> None:
+    with pytest.raises(mln.InvalidArgumentError) as raised:
+        style.GeoJsonSourceOptions(**{field: -1})
+
+    assert raised.value.status == mln.MaplibreStatus.INVALID_ARGUMENT
+    assert raised.value.native_status_code is None
+    assert field in raised.value.diagnostic
+
+
 def test_style_source_url_metadata_and_removal_public_api() -> None:
     with mln.RuntimeHandle() as runtime:
         with runtime.create_map() as map_handle:

--- a/bindings/python/tests/test_package.py
+++ b/bindings/python/tests/test_package.py
@@ -886,7 +886,16 @@ def test_style_source_url_metadata_and_removal_public_api() -> None:
                 ),
             )
             map_handle.add_geojson_source_url(
-                "points", "https://example.test/points.geojson"
+                "points",
+                "https://example.test/points.geojson",
+                style.GeoJsonSourceOptions(
+                    min_zoom=1.0,
+                    max_zoom=14.0,
+                    tolerance=0.5,
+                    tile_size=256,
+                    buffer=64,
+                    line_metrics=True,
+                ),
             )
             inline_points = geo.FeatureCollection(
                 (
@@ -897,7 +906,19 @@ def test_style_source_url_metadata_and_removal_public_api() -> None:
                     ),
                 )
             )
-            map_handle.add_geojson_source_data("inline-points", inline_points)
+            map_handle.add_geojson_source_data(
+                "inline-points",
+                inline_points,
+                style.GeoJsonSourceOptions(
+                    cluster=True,
+                    cluster_radius=40,
+                    cluster_max_zoom=12.0,
+                    cluster_min_points=3,
+                    cluster_properties=json.from_python(
+                        {"name_count": ["+", ["case", ["has", "name"], 1, 0]]}
+                    ),
+                ),
+            )
             map_handle.set_geojson_source_url(
                 "inline-points",
                 "https://example.test/inline-points.geojson",

--- a/bindings/python/tests/test_render_metal_owned.py
+++ b/bindings/python/tests/test_render_metal_owned.py
@@ -13,6 +13,7 @@ from maplibre_native import camera, geo, json, query, render
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
     assert_cluster_feature_extensions,
+    assert_typed_geojson_cluster_source,
     skip_or_fail_fixture_setup,
 )
 
@@ -420,6 +421,16 @@ def test_cluster_feature_extension_queries_resolve_unsigned_cluster_id_and_limit
     metal_owned_session: MetalOwnedSession,
 ) -> None:
     assert_cluster_feature_extensions(
+        metal_owned_session.runtime,
+        metal_owned_session.map,
+        metal_owned_session.session,
+    )
+
+
+def test_typed_geojson_source_options_cluster_nearby_points(
+    metal_owned_session: MetalOwnedSession,
+) -> None:
+    assert_typed_geojson_cluster_source(
         metal_owned_session.runtime,
         metal_owned_session.map,
         metal_owned_session.session,

--- a/bindings/python/tests/test_render_opengl_egl.py
+++ b/bindings/python/tests/test_render_opengl_egl.py
@@ -14,6 +14,7 @@ from maplibre_native import camera, geo, json, query, render
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
     assert_cluster_feature_extensions,
+    assert_typed_geojson_cluster_source,
     render_until_update,
     skip_or_fail_fixture_setup,
 )
@@ -588,6 +589,16 @@ def test_cluster_feature_extension_queries_resolve_unsigned_cluster_id_and_limit
     opengl_owned_session: OpenGLOwnedSession,
 ) -> None:
     assert_cluster_feature_extensions(
+        opengl_owned_session.runtime,
+        opengl_owned_session.map,
+        opengl_owned_session.session,
+    )
+
+
+def test_typed_geojson_source_options_cluster_nearby_points(
+    opengl_owned_session: OpenGLOwnedSession,
+) -> None:
+    assert_typed_geojson_cluster_source(
         opengl_owned_session.runtime,
         opengl_owned_session.map,
         opengl_owned_session.session,

--- a/bindings/python/tests/test_render_vulkan_owned.py
+++ b/bindings/python/tests/test_render_vulkan_owned.py
@@ -13,6 +13,7 @@ from maplibre_native import camera, geo, json, query, render
 from render_backend_helpers.runtime import (
     EMPTY_STYLE_JSON,
     assert_cluster_feature_extensions,
+    assert_typed_geojson_cluster_source,
     skip_or_fail_fixture_setup,
 )
 
@@ -463,6 +464,16 @@ def test_cluster_feature_extension_queries_resolve_unsigned_cluster_id_and_limit
     vulkan_owned_session: VulkanOwnedSession,
 ) -> None:
     assert_cluster_feature_extensions(
+        vulkan_owned_session.runtime,
+        vulkan_owned_session.map,
+        vulkan_owned_session.session,
+    )
+
+
+def test_typed_geojson_source_options_cluster_nearby_points(
+    vulkan_owned_session: VulkanOwnedSession,
+) -> None:
+    assert_typed_geojson_cluster_source(
         vulkan_owned_session.runtime,
         vulkan_owned_session.map,
         vulkan_owned_session.session,

--- a/bindings/rust/crates/maplibre-native-core/src/lib.rs
+++ b/bindings/rust/crates/maplibre-native-core/src/lib.rs
@@ -69,7 +69,9 @@ pub use runtime::{
     OfflineRegionDefinition, OfflineRegionInfo, RuntimeOptions, network_status, set_network_status,
     set_network_status_raw,
 };
-pub use style::{SourceInfo, StyleImage, StyleImageOptions, TileSourceOptions};
+pub use style::{
+    GeoJsonSourceOptions, SourceInfo, StyleImage, StyleImageOptions, TileSourceOptions,
+};
 pub use values::{
     EdgeInsets, LatLng, LatLngBounds, PremultipliedRgba8Image, ProjectedMeters, Quaternion,
     ScreenBox, ScreenPoint, StyleImageInfo, TextureImageInfo, UnitBezier, Vec3,

--- a/bindings/rust/crates/maplibre-native-core/src/style.rs
+++ b/bindings/rust/crates/maplibre-native-core/src/style.rs
@@ -5,6 +5,7 @@ use std::ptr::NonNull;
 use maplibre_native_sys as sys;
 
 use crate::enums::{RasterDemEncoding, SourceType, TileScheme, VectorTileEncoding};
+use crate::json::{JsonValue, NativeJsonValue, json_value_try_to_native};
 use crate::string::{StringView, string_view};
 use crate::values::{
     LatLngBounds, PremultipliedRgba8Image, StyleImageInfo, TextureImageInfo,
@@ -92,6 +93,120 @@ impl AsRef<sys::mln_style_tile_source_options> for NativeTileSourceOptions<'_> {
 
 pub fn tile_source_options_to_native(options: &TileSourceOptions) -> NativeTileSourceOptions<'_> {
     options.to_native()
+}
+
+/// Options for GeoJSON sources.
+///
+/// MapLibre Native fixes these options when the source is created, so updating
+/// a GeoJSON source's URL or data keeps the options it was added with.
+#[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
+pub struct GeoJsonSourceOptions {
+    pub min_zoom: Option<f64>,
+    pub max_zoom: Option<f64>,
+    pub tolerance: Option<f64>,
+    pub cluster_max_zoom: Option<f64>,
+    /// Cluster aggregation expressions keyed by property name, as a JSON object
+    /// whose members follow the MapLibre Style Spec `clusterProperties` form.
+    pub cluster_properties: Option<JsonValue>,
+    pub tile_size: Option<u32>,
+    pub buffer: Option<u32>,
+    pub cluster_radius: Option<u32>,
+    pub cluster_min_points: Option<u32>,
+    pub line_metrics: Option<bool>,
+    pub cluster: Option<bool>,
+}
+
+impl GeoJsonSourceOptions {
+    fn try_to_native(&self) -> crate::Result<NativeGeoJsonSourceOptions> {
+        NativeGeoJsonSourceOptions::new(self)
+    }
+}
+
+pub struct NativeGeoJsonSourceOptions {
+    raw: sys::mln_geojson_source_options,
+    _cluster_properties: Option<NativeJsonValue>,
+    _cluster_properties_raw: Option<Box<sys::mln_json_value>>,
+}
+
+impl NativeGeoJsonSourceOptions {
+    fn new(options: &GeoJsonSourceOptions) -> crate::Result<Self> {
+        // SAFETY: This C helper returns a plain value with no preconditions.
+        let mut raw = unsafe { sys::mln_geojson_source_options_default() };
+        if let Some(value) = options.min_zoom {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM;
+            raw.min_zoom = value;
+        }
+        if let Some(value) = options.max_zoom {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM;
+            raw.max_zoom = value;
+        }
+        if let Some(value) = options.tolerance {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_TOLERANCE;
+            raw.tolerance = value;
+        }
+        if let Some(value) = options.cluster_max_zoom {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM;
+            raw.cluster_max_zoom = value;
+        }
+        let cluster_properties = options
+            .cluster_properties
+            .as_ref()
+            .map(json_value_try_to_native)
+            .transpose()?;
+        let cluster_properties_raw = cluster_properties
+            .as_ref()
+            .map(|properties| Box::new(*properties.as_ref()));
+        if let Some(properties) = &cluster_properties_raw {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES;
+            raw.cluster_properties = properties.as_ref();
+        }
+        if let Some(value) = options.tile_size {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE;
+            raw.tile_size = value;
+        }
+        if let Some(value) = options.buffer {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_BUFFER;
+            raw.buffer = value;
+        }
+        if let Some(value) = options.cluster_radius {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS;
+            raw.cluster_radius = value;
+        }
+        if let Some(value) = options.cluster_min_points {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS;
+            raw.cluster_min_points = value;
+        }
+        if let Some(value) = options.line_metrics {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS;
+            raw.line_metrics = value;
+        }
+        if let Some(value) = options.cluster {
+            raw.fields |= sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER;
+            raw.cluster = value;
+        }
+        Ok(Self {
+            raw,
+            _cluster_properties: cluster_properties,
+            _cluster_properties_raw: cluster_properties_raw,
+        })
+    }
+
+    pub fn as_ptr(&self) -> *const sys::mln_geojson_source_options {
+        ptr::from_ref(&self.raw)
+    }
+}
+
+impl AsRef<sys::mln_geojson_source_options> for NativeGeoJsonSourceOptions {
+    fn as_ref(&self) -> &sys::mln_geojson_source_options {
+        &self.raw
+    }
+}
+
+pub fn geojson_source_options_to_native(
+    options: &GeoJsonSourceOptions,
+) -> crate::Result<NativeGeoJsonSourceOptions> {
+    options.try_to_native()
 }
 
 pub struct NativeTileUrls<'a> {
@@ -310,6 +425,17 @@ pub trait TileSourceOptionsNativeExt {
 impl TileSourceOptionsNativeExt for TileSourceOptions {
     fn to_native(&self) -> NativeTileSourceOptions<'_> {
         tile_source_options_to_native(self)
+    }
+}
+
+#[doc(hidden)]
+pub trait GeoJsonSourceOptionsNativeExt {
+    fn try_to_native(&self) -> crate::Result<NativeGeoJsonSourceOptions>;
+}
+
+impl GeoJsonSourceOptionsNativeExt for GeoJsonSourceOptions {
+    fn try_to_native(&self) -> crate::Result<NativeGeoJsonSourceOptions> {
+        geojson_source_options_to_native(self)
     }
 }
 

--- a/bindings/rust/crates/maplibre-native-core/src/style.rs
+++ b/bindings/rust/crates/maplibre-native-core/src/style.rs
@@ -538,6 +538,70 @@ mod tests {
     }
 
     #[test]
+    fn geojson_source_options_materialize_masks_fields_and_cluster_properties() {
+        let default_native =
+            geojson_source_options_to_native(&GeoJsonSourceOptions::default()).unwrap();
+        let default_raw = default_native.as_ref();
+        assert_eq!(
+            default_raw.size,
+            std::mem::size_of::<sys::mln_geojson_source_options>() as u32
+        );
+        assert_eq!(default_raw.fields, 0);
+        assert!(default_raw.cluster_properties.is_null());
+
+        let options = GeoJsonSourceOptions {
+            min_zoom: Some(0.0),
+            max_zoom: Some(14.0),
+            tolerance: Some(0.5),
+            cluster_max_zoom: Some(12.0),
+            cluster_properties: Some(JsonValue::Object(vec![crate::json::JsonMember::new(
+                "sum",
+                JsonValue::String("+".into()),
+            )])),
+            tile_size: Some(256),
+            buffer: Some(64),
+            cluster_radius: Some(60),
+            cluster_min_points: Some(3),
+            line_metrics: Some(false),
+            cluster: Some(true),
+        };
+
+        let native = geojson_source_options_to_native(&options).unwrap();
+        let raw = native.as_ref();
+
+        assert_eq!(
+            raw.fields,
+            sys::MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM
+                | sys::MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM
+                | sys::MLN_GEOJSON_SOURCE_OPTION_TOLERANCE
+                | sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM
+                | sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+                | sys::MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE
+                | sys::MLN_GEOJSON_SOURCE_OPTION_BUFFER
+                | sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS
+                | sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+                | sys::MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS
+                | sys::MLN_GEOJSON_SOURCE_OPTION_CLUSTER
+        );
+        // A present zero stays distinguishable from an absent field.
+        assert_eq!(raw.min_zoom, 0.0);
+        assert_eq!(raw.max_zoom, 14.0);
+        assert_eq!(raw.tolerance, 0.5);
+        assert_eq!(raw.cluster_max_zoom, 12.0);
+        assert_eq!(raw.tile_size, 256);
+        assert_eq!(raw.buffer, 64);
+        assert_eq!(raw.cluster_radius, 60);
+        assert_eq!(raw.cluster_min_points, 3);
+        assert!(!raw.line_metrics);
+        assert!(raw.cluster);
+        // SAFETY: native keeps the cluster properties descriptor graph alive for
+        // this scope.
+        let copied = unsafe { crate::json::json_value_from_native(&*raw.cluster_properties) }
+            .expect("cluster properties should copy back");
+        assert_eq!(copied, options.cluster_properties.unwrap());
+    }
+
+    #[test]
     fn native_tile_urls_materialize_string_view_array() {
         let urls = vec!["a://tile".to_string(), "b://tile".to_string()];
         let native = NativeTileUrls::new(&urls);

--- a/bindings/rust/crates/maplibre-native/src/lib.rs
+++ b/bindings/rust/crates/maplibre-native/src/lib.rs
@@ -43,8 +43,9 @@ pub use geometry::Geometry;
 pub use json::{JsonMember, JsonValue};
 pub use logging::{LogRecord, clear_log_callback, set_async_log_severity_mask, set_log_callback};
 pub use map::{
-    LocationIndicatorImageKind, MapHandle, RasterDemEncoding, SourceInfo, SourceType, StyleImage,
-    StyleImageInfo, StyleImageOptions, TileScheme, TileSourceOptions, VectorTileEncoding,
+    GeoJsonSourceOptions, LocationIndicatorImageKind, MapHandle, RasterDemEncoding, SourceInfo,
+    SourceType, StyleImage, StyleImageInfo, StyleImageOptions, TileScheme, TileSourceOptions,
+    VectorTileEncoding,
 };
 pub use maplibre_core::{
     AmbientCacheOperation, ConstrainMode, Error, ErrorKind, LogEvent, LogSeverity, LogSeverityMask,

--- a/bindings/rust/crates/maplibre-native/src/map.rs
+++ b/bindings/rust/crates/maplibre-native/src/map.rs
@@ -41,8 +41,9 @@ use crate::{GeoJson, JsonValue, PremultipliedRgba8Image};
 
 mod style;
 pub use style::{
-    LocationIndicatorImageKind, RasterDemEncoding, SourceInfo, SourceType, StyleImage,
-    StyleImageInfo, StyleImageOptions, TileScheme, TileSourceOptions, VectorTileEncoding,
+    GeoJsonSourceOptions, LocationIndicatorImageKind, RasterDemEncoding, SourceInfo, SourceType,
+    StyleImage, StyleImageInfo, StyleImageOptions, TileScheme, TileSourceOptions,
+    VectorTileEncoding,
 };
 
 #[derive(Debug)]

--- a/bindings/rust/crates/maplibre-native/src/map/style.rs
+++ b/bindings/rust/crates/maplibre-native/src/map/style.rs
@@ -1,11 +1,13 @@
 use std::ptr;
 
 pub(crate) use maplibre_core::style::{
-    NativeTileSourceOptions, NativeTileUrls, StyleImageOptionsNativeExt, TileSourceOptionsNativeExt,
+    GeoJsonSourceOptionsNativeExt, NativeGeoJsonSourceOptions, NativeTileSourceOptions,
+    NativeTileUrls, StyleImageOptionsNativeExt, TileSourceOptionsNativeExt,
 };
 pub use maplibre_core::{
-    LocationIndicatorImageKind, RasterDemEncoding, SourceInfo, SourceType, StyleImage,
-    StyleImageInfo, StyleImageOptions, TileScheme, TileSourceOptions, VectorTileEncoding,
+    GeoJsonSourceOptions, LocationIndicatorImageKind, RasterDemEncoding, SourceInfo, SourceType,
+    StyleImage, StyleImageInfo, StyleImageOptions, TileScheme, TileSourceOptions,
+    VectorTileEncoding,
 };
 use maplibre_native_core as maplibre_core;
 use maplibre_native_core::ptr::const_ptr_or_null;
@@ -715,19 +717,78 @@ impl super::MapHandle {
         })
     }
 
+    /// Adds a GeoJSON source that loads data from a URL.
+    ///
+    /// MapLibre Native fixes `options` when the source is created, so
+    /// [`Self::set_geojson_source_url`] and [`Self::set_geojson_source_data`]
+    /// keep the options the source was added with.
+    pub fn add_geojson_source_url(
+        &self,
+        source_id: &str,
+        url: &str,
+        options: Option<&GeoJsonSourceOptions>,
+    ) -> Result<()> {
+        let map = self.inner.as_ptr()?;
+        let source_id = maplibre_core::string::string_view(source_id);
+        let url = maplibre_core::string::string_view(url);
+        let options = options
+            .map(GeoJsonSourceOptions::try_to_native)
+            .transpose()?;
+        let options_ptr = options
+            .as_ref()
+            .map_or(ptr::null(), NativeGeoJsonSourceOptions::as_ptr);
+        // SAFETY: map is live, source_id and url are valid for this call, and
+        // options_ptr is null or points to call-scoped native options that own
+        // any cluster-properties descriptor graph.
+        maplibre_core::check(unsafe {
+            sys::mln_map_add_geojson_source_url(map, source_id.raw(), url.raw(), options_ptr)
+        })
+    }
+
     /// Adds a GeoJSON source with inline data.
-    pub fn add_geojson_source_data(&self, source_id: &str, data: &GeoJson) -> Result<()> {
+    ///
+    /// MapLibre Native fixes `options` when the source is created, so
+    /// [`Self::set_geojson_source_url`] and [`Self::set_geojson_source_data`]
+    /// keep the options the source was added with.
+    pub fn add_geojson_source_data(
+        &self,
+        source_id: &str,
+        data: &GeoJson,
+        options: Option<&GeoJsonSourceOptions>,
+    ) -> Result<()> {
         let map = self.inner.as_ptr()?;
         let source_id = maplibre_core::string::string_view(source_id);
         let data = data.try_to_native()?;
-        // SAFETY: map is live, source_id is valid for this call, and data owns
-        // the descriptor graph for this call.
+        let options = options
+            .map(GeoJsonSourceOptions::try_to_native)
+            .transpose()?;
+        let options_ptr = options
+            .as_ref()
+            .map_or(ptr::null(), NativeGeoJsonSourceOptions::as_ptr);
+        // SAFETY: map is live, source_id is valid for this call, data owns the
+        // descriptor graph for this call, and options_ptr is null or points to
+        // call-scoped native options that own any cluster-properties graph.
         maplibre_core::check(unsafe {
-            sys::mln_map_add_geojson_source_data(map, source_id.raw(), data.as_ptr())
+            sys::mln_map_add_geojson_source_data(map, source_id.raw(), data.as_ptr(), options_ptr)
+        })
+    }
+
+    /// Updates one GeoJSON source to load data from a URL.
+    ///
+    /// The source keeps the options it was added with.
+    pub fn set_geojson_source_url(&self, source_id: &str, url: &str) -> Result<()> {
+        let map = self.inner.as_ptr()?;
+        let source_id = maplibre_core::string::string_view(source_id);
+        let url = maplibre_core::string::string_view(url);
+        // SAFETY: map is live and source_id and url are valid for this call.
+        maplibre_core::check(unsafe {
+            sys::mln_map_set_geojson_source_url(map, source_id.raw(), url.raw())
         })
     }
 
     /// Updates one GeoJSON source with inline data.
+    ///
+    /// The source keeps the options it was added with.
     pub fn set_geojson_source_data(&self, source_id: &str, data: &GeoJson) -> Result<()> {
         let map = self.inner.as_ptr()?;
         let source_id = maplibre_core::string::string_view(source_id);

--- a/bindings/rust/crates/maplibre-native/src/map/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/map/tests.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use crate::events::{RuntimeEventSource, RuntimeEventType, empty_runtime_event};
 use crate::{
-    CustomGeometrySourceOptions, EdgeInsets, ErrorKind, JsonMember, MapMode, ResourceKind,
+    CustomGeometrySourceOptions, EdgeInsets, ErrorKind, Feature, JsonMember, MapMode, ResourceKind,
     ResourceProviderDecision, ResourceResponse, TextureImageInfo,
 };
 
@@ -218,6 +218,61 @@ fn tile_source_helpers_call_real_c_api() {
         map.style_source_type("dem-tiles").unwrap(),
         Some(SourceType::RasterDem)
     );
+}
+
+#[test]
+// Spec coverage: BND-060, BND-061, and BND-105.
+fn geojson_source_helpers_accept_options_and_keep_them_across_updates() {
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::default()).unwrap();
+    map.set_style_json(VALID_STYLE_JSON).unwrap();
+
+    let mut options = GeoJsonSourceOptions::default();
+    options.cluster = Some(true);
+    options.cluster_radius = Some(40);
+    // A present zero must reach native as an explicit buffer of zero.
+    options.buffer = Some(0);
+    options.cluster_properties = Some(JsonValue::Object(vec![JsonMember::new(
+        "weight_sum",
+        JsonValue::Array(vec![
+            JsonValue::String("+".to_owned()),
+            JsonValue::Array(vec![
+                JsonValue::String("get".to_owned()),
+                JsonValue::String("weight".to_owned()),
+            ]),
+        ]),
+    )]));
+
+    map.add_geojson_source_url(
+        "geojson-url",
+        "https://example.com/points.geojson",
+        Some(&options),
+    )
+    .unwrap();
+    assert_eq!(
+        map.style_source_type("geojson-url").unwrap(),
+        Some(SourceType::GeoJson)
+    );
+
+    let data = GeoJson::FeatureCollection(vec![Feature::new(
+        Geometry::Point(LatLng::new(0.0, 0.0)),
+        vec![JsonMember::new("weight", JsonValue::UInt(1))],
+    )]);
+    map.add_geojson_source_data("geojson-data", &data, None)
+        .unwrap();
+    assert_eq!(
+        map.style_source_type("geojson-data").unwrap(),
+        Some(SourceType::GeoJson)
+    );
+
+    // Updates carry no options of their own; the source keeps what it was added
+    // with.
+    map.set_geojson_source_data("geojson-url", &data).unwrap();
+    map.set_geojson_source_url("geojson-data", "https://example.com/points.geojson")
+        .unwrap();
+
+    map.close().unwrap();
+    runtime.close().unwrap();
 }
 
 #[test]

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -26,9 +26,10 @@ use static_assertions::assert_not_impl_any;
 use super::*;
 use crate::logging::test_support::LoggingTestGuard;
 use crate::{
-    CameraOptions, ErrorKind, FeatureIdentifier, Geometry, JsonMember, LatLng, LogSeverity,
-    LogSeverityMask, MapMode, MapOptions, OpenGLContextProviderMask, RenderBackendMask,
-    RuntimeEventType, RuntimeHandle, ScreenBox, ScreenPoint,
+    CameraOptions, ErrorKind, FeatureIdentifier, GeoJson, GeoJsonSourceOptions, Geometry,
+    JsonMember, LatLng, LogSeverity, LogSeverityMask, MapMode, MapOptions,
+    OpenGLContextProviderMask, RenderBackendMask, RuntimeEventType, RuntimeHandle, ScreenBox,
+    ScreenPoint,
 };
 
 assert_not_impl_any!(NativePointer: Send, Sync);
@@ -1995,6 +1996,12 @@ fn feature_extension_queries_copy_value_and_feature_collection_results() {
         feature_member(&cluster.feature, "cluster_id"),
         Some(&JsonValue::UInt(_))
     ));
+
+    // The rendered cluster exists only because the typed GeoJSON adder passed
+    // GeoJsonSourceOptions::cluster, and weight_sum is produced by the
+    // cluster_properties aggregation lowered through the same options.
+    assert_eq!(numeric_member(&cluster.feature, "point_count"), Some(3.0));
+    assert_eq!(numeric_member(&cluster.feature, "weight_sum"), Some(6.0));
 
     let children = session
         .query_feature_extension(

--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -41,7 +41,7 @@ assert_not_impl_any!(OpenGLOwnedTextureFrameHandle: Send, Sync);
 
 const FEATURE_STATE_STYLE_JSON: &str = r#"{"version":8,"sources":{"point":{"type":"geojson","data":{"type":"FeatureCollection","features":[{"type":"Feature","id":"feature-1","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}}]}}},"layers":[{"id":"circle","type":"circle","source":"point","paint":{"circle-radius":["case",["boolean",["feature-state","hover"],false],10,5]}}]}"#;
 const QUERY_STYLE_JSON: &str = r##"{"version":8,"sources":{"point":{"type":"geojson","data":{"type":"FeatureCollection","features":[{"type":"Feature","id":"feature-1","geometry":{"type":"Point","coordinates":[-122.4194,37.7749]},"properties":{"kind":"capital","visible":true}}]}}},"layers":[{"id":"background","type":"background","paint":{"background-color":"#d8f1ff"}},{"id":"point-circle","type":"circle","source":"point","paint":{"circle-color":"#f97316","circle-radius":12}}]}"##;
-const CLUSTER_STYLE_JSON: &str = r##"{"version":8,"sources":{"cluster-source":{"type":"geojson","cluster":true,"data":{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[0.0,0.0]},"properties":{"name":"one"}},{"type":"Feature","geometry":{"type":"Point","coordinates":[0.001,0.001]},"properties":{"name":"two"}},{"type":"Feature","geometry":{"type":"Point","coordinates":[0.002,0.002]},"properties":{"name":"three"}}]}}},"layers":[{"id":"background","type":"background","paint":{"background-color":"#ffffff"}},{"id":"cluster-circle","type":"circle","source":"cluster-source","filter":["has","point_count"],"paint":{"circle-color":"#2563eb","circle-radius":20}}]}"##;
+const CLUSTER_BASE_STYLE_JSON: &str = r##"{"version":8,"sources":{},"layers":[{"id":"background","type":"background","paint":{"background-color":"#ffffff"}}]}"##;
 fn create_owned_texture_session(
     map: &MapHandle,
     extent: RenderTargetExtent,
@@ -1235,13 +1235,79 @@ fn load_query_style(runtime: &RuntimeHandle, map: &MapHandle, session: &RenderSe
     render_available_updates(runtime, session, 5);
 }
 
+fn cluster_point(latitude: f64, longitude: f64, name: &str, weight: u64) -> Feature {
+    Feature::new(
+        Geometry::Point(LatLng::new(latitude, longitude)),
+        vec![
+            JsonMember::new("name", JsonValue::String(name.to_owned())),
+            JsonMember::new("weight", JsonValue::UInt(weight)),
+        ],
+    )
+}
+
+/// Builds the clustered source through the typed GeoJSON adder so the render
+/// tests exercise `GeoJsonSourceOptions` rather than raw style JSON.
 fn load_cluster_style(runtime: &RuntimeHandle, map: &MapHandle, session: &RenderSessionHandle) {
     let mut camera = CameraOptions::default();
     camera.center = Some(LatLng::new(0.0, 0.0));
     camera.zoom = Some(0.0);
     map.jump_to(&camera).unwrap();
-    map.set_style_json(CLUSTER_STYLE_JSON).unwrap();
+    map.set_style_json(CLUSTER_BASE_STYLE_JSON).unwrap();
+
+    let data = GeoJson::FeatureCollection(vec![
+        cluster_point(0.0, 0.0, "one", 1),
+        cluster_point(0.001, 0.001, "two", 2),
+        cluster_point(0.002, 0.002, "three", 3),
+    ]);
+    let mut options = GeoJsonSourceOptions::default();
+    options.cluster = Some(true);
+    options.cluster_radius = Some(60);
+    options.cluster_min_points = Some(2);
+    options.cluster_max_zoom = Some(17.0);
+    options.cluster_properties = Some(JsonValue::Object(vec![JsonMember::new(
+        "weight_sum",
+        JsonValue::Array(vec![
+            JsonValue::String("+".to_owned()),
+            JsonValue::Array(vec![
+                JsonValue::String("get".to_owned()),
+                JsonValue::String("weight".to_owned()),
+            ]),
+        ]),
+    )]));
+    map.add_geojson_source_data("cluster-source", &data, Some(&options))
+        .unwrap();
+
+    let layer = JsonValue::Object(vec![
+        JsonMember::new("id", JsonValue::String("cluster-circle".to_owned())),
+        JsonMember::new("type", JsonValue::String("circle".to_owned())),
+        JsonMember::new("source", JsonValue::String("cluster-source".to_owned())),
+        JsonMember::new(
+            "filter",
+            JsonValue::Array(vec![
+                JsonValue::String("has".to_owned()),
+                JsonValue::String("point_count".to_owned()),
+            ]),
+        ),
+        JsonMember::new(
+            "paint",
+            JsonValue::Object(vec![
+                JsonMember::new("circle-color", JsonValue::String("#2563eb".to_owned())),
+                JsonMember::new("circle-radius", JsonValue::Double(20.0)),
+            ]),
+        ),
+    ]);
+    map.add_style_layer_json(&layer, None).unwrap();
+
     render_available_updates(runtime, session, 5);
+}
+
+fn numeric_member(feature: &Feature, key: &str) -> Option<f64> {
+    match feature_member(feature, key)? {
+        JsonValue::UInt(value) => Some(*value as f64),
+        JsonValue::Int(value) => Some(*value as f64),
+        JsonValue::Double(value) => Some(*value),
+        _ => None,
+    }
 }
 
 fn render_available_updates(runtime: &RuntimeHandle, session: &RenderSessionHandle, count: usize) {

--- a/bindings/swift/Sources/MaplibreNative/Style.swift
+++ b/bindings/swift/Sources/MaplibreNative/Style.swift
@@ -71,6 +71,70 @@ public struct StyleTileSourceOptions: Equatable, Sendable {
   }
 }
 
+/// Options for GeoJSON sources.
+///
+/// MapLibre Native fixes these options when the source is created, so
+/// ``MapHandle/setGeoJSONSourceURL(sourceId:url:)`` and
+/// ``MapHandle/setGeoJSONSourceData(sourceId:data:)`` keep the options the
+/// source was added with.
+public struct StyleGeoJSONSourceOptions: Equatable, Sendable {
+  public var minZoom: Double?
+  public var maxZoom: Double?
+  public var tolerance: Double?
+  public var clusterMaxZoom: Double?
+  /// Cluster aggregation expressions keyed by property name, as a JSON object
+  /// whose members follow the MapLibre Style Spec `clusterProperties` form.
+  public var clusterProperties: JSONValue?
+  public var tileSize: UInt32?
+  public var buffer: UInt32?
+  public var clusterRadius: UInt32?
+  public var clusterMinPoints: UInt32?
+  public var lineMetrics: Bool?
+  public var cluster: Bool?
+
+  public init(
+    minZoom: Double? = nil,
+    maxZoom: Double? = nil,
+    tolerance: Double? = nil,
+    clusterMaxZoom: Double? = nil,
+    clusterProperties: JSONValue? = nil,
+    tileSize: UInt32? = nil,
+    buffer: UInt32? = nil,
+    clusterRadius: UInt32? = nil,
+    clusterMinPoints: UInt32? = nil,
+    lineMetrics: Bool? = nil,
+    cluster: Bool? = nil
+  ) {
+    self.minZoom = minZoom
+    self.maxZoom = maxZoom
+    self.tolerance = tolerance
+    self.clusterMaxZoom = clusterMaxZoom
+    self.clusterProperties = clusterProperties
+    self.tileSize = tileSize
+    self.buffer = buffer
+    self.clusterRadius = clusterRadius
+    self.clusterMinPoints = clusterMinPoints
+    self.lineMetrics = lineMetrics
+    self.cluster = cluster
+  }
+
+  var nativeOptions: NativeGeoJSONSourceOptions {
+    NativeGeoJSONSourceOptions(
+      minZoom: minZoom,
+      maxZoom: maxZoom,
+      tolerance: tolerance,
+      clusterMaxZoom: clusterMaxZoom,
+      clusterProperties: clusterProperties?.nativeValue,
+      tileSize: tileSize,
+      buffer: buffer,
+      clusterRadius: clusterRadius,
+      clusterMinPoints: clusterMinPoints,
+      lineMetrics: lineMetrics,
+      cluster: cluster
+    )
+  }
+}
+
 public struct StyleRGBA8Image: Equatable, Sendable {
   public let width: UInt32
   public let height: UInt32
@@ -301,26 +365,52 @@ public extension MapHandle {
     try mapNativeFailure { try NativeStyle.sourceIds(requireLivePointer()) }
   }
 
-  func addGeoJSONSourceURL(sourceId: String, url: String) throws {
+  /// Adds a GeoJSON source that loads data from a URL.
+  ///
+  /// `options` is fixed when the source is created;
+  /// ``setGeoJSONSourceURL(sourceId:url:)`` and
+  /// ``setGeoJSONSourceData(sourceId:data:)`` keep the options the source was
+  /// added with.
+  func addGeoJSONSourceURL(
+    sourceId: String,
+    url: String,
+    options: StyleGeoJSONSourceOptions = StyleGeoJSONSourceOptions()
+  ) throws {
     try mapNativeFailure {
       let arena = NativeInputArena()
-      try checkStatus(mln_map_add_geojson_source_url(
-        requireLivePointer(),
-        arena.view(sourceId),
-        arena.view(url)
-      ))
+      try options.nativeOptions.withNativeOptions { options in
+        try checkStatus(mln_map_add_geojson_source_url(
+          requireLivePointer(),
+          arena.view(sourceId),
+          arena.view(url),
+          options
+        ))
+      }
     }
   }
 
-  func addGeoJSONSourceData(sourceId: String, data: GeoJSON) throws {
+  /// Adds a GeoJSON source with inline data.
+  ///
+  /// `options` is fixed when the source is created;
+  /// ``setGeoJSONSourceURL(sourceId:url:)`` and
+  /// ``setGeoJSONSourceData(sourceId:data:)`` keep the options the source was
+  /// added with.
+  func addGeoJSONSourceData(
+    sourceId: String,
+    data: GeoJSON,
+    options: StyleGeoJSONSourceOptions = StyleGeoJSONSourceOptions()
+  ) throws {
     try mapNativeFailure {
       let arena = NativeInputArena()
       try arena.withNativeGeoJSON(data.nativeGeoJSON) { data in
-        try checkStatus(mln_map_add_geojson_source_data(
-          requireLivePointer(),
-          arena.view(sourceId),
-          data
-        ))
+        try options.nativeOptions.withNativeOptions { options in
+          try checkStatus(mln_map_add_geojson_source_data(
+            requireLivePointer(),
+            arena.view(sourceId),
+            data,
+            options
+          ))
+        }
       }
     }
   }

--- a/bindings/swift/Sources/MaplibreNative/Support/StyleStructs.swift
+++ b/bindings/swift/Sources/MaplibreNative/Support/StyleStructs.swift
@@ -93,7 +93,110 @@ struct NativeStyleTileSourceOptions: Equatable {
       options.fields |= MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING.rawValue
       options.raster_encoding = rasterEncoding
     }
-    return try withUnsafePointer(to: &options, body)
+    return try withUnsafePointer(to: &options) { options in
+      try withExtendedLifetime(arena) { try body(options) }
+    }
+  }
+}
+
+struct NativeGeoJSONSourceOptions: Equatable {
+  var minZoom: Double?
+  var maxZoom: Double?
+  var tolerance: Double?
+  var clusterMaxZoom: Double?
+  var clusterProperties: NativeJSONValue?
+  var tileSize: UInt32?
+  var buffer: UInt32?
+  var clusterRadius: UInt32?
+  var clusterMinPoints: UInt32?
+  var lineMetrics: Bool?
+  var cluster: Bool?
+
+  init(
+    minZoom: Double? = nil,
+    maxZoom: Double? = nil,
+    tolerance: Double? = nil,
+    clusterMaxZoom: Double? = nil,
+    clusterProperties: NativeJSONValue? = nil,
+    tileSize: UInt32? = nil,
+    buffer: UInt32? = nil,
+    clusterRadius: UInt32? = nil,
+    clusterMinPoints: UInt32? = nil,
+    lineMetrics: Bool? = nil,
+    cluster: Bool? = nil
+  ) {
+    self.minZoom = minZoom
+    self.maxZoom = maxZoom
+    self.tolerance = tolerance
+    self.clusterMaxZoom = clusterMaxZoom
+    self.clusterProperties = clusterProperties
+    self.tileSize = tileSize
+    self.buffer = buffer
+    self.clusterRadius = clusterRadius
+    self.clusterMinPoints = clusterMinPoints
+    self.lineMetrics = lineMetrics
+    self.cluster = cluster
+  }
+
+  func withNativeOptions<Result>(
+    _ body: (UnsafePointer<mln_geojson_source_options>?) throws -> Result
+  ) throws -> Result {
+    if minZoom == nil, maxZoom == nil, tolerance == nil, clusterMaxZoom == nil,
+       clusterProperties == nil, tileSize == nil, buffer == nil,
+       clusterRadius == nil, clusterMinPoints == nil, lineMetrics == nil,
+       cluster == nil
+    {
+      return try body(nil)
+    }
+    let arena = NativeInputArena()
+    var options = mln_geojson_source_options_default()
+    if let minZoom {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM.rawValue
+      options.min_zoom = minZoom
+    }
+    if let maxZoom {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM.rawValue
+      options.max_zoom = maxZoom
+    }
+    if let tolerance {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_TOLERANCE.rawValue
+      options.tolerance = tolerance
+    }
+    if let clusterMaxZoom {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM.rawValue
+      options.cluster_max_zoom = clusterMaxZoom
+    }
+    if let clusterProperties {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES.rawValue
+      options.cluster_properties = arena.allocate(clusterProperties)
+    }
+    if let tileSize {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE.rawValue
+      options.tile_size = tileSize
+    }
+    if let buffer {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_BUFFER.rawValue
+      options.buffer = buffer
+    }
+    if let clusterRadius {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS.rawValue
+      options.cluster_radius = clusterRadius
+    }
+    if let clusterMinPoints {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS.rawValue
+      options.cluster_min_points = clusterMinPoints
+    }
+    if let lineMetrics {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS.rawValue
+      options.line_metrics = lineMetrics
+    }
+    if let cluster {
+      options.fields |= MLN_GEOJSON_SOURCE_OPTION_CLUSTER.rawValue
+      options.cluster = cluster
+    }
+    return try withUnsafePointer(to: &options) { options in
+      try withExtendedLifetime(arena) { try body(options) }
+    }
   }
 }
 

--- a/bindings/swift/Tests/MaplibreNativeTests/StyleTests.swift
+++ b/bindings/swift/Tests/MaplibreNativeTests/StyleTests.swift
@@ -409,3 +409,124 @@ import Testing
     Issue.record("unexpected error: \(error)")
   }
 }
+
+@Test func geoJSONSourceOptionsMaterializeFieldMaskAndClusterProperties(
+) throws {
+  let options = StyleGeoJSONSourceOptions(
+    minZoom: 1,
+    maxZoom: 12,
+    tolerance: 0.5,
+    clusterMaxZoom: 15,
+    clusterProperties: clusterPropertiesValue(),
+    tileSize: 256,
+    buffer: 64,
+    clusterRadius: 60,
+    clusterMinPoints: 3,
+    lineMetrics: true,
+    cluster: true
+  )
+
+  try options.nativeOptions.withNativeOptions { native in
+    let native = try #require(native)
+    let fields = native.pointee.fields
+    #expect((fields & MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM.rawValue) != 0)
+    #expect((fields & MLN_GEOJSON_SOURCE_OPTION_CLUSTER.rawValue) != 0)
+    #expect(
+      (fields & MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES.rawValue) != 0
+    )
+    #expect(native.pointee.min_zoom == 1)
+    #expect(native.pointee.max_zoom == 12)
+    #expect(native.pointee.tolerance == 0.5)
+    #expect(native.pointee.cluster_max_zoom == 15)
+    #expect(native.pointee.tile_size == 256)
+    #expect(native.pointee.buffer == 64)
+    #expect(native.pointee.cluster_radius == 60)
+    #expect(native.pointee.cluster_min_points == 3)
+    #expect(native.pointee.line_metrics)
+    #expect(native.pointee.cluster)
+
+    let clusterProperties = try #require(native.pointee.cluster_properties)
+    let copied = try NativeJSONValue(copying: clusterProperties.pointee)
+    #expect(JSONValue(native: copied) == clusterPropertiesValue())
+  }
+
+  // Absent options keep the descriptor out of the call.
+  try StyleGeoJSONSourceOptions().nativeOptions.withNativeOptions { native in
+    #expect(native == nil)
+  }
+}
+
+@Test func clusteredGeoJSONSourceOptionsParseThroughNativeMap() throws {
+  let runtime =
+    try RuntimeHandle(options: RuntimeOptions(cachePath: ":memory:"))
+  defer { try? runtime.close() }
+  let map = try MapHandle(
+    runtime: runtime,
+    options: MapOptions(width: 512, height: 512)
+  )
+  defer { try? map.close() }
+
+  try map.setStyleJSON("""
+  {"version":8,"sources":{},"layers":[]}
+  """)
+
+  try map.addGeoJSONSourceData(
+    sourceId: "clustered",
+    data: nearbyPoints(),
+    options: clusterOptions()
+  )
+
+  #expect(try map.styleSourceExists("clustered"))
+  #expect(try map.styleSourceType("clustered") == .geoJSON)
+
+  // The cluster aggregation graph is borrowed for the call and parsed by
+  // MapLibre Native, so an unparseable expression fails the add.
+  var invalid = clusterOptions()
+  invalid.clusterProperties = .object([
+    JSONMember(key: "weight_sum", value: .string("not-an-expression")),
+  ])
+
+  do {
+    try map.addGeoJSONSourceData(
+      sourceId: "clustered-invalid",
+      data: nearbyPoints(),
+      options: invalid
+    )
+    Issue.record("unparseable cluster properties should throw")
+  } catch let error as MaplibreError {
+    #expect(error.kind == .invalidArgument)
+  } catch {
+    Issue.record("unexpected error: \(error)")
+  }
+
+  #expect(try !map.styleSourceExists("clustered-invalid"))
+}
+
+private func clusterPropertiesValue() -> JSONValue {
+  .object([
+    JSONMember(
+      key: "weight_sum",
+      value: .array([.string("+"), .array([.string("get"), .string("weight")])])
+    ),
+  ])
+}
+
+private func clusterOptions() -> StyleGeoJSONSourceOptions {
+  StyleGeoJSONSourceOptions(
+    clusterMaxZoom: 17,
+    clusterProperties: clusterPropertiesValue(),
+    clusterRadius: 60,
+    clusterMinPoints: 2,
+    cluster: true
+  )
+}
+
+private func nearbyPoints() -> GeoJSON {
+  .featureCollection((0 ..< 3).map { index in
+    let offset = Double(index) * 0.001
+    return Feature(
+      geometry: .point(LatLng(latitude: offset, longitude: offset)),
+      properties: [JSONMember(key: "weight", value: .uint(UInt64(index + 1)))]
+    )
+  })
+}

--- a/bindings/zig/src/map.zig
+++ b/bindings/zig/src/map.zig
@@ -932,16 +932,26 @@ pub const MapHandle = enum(u128) {
         );
     }
 
+    /// Adds a GeoJSON source with inline data. MapLibre Native fixes options when the source is
+    /// created, so later setGeoJsonSourceData and setGeoJsonSourceUrl calls keep the options
+    /// passed here.
     pub fn addGeoJsonSourceData(
         self: *MapHandle,
         allocator: std.mem.Allocator,
         source_id: []const u8,
         data: values.GeoJson,
+        options: ?values.StyleGeoJsonSourceOptions,
     ) status.Error!void {
         var temp = native_temp.TempStorage.init(allocator);
         defer temp.deinit();
+        var raw_options = if (options) |value| try styleGeoJsonSourceOptionsToNative(&temp, value) else undefined;
         try status.checkStatus(
-            c.mln_map_add_geojson_source_data(try native(self), try temp.stringView(source_id), try temp.geoJson(data)),
+            c.mln_map_add_geojson_source_data(
+                try native(self),
+                try temp.stringView(source_id),
+                try temp.geoJson(data),
+                if (options != null) &raw_options else null,
+            ),
             diagnosticStore(self),
         );
     }
@@ -960,16 +970,26 @@ pub const MapHandle = enum(u128) {
         );
     }
 
+    /// Adds a GeoJSON source that loads from a URL. MapLibre Native fixes options when the source
+    /// is created, so later setGeoJsonSourceUrl and setGeoJsonSourceData calls keep the options
+    /// passed here.
     pub fn addGeoJsonSourceUrl(
         self: *MapHandle,
         allocator: std.mem.Allocator,
         source_id: []const u8,
         url: []const u8,
+        options: ?values.StyleGeoJsonSourceOptions,
     ) status.Error!void {
         var temp = native_temp.TempStorage.init(allocator);
         defer temp.deinit();
+        var raw_options = if (options) |value| try styleGeoJsonSourceOptionsToNative(&temp, value) else undefined;
         try status.checkStatus(
-            c.mln_map_add_geojson_source_url(try native(self), try temp.stringView(source_id), try temp.stringView(url)),
+            c.mln_map_add_geojson_source_url(
+                try native(self),
+                try temp.stringView(source_id),
+                try temp.stringView(url),
+                if (options != null) &raw_options else null,
+            ),
             diagnosticStore(self),
         );
     }
@@ -1444,6 +1464,58 @@ fn styleTileSourceOptionsToNative(
     if (options.raster_encoding) |encoding| {
         raw.fields |= c.MLN_STYLE_TILE_SOURCE_OPTION_RASTER_ENCODING;
         raw.raster_encoding = values.styleRasterDemEncodingToNative(encoding);
+    }
+    return raw;
+}
+
+fn styleGeoJsonSourceOptionsToNative(
+    temp: *native_temp.TempStorage,
+    options: values.StyleGeoJsonSourceOptions,
+) status.Error!c.mln_geojson_source_options {
+    var raw = c.mln_geojson_source_options_default();
+    if (options.min_zoom) |min_zoom| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM;
+        raw.min_zoom = min_zoom;
+    }
+    if (options.max_zoom) |max_zoom| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM;
+        raw.max_zoom = max_zoom;
+    }
+    if (options.tolerance) |tolerance| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_TOLERANCE;
+        raw.tolerance = tolerance;
+    }
+    if (options.cluster_max_zoom) |cluster_max_zoom| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM;
+        raw.cluster_max_zoom = cluster_max_zoom;
+    }
+    if (options.cluster_properties) |cluster_properties| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES;
+        raw.cluster_properties = try temp.jsonValue(cluster_properties);
+    }
+    if (options.tile_size) |tile_size| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE;
+        raw.tile_size = tile_size;
+    }
+    if (options.buffer) |buffer| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_BUFFER;
+        raw.buffer = buffer;
+    }
+    if (options.cluster_radius) |cluster_radius| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS;
+        raw.cluster_radius = cluster_radius;
+    }
+    if (options.cluster_min_points) |cluster_min_points| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS;
+        raw.cluster_min_points = cluster_min_points;
+    }
+    if (options.line_metrics) |line_metrics| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS;
+        raw.line_metrics = line_metrics;
+    }
+    if (options.cluster) |cluster| {
+        raw.fields |= c.MLN_GEOJSON_SOURCE_OPTION_CLUSTER;
+        raw.cluster = cluster;
     }
     return raw;
 }

--- a/bindings/zig/src/maplibre_native.zig
+++ b/bindings/zig/src/maplibre_native.zig
@@ -149,6 +149,7 @@ pub const StyleTileScheme = values.StyleTileScheme;
 pub const StyleVectorTileEncoding = values.StyleVectorTileEncoding;
 pub const StyleRasterDemEncoding = values.StyleRasterDemEncoding;
 pub const StyleTileSourceOptions = values.StyleTileSourceOptions;
+pub const StyleGeoJsonSourceOptions = values.StyleGeoJsonSourceOptions;
 pub const PremultipliedRgba8Image = values.PremultipliedRgba8Image;
 pub const StyleImageOptions = values.StyleImageOptions;
 pub const StyleImageInfo = values.StyleImageInfo;

--- a/bindings/zig/src/maplibre_native.zig
+++ b/bindings/zig/src/maplibre_native.zig
@@ -150,6 +150,7 @@ pub const StyleVectorTileEncoding = values.StyleVectorTileEncoding;
 pub const StyleRasterDemEncoding = values.StyleRasterDemEncoding;
 pub const StyleTileSourceOptions = values.StyleTileSourceOptions;
 pub const StyleGeoJsonSourceOptions = values.StyleGeoJsonSourceOptions;
+pub const OwnedStyleGeoJsonSourceOptions = values.OwnedStyleGeoJsonSourceOptions;
 pub const PremultipliedRgba8Image = values.PremultipliedRgba8Image;
 pub const StyleImageOptions = values.StyleImageOptions;
 pub const StyleImageInfo = values.StyleImageInfo;

--- a/bindings/zig/src/values.zig
+++ b/bindings/zig/src/values.zig
@@ -192,6 +192,23 @@ pub const StyleGeoJsonSourceOptions = struct {
     cluster_min_points: ?u32 = null,
     line_metrics: ?bool = null,
     cluster: ?bool = null,
+
+    /// Copies this descriptor and recursively owns all nested cluster-property storage.
+    pub fn copy(self: StyleGeoJsonSourceOptions, allocator: std.mem.Allocator) std.mem.Allocator.Error!OwnedStyleGeoJsonSourceOptions {
+        var copied = self;
+        copied.cluster_properties = if (self.cluster_properties) |value| try copyJsonValue(allocator, value) else null;
+        return .{ .allocator = allocator, .options = copied };
+    }
+};
+
+pub const OwnedStyleGeoJsonSourceOptions = struct {
+    allocator: std.mem.Allocator,
+    options: StyleGeoJsonSourceOptions,
+
+    pub fn deinit(self: *OwnedStyleGeoJsonSourceOptions) void {
+        if (self.options.cluster_properties) |value| deinitCopiedJsonValue(self.allocator, value);
+        self.options.cluster_properties = null;
+    }
 };
 
 pub const PremultipliedRgba8Image = struct {
@@ -248,6 +265,66 @@ pub const JsonValue = union(enum) {
     array: []const JsonValue,
     object: []const JsonMember,
 };
+
+fn copyJsonValue(allocator: std.mem.Allocator, value: JsonValue) std.mem.Allocator.Error!JsonValue {
+    return switch (value) {
+        .null => .null,
+        .bool => |item| .{ .bool = item },
+        .uint => |item| .{ .uint = item },
+        .int => |item| .{ .int = item },
+        .double => |item| .{ .double = item },
+        .string => |item| .{ .string = try allocator.dupe(u8, item) },
+        .array => |items| blk: {
+            const copied = try allocator.alloc(JsonValue, items.len);
+            var initialized: usize = 0;
+            errdefer {
+                for (copied[0..initialized]) |item| deinitCopiedJsonValue(allocator, item);
+                allocator.free(copied);
+            }
+            for (items, copied) |item, *out| {
+                out.* = try copyJsonValue(allocator, item);
+                initialized += 1;
+            }
+            break :blk .{ .array = copied };
+        },
+        .object => |members| blk: {
+            const copied = try allocator.alloc(JsonMember, members.len);
+            var initialized: usize = 0;
+            errdefer {
+                for (copied[0..initialized]) |*member| {
+                    allocator.free(member.key);
+                    deinitCopiedJsonValue(allocator, member.value);
+                }
+                allocator.free(copied);
+            }
+            for (members, copied) |member, *out| {
+                out.key = try allocator.dupe(u8, member.key);
+                errdefer allocator.free(out.key);
+                out.value = try copyJsonValue(allocator, member.value);
+                initialized += 1;
+            }
+            break :blk .{ .object = copied };
+        },
+    };
+}
+
+fn deinitCopiedJsonValue(allocator: std.mem.Allocator, value: JsonValue) void {
+    switch (value) {
+        .null, .bool, .uint, .int, .double => {},
+        .string => |item| allocator.free(item),
+        .array => |items| {
+            for (items) |item| deinitCopiedJsonValue(allocator, item);
+            allocator.free(items);
+        },
+        .object => |members| {
+            for (members) |member| {
+                allocator.free(member.key);
+                deinitCopiedJsonValue(allocator, member.value);
+            }
+            allocator.free(members);
+        },
+    }
+}
 
 pub const OwnedJsonMember = struct {
     key: []const u8,
@@ -1029,4 +1106,35 @@ test "owned JSON copy handles empty native arrays and objects" {
     var copied_object = try ownedJsonValueFromNative(std.testing.allocator, &empty_object);
     defer copied_object.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 0), copied_object.object.len);
+}
+
+test "GeoJSON source option copy owns nested cluster properties" {
+    var property_name = [_]u8{ 't', 'o', 't', 'a', 'l' };
+    var operator = [_]u8{'+'};
+    var expression = [_]JsonValue{
+        .{ .string = operator[0..] },
+        .{ .uint = 1 },
+    };
+    var members = [_]JsonMember{.{
+        .key = property_name[0..],
+        .value = .{ .array = expression[0..] },
+    }};
+    const original = StyleGeoJsonSourceOptions{
+        .max_zoom = 18,
+        .cluster_properties = .{ .object = members[0..] },
+    };
+
+    var copied = try original.copy(std.testing.allocator);
+    defer copied.deinit();
+    copied.options.max_zoom = 12;
+    property_name[0] = 'x';
+    operator[0] = '-';
+    expression[1] = .{ .uint = 2 };
+
+    try std.testing.expectEqual(@as(f64, 18), original.max_zoom.?);
+    try std.testing.expectEqual(@as(f64, 12), copied.options.max_zoom.?);
+    const copied_member = copied.options.cluster_properties.?.object[0];
+    try std.testing.expectEqualStrings("total", copied_member.key);
+    try std.testing.expectEqualStrings("+", copied_member.value.array[0].string);
+    try std.testing.expectEqual(@as(u64, 1), copied_member.value.array[1].uint);
 }

--- a/bindings/zig/src/values.zig
+++ b/bindings/zig/src/values.zig
@@ -176,6 +176,24 @@ pub const StyleTileSourceOptions = struct {
     raster_encoding: ?StyleRasterDemEncoding = null,
 };
 
+/// Options for GeoJSON sources. MapLibre Native fixes these options when the source is created, so
+/// setGeoJsonSourceUrl and setGeoJsonSourceData keep the options the source was added with.
+pub const StyleGeoJsonSourceOptions = struct {
+    min_zoom: ?f64 = null,
+    max_zoom: ?f64 = null,
+    tolerance: ?f64 = null,
+    cluster_max_zoom: ?f64 = null,
+    /// Cluster aggregation expressions keyed by property name, as a JSON object whose members
+    /// follow the MapLibre Style Spec clusterProperties form.
+    cluster_properties: ?JsonValue = null,
+    tile_size: ?u32 = null,
+    buffer: ?u32 = null,
+    cluster_radius: ?u32 = null,
+    cluster_min_points: ?u32 = null,
+    line_metrics: ?bool = null,
+    cluster: ?bool = null,
+};
+
 pub const PremultipliedRgba8Image = struct {
     width: u32,
     height: u32,

--- a/bindings/zig/tests/geojson.zig
+++ b/bindings/zig/tests/geojson.zig
@@ -39,7 +39,7 @@ test "GeoJSON descriptors add and update sources through public binding" {
     defer map.close() catch @panic("map close failed");
 
     const empty_features = [_]maplibre.Feature{};
-    try map.addGeoJsonSourceData(testing.allocator, "empty", .{ .feature_collection = empty_features[0..] });
+    try map.addGeoJsonSourceData(testing.allocator, "empty", .{ .feature_collection = empty_features[0..] }, null);
     try testing.expect(try map.styleSourceExists(testing.allocator, "empty"));
 
     var source_ids = try map.listStyleSourceIds(testing.allocator);
@@ -58,11 +58,18 @@ test "GeoJSON descriptors add and update sources through public binding" {
     try map.setGeoJsonSourceData(testing.allocator, "empty", .{ .feature_collection = features[0..] });
     try map.setGeoJsonSourceUrl(testing.allocator, "empty", "https://example.com/data.geojson");
 
-    try map.addGeoJsonSourceUrl(testing.allocator, "geo-url", "https://example.com/initial.geojson");
+    try map.addGeoJsonSourceUrl(testing.allocator, "geo-url", "https://example.com/initial.geojson", .{
+        .min_zoom = 1,
+        .max_zoom = 16,
+        .tolerance = 0.5,
+        .buffer = 0,
+        .tile_size = 256,
+        .line_metrics = true,
+    });
     try testing.expectEqual(maplibre.StyleSourceType.geojson, (try map.getStyleSourceType(testing.allocator, "geo-url")).?);
     try map.setGeoJsonSourceUrl(testing.allocator, "geo-url", "https://example.com/updated.geojson");
 
-    try testing.expectError(error.InvalidArgument, map.addGeoJsonSourceUrl(testing.allocator, "empty", "https://example.com/again.geojson"));
+    try testing.expectError(error.InvalidArgument, map.addGeoJsonSourceUrl(testing.allocator, "empty", "https://example.com/again.geojson", null));
     try map.addVectorSourceUrl(testing.allocator, "vector-url", "https://example.com/vector.json", null);
     try testing.expectError(error.InvalidArgument, map.setGeoJsonSourceUrl(testing.allocator, "vector-url", "https://example.com/not-geojson"));
 }
@@ -89,7 +96,7 @@ test "geometry descriptor graphs support nested collections" {
         .{ .polygon = rings[0..] },
     };
 
-    try map.addGeoJsonSourceData(testing.allocator, "collection", .{ .geometry = .{ .collection = children[0..] } });
+    try map.addGeoJsonSourceData(testing.allocator, "collection", .{ .geometry = .{ .collection = children[0..] } }, null);
     try testing.expect(try map.styleSourceExists(testing.allocator, "collection"));
 }
 
@@ -101,7 +108,7 @@ test "GeoJSON descriptors reject invalid native values and pass explicit-length 
 
     try testing.expectError(
         error.InvalidArgument,
-        map.addGeoJsonSourceData(testing.allocator, "", .{ .geometry = .{ .empty = {} } }),
+        map.addGeoJsonSourceData(testing.allocator, "", .{ .geometry = .{ .empty = {} } }, null),
     );
     try testing.expectError(
         error.InvalidArgument,
@@ -109,13 +116,14 @@ test "GeoJSON descriptors reject invalid native values and pass explicit-length 
             testing.allocator,
             "bad-coordinate",
             .{ .geometry = .{ .point = .{ .latitude = std.math.inf(f64), .longitude = 0.0 } } },
+            null,
         ),
     );
     const features = [_]maplibre.Feature{.{
         .geometry = .{ .point = .{ .latitude = 0.0, .longitude = 0.0 } },
         .identifier = .{ .string = "bad\x00id" },
     }};
-    try map.addGeoJsonSourceData(testing.allocator, "embedded-nul-id", .{ .feature_collection = features[0..] });
+    try map.addGeoJsonSourceData(testing.allocator, "embedded-nul-id", .{ .feature_collection = features[0..] }, null);
     try testing.expect(try map.styleSourceExists(testing.allocator, "embedded-nul-id"));
 }
 
@@ -139,6 +147,54 @@ test "geometry coordinate spans remain stable across nested materialization" {
         testing.allocator,
         "many-lines",
         .{ .geometry = .{ .multi_line_string = lines[0..] } },
+        null,
     );
     try testing.expect(try map.styleSourceExists(testing.allocator, "many-lines"));
+}
+
+test "GeoJSON source options carry cluster settings and reject malformed cluster properties" {
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+    var map = try createLoadedMap(&runtime);
+    defer map.close() catch @panic("map close failed");
+
+    const first_properties = [_]maplibre.JsonMember{.{ .key = "rank", .value = .{ .uint = 1 } }};
+    const second_properties = [_]maplibre.JsonMember{.{ .key = "rank", .value = .{ .uint = 2 } }};
+    const features = [_]maplibre.Feature{
+        .{ .geometry = .{ .point = .{ .latitude = 0.0, .longitude = 0.0 } }, .properties = first_properties[0..] },
+        .{ .geometry = .{ .point = .{ .latitude = 0.001, .longitude = 0.001 } }, .properties = second_properties[0..] },
+    };
+    const rank_expression = [_]maplibre.JsonValue{ .{ .string = "get" }, .{ .string = "rank" } };
+    const total_expression = [_]maplibre.JsonValue{ .{ .string = "+" }, .{ .array = rank_expression[0..] } };
+    const cluster_properties = [_]maplibre.JsonMember{.{ .key = "total", .value = .{ .array = total_expression[0..] } }};
+    // MapLibre Native parses the aggregation expressions while the descriptor is borrowed, so a
+    // source that adds successfully proves the nested cluster property tree crossed the boundary.
+    try map.addGeoJsonSourceData(
+        testing.allocator,
+        "clustered",
+        .{ .feature_collection = features[0..] },
+        .{
+            .min_zoom = 0,
+            .buffer = 0,
+            .cluster = true,
+            .cluster_radius = 50,
+            .cluster_min_points = 2,
+            .cluster_max_zoom = 14,
+            .cluster_properties = .{ .object = cluster_properties[0..] },
+        },
+    );
+    try testing.expect(try map.styleSourceExists(testing.allocator, "clustered"));
+
+    // Options are fixed at creation, so replacing the data keeps the clustered source usable.
+    try map.setGeoJsonSourceData(testing.allocator, "clustered", .{ .feature_collection = features[0..] });
+    try testing.expectEqual(maplibre.StyleSourceType.geojson, (try map.getStyleSourceType(testing.allocator, "clustered")).?);
+
+    const malformed_expression = [_]maplibre.JsonValue{.{ .string = "+" }};
+    const malformed_properties = [_]maplibre.JsonMember{.{ .key = "total", .value = .{ .array = malformed_expression[0..] } }};
+    try testing.expectError(error.InvalidArgument, map.addGeoJsonSourceData(
+        testing.allocator,
+        "malformed-clustered",
+        .{ .feature_collection = features[0..] },
+        .{ .cluster = true, .cluster_properties = .{ .object = malformed_properties[0..] } },
+    ));
 }

--- a/bindings/zig/tests/render.zig
+++ b/bindings/zig/tests/render.zig
@@ -1506,6 +1506,101 @@ test "render session queries cluster feature extensions" {
     try testing.expect(!std.mem.eql(u8, try singleLeafName(first), try singleLeafName(second)));
 }
 
+fn featurePropertyNumber(feature: *const maplibre.QueriedFeature, key: []const u8) !f64 {
+    for (feature.feature.properties) |property| {
+        if (!std.mem.eql(u8, property.key, key)) continue;
+        return switch (property.value) {
+            .uint => |value| @floatFromInt(value),
+            .int => |value| @floatFromInt(value),
+            .double => |value| value,
+            else => error.ExpectedNumberProperty,
+        };
+    }
+    return error.MissingFeatureProperty;
+}
+
+fn featurePropertyBool(feature: *const maplibre.QueriedFeature, key: []const u8) !bool {
+    for (feature.feature.properties) |property| {
+        if (!std.mem.eql(u8, property.key, key)) continue;
+        return switch (property.value) {
+            .bool => |value| value,
+            else => error.ExpectedBoolProperty,
+        };
+    }
+    return error.MissingFeatureProperty;
+}
+
+test "GeoJSON source options cluster nearby points and aggregate cluster properties" {
+    if (!supports_test_owned_texture) return error.SkipZigTest;
+    var runtime = try maplibre.RuntimeHandle.create(testing.allocator, .{}, null);
+    defer runtime.close() catch @panic("runtime close failed");
+
+    var map = try maplibre.MapHandle.create(&runtime, .{});
+    defer map.close() catch @panic("map close failed");
+
+    var owned = try attachTestOwnedTexture(&map, .{});
+    defer owned.close() catch {};
+    const session = &owned.session;
+
+    try map.jumpTo(.{ .center = .{ .latitude = 0, .longitude = 0 }, .zoom = 0 });
+    try map.setStyleJson(testing.allocator, support.style_json);
+    try testing.expect(try waitForEvent(&runtime, .map_style_loaded));
+
+    const first_properties = [_]maplibre.JsonMember{.{ .key = "rank", .value = .{ .uint = 1 } }};
+    const second_properties = [_]maplibre.JsonMember{.{ .key = "rank", .value = .{ .uint = 2 } }};
+    const third_properties = [_]maplibre.JsonMember{.{ .key = "rank", .value = .{ .uint = 3 } }};
+    const features = [_]maplibre.Feature{
+        .{ .geometry = .{ .point = .{ .latitude = 0.0, .longitude = 0.0 } }, .properties = first_properties[0..] },
+        .{ .geometry = .{ .point = .{ .latitude = 0.001, .longitude = 0.001 } }, .properties = second_properties[0..] },
+        .{ .geometry = .{ .point = .{ .latitude = 0.002, .longitude = 0.002 } }, .properties = third_properties[0..] },
+    };
+    const rank_expression = [_]maplibre.JsonValue{ .{ .string = "get" }, .{ .string = "rank" } };
+    const total_expression = [_]maplibre.JsonValue{ .{ .string = "+" }, .{ .array = rank_expression[0..] } };
+    const cluster_properties = [_]maplibre.JsonMember{.{ .key = "total", .value = .{ .array = total_expression[0..] } }};
+    try map.addGeoJsonSourceData(
+        testing.allocator,
+        "cluster-options-source",
+        .{ .feature_collection = features[0..] },
+        .{
+            .cluster = true,
+            .cluster_radius = 50,
+            .cluster_min_points = 2,
+            .cluster_max_zoom = 14,
+            .cluster_properties = .{ .object = cluster_properties[0..] },
+        },
+    );
+
+    const filter = [_]maplibre.JsonValue{ .{ .string = "has" }, .{ .string = "point_count" } };
+    const paint = [_]maplibre.JsonMember{.{ .key = "circle-radius", .value = .{ .uint = 20 } }};
+    const layer_members = [_]maplibre.JsonMember{
+        .{ .key = "id", .value = .{ .string = "cluster-options-circle" } },
+        .{ .key = "type", .value = .{ .string = "circle" } },
+        .{ .key = "source", .value = .{ .string = "cluster-options-source" } },
+        .{ .key = "filter", .value = .{ .array = filter[0..] } },
+        .{ .key = "paint", .value = .{ .object = paint[0..] } },
+    };
+    try map.addStyleLayerJson(testing.allocator, .{ .object = layer_members[0..] }, "");
+
+    for (0..5) |_| {
+        if (!try waitForEvent(&runtime, .map_render_update_available)) break;
+        _ = try session.renderUpdate();
+    }
+
+    // The layer only draws features carrying point_count, so a queried feature proves the source
+    // options clustered the points rather than rendering them individually.
+    const query_point = try map.pixelForLatLng(.{ .latitude = 0, .longitude = 0 });
+    var clusters = try waitForRenderedFeatureQuery(&runtime, session, .{ .box = .{
+        .min = .{ .x = query_point.x - 30, .y = query_point.y - 30 },
+        .max = .{ .x = query_point.x + 30, .y = query_point.y + 30 },
+    } }, .{ .layer_ids = &.{"cluster-options-circle"} });
+    defer clusters.deinit();
+
+    const cluster = &clusters.features[0];
+    try testing.expect(try featurePropertyBool(cluster, "cluster"));
+    try testing.expectEqual(@as(f64, 3), try featurePropertyNumber(cluster, "point_count"));
+    try testing.expectEqual(@as(f64, 6), try featurePropertyNumber(cluster, "total"));
+}
+
 fn singleLeafName(result: maplibre.FeatureExtensionResult) ![]const u8 {
     const collection = switch (result) {
         .feature_collection => |value| value,

--- a/bindings/zig/tests/style_sources.zig
+++ b/bindings/zig/tests/style_sources.zig
@@ -74,7 +74,7 @@ test "style source removal reports state and copies missing results" {
     defer map.close() catch @panic("map close failed");
 
     const empty_features = [_]maplibre.Feature{};
-    try map.addGeoJsonSourceData(testing.allocator, "remove-me", .{ .feature_collection = empty_features[0..] });
+    try map.addGeoJsonSourceData(testing.allocator, "remove-me", .{ .feature_collection = empty_features[0..] }, null);
     try testing.expect(try map.styleSourceExists(testing.allocator, "remove-me"));
     try testing.expect(try map.removeStyleSource(testing.allocator, "remove-me"));
     try testing.expect(!try map.styleSourceExists(testing.allocator, "remove-me"));

--- a/bindings/zig/tests/style_values.zig
+++ b/bindings/zig/tests/style_values.zig
@@ -72,7 +72,7 @@ test "style layer JSON helpers manage lifecycle and order" {
     defer map.close() catch @panic("map close failed");
 
     const empty_features = [_]maplibre.Feature{};
-    try map.addGeoJsonSourceData(testing.allocator, "empty-layer-source", .{ .feature_collection = empty_features[0..] });
+    try map.addGeoJsonSourceData(testing.allocator, "empty-layer-source", .{ .feature_collection = empty_features[0..] }, null);
 
     const layer_members = [_]maplibre.JsonMember{
         .{ .key = "id", .value = .{ .string = "empty-circle" } },

--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -65,6 +65,21 @@ typedef enum mln_style_raster_dem_encoding : uint32_t {
   MLN_STYLE_RASTER_DEM_ENCODING_TERRARIUM = 1,
 } mln_style_raster_dem_encoding;
 
+/** Field mask values for mln_geojson_source_options. */
+typedef enum mln_geojson_source_option_field : uint32_t {
+  MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM = 1U << 0U,
+  MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM = 1U << 1U,
+  MLN_GEOJSON_SOURCE_OPTION_TOLERANCE = 1U << 2U,
+  MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM = 1U << 3U,
+  MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES = 1U << 4U,
+  MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE = 1U << 5U,
+  MLN_GEOJSON_SOURCE_OPTION_BUFFER = 1U << 6U,
+  MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS = 1U << 7U,
+  MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS = 1U << 8U,
+  MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS = 1U << 9U,
+  MLN_GEOJSON_SOURCE_OPTION_CLUSTER = 1U << 10U,
+} mln_geojson_source_option_field;
+
 /** Field mask values for mln_custom_geometry_source_options. */
 typedef enum mln_custom_geometry_source_option_field : uint32_t {
   MLN_CUSTOM_GEOMETRY_SOURCE_OPTION_MIN_ZOOM = 1U << 0U,
@@ -119,6 +134,44 @@ typedef struct mln_style_tile_source_options {
   /** One of mln_style_raster_dem_encoding. Defaults to Mapbox. */
   uint32_t raster_encoding;
 } mln_style_tile_source_options;
+
+/**
+ * Options for GeoJSON sources.
+ *
+ * MapLibre Native fixes these options when the source is created, so
+ * mln_map_set_geojson_source_url() and mln_map_set_geojson_source_data() keep
+ * the options the source was added with.
+ */
+typedef struct mln_geojson_source_options {
+  uint32_t size;
+  uint32_t fields;
+  /** Minimum tiling zoom. Defaults to 0. */
+  double min_zoom;
+  /** Maximum tiling zoom. Defaults to 18. */
+  double max_zoom;
+  /** Douglas-Peucker simplification tolerance. Defaults to 0.375. */
+  double tolerance;
+  /** Highest zoom that clusters points. Defaults to 17. */
+  double cluster_max_zoom;
+  /**
+   * Cluster aggregation expressions keyed by property name, as a JSON object
+   * whose members follow the MapLibre Style Spec clusterProperties form. The
+   * descriptor graph is borrowed for the call.
+   */
+  const mln_json_value* cluster_properties;
+  /** Tile extent in pixels. Defaults to 512. */
+  uint32_t tile_size;
+  /** Tile buffer in pixels. Defaults to 128. */
+  uint32_t buffer;
+  /** Cluster radius in pixels. Defaults to 50. */
+  uint32_t cluster_radius;
+  /** Points required to form a cluster. Defaults to 2. */
+  uint32_t cluster_min_points;
+  /** Adds line distance metrics to line features. Defaults to false. */
+  bool line_metrics;
+  /** Clusters point features. Defaults to false. */
+  bool cluster;
+} mln_geojson_source_options;
 
 /** Canonical tile identity used by custom geometry source callbacks. */
 typedef struct mln_canonical_tile_id {
@@ -189,6 +242,10 @@ typedef struct mln_style_image_info {
 /** Returns default tile source options. */
 MLN_API mln_style_tile_source_options
 mln_style_tile_source_options_default(void) MLN_NOEXCEPT;
+
+/** Returns default GeoJSON source options. */
+MLN_API mln_geojson_source_options
+mln_geojson_source_options_default(void) MLN_NOEXCEPT;
 
 /** Returns default custom geometry source options. */
 MLN_API mln_custom_geometry_source_options
@@ -377,43 +434,49 @@ MLN_API mln_status mln_map_list_style_source_ids(
 /**
  * Adds a GeoJSON source with URL data.
  *
- * source_id and url are borrowed for the call. The source loads GeoJSON from
- * url through MapLibre Native's resource system.
+ * source_id, url, and options are borrowed for the call. The source loads
+ * GeoJSON from url through MapLibre Native's resource system. options may be
+ * null for defaults, and the options are fixed for the lifetime of the source.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id or url
- *   is invalid or empty, or the source ID already exists.
+ *   is invalid or empty, options is invalid, or the source ID already exists.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_map_add_geojson_source_url(
-  mln_map* map, mln_string_view source_id, mln_string_view url
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_geojson_source_options* options
 ) MLN_NOEXCEPT;
 
 /**
  * Adds a GeoJSON source with inline data.
  *
- * source_id and data are borrowed for the call. The accepted GeoJSON descriptor
- * is copied into MapLibre Native before return.
+ * source_id, data, and options are borrowed for the call. The accepted GeoJSON
+ * descriptor is copied into MapLibre Native before return. options may be null
+ * for defaults, and the options are fixed for the lifetime of the source.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
- *   invalid or empty, data is null or invalid, or the source ID already exists.
+ *   invalid or empty, data is null or invalid, options is invalid, or the
+ *   source ID already exists.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
  */
 MLN_API mln_status mln_map_add_geojson_source_data(
-  mln_map* map, mln_string_view source_id, const mln_geojson* data
+  mln_map* map, mln_string_view source_id, const mln_geojson* data,
+  const mln_geojson_source_options* options
 ) MLN_NOEXCEPT;
 
 /**
  * Updates one GeoJSON source to load data from a URL.
  *
- * source_id and url are borrowed for the call.
+ * source_id and url are borrowed for the call. The source keeps the
+ * mln_geojson_source_options it was added with.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
@@ -432,7 +495,8 @@ MLN_API mln_status mln_map_set_geojson_source_url(
  * Updates one GeoJSON source with inline data.
  *
  * source_id and data are borrowed for the call. The accepted GeoJSON descriptor
- * is copied into MapLibre Native before return.
+ * is copied into MapLibre Native before return. The source keeps the
+ * mln_geojson_source_options it was added with.
  *
  * Returns:
  * - MLN_STATUS_OK on success.

--- a/src/c_api/map.cpp
+++ b/src/c_api/map.cpp
@@ -50,6 +50,11 @@ auto mln_style_tile_source_options_default(void) noexcept
   return mln::core::style_tile_source_options_default();
 }
 
+auto mln_geojson_source_options_default(void) noexcept
+  -> mln_geojson_source_options {
+  return mln::core::geojson_source_options_default();
+}
+
 auto mln_custom_geometry_source_options_default(void) noexcept
   -> mln_custom_geometry_source_options {
   return mln::core::custom_geometry_source_options_default();
@@ -195,18 +200,22 @@ auto mln_map_list_style_source_ids(
 }
 
 auto mln_map_add_geojson_source_url(
-  mln_map* map, mln_string_view source_id, mln_string_view url
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_geojson_source_options* options
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::map_add_geojson_source_url(map, source_id, url);
+    return mln::core::map_add_geojson_source_url(map, source_id, url, options);
   });
 }
 
 auto mln_map_add_geojson_source_data(
-  mln_map* map, mln_string_view source_id, const mln_geojson* data
+  mln_map* map, mln_string_view source_id, const mln_geojson* data,
+  const mln_geojson_source_options* options
 ) noexcept -> mln_status {
   return mln::c_api::status_boundary([&]() -> mln_status {
-    return mln::core::map_add_geojson_source_data(map, source_id, data);
+    return mln::core::map_add_geojson_source_data(
+      map, source_id, data, options
+    );
   });
 }
 

--- a/src/c_api/tests/style_values_abi.c
+++ b/src/c_api/tests/style_values_abi.c
@@ -69,6 +69,17 @@ static void geojson_source_options_reject_unsafe_raw_headers(void) {
     )
   );
 
+  mln_geojson_source_options null_cluster_properties =
+    mln_geojson_source_options_default();
+  null_cluster_properties.fields = MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_add_geojson_source_url(
+      map, (mln_string_view){.data = "null-properties", .size = 15}, url,
+      &null_cluster_properties
+    )
+  );
+
   // A rejected descriptor leaves the source ID free for a later valid add.
   mln_geojson_source_options clustered = mln_geojson_source_options_default();
   clustered.fields = MLN_GEOJSON_SOURCE_OPTION_CLUSTER;

--- a/src/c_api/tests/style_values_abi.c
+++ b/src/c_api/tests/style_values_abi.c
@@ -80,6 +80,24 @@ static void geojson_source_options_reject_unsafe_raw_headers(void) {
     )
   );
 
+  mln_json_value json_null_cluster_properties = {
+    .size = sizeof(mln_json_value),
+    .type = MLN_JSON_VALUE_TYPE_NULL,
+  };
+  mln_geojson_source_options non_object_cluster_properties =
+    mln_geojson_source_options_default();
+  non_object_cluster_properties.fields =
+    MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES;
+  non_object_cluster_properties.cluster_properties =
+    &json_null_cluster_properties;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_add_geojson_source_url(
+      map, (mln_string_view){.data = "json-null-properties", .size = 20}, url,
+      &non_object_cluster_properties
+    )
+  );
+
   // A rejected descriptor leaves the source ID free for a later valid add.
   mln_geojson_source_options clustered = mln_geojson_source_options_default();
   clustered.fields = MLN_GEOJSON_SOURCE_OPTION_CLUSTER;

--- a/src/c_api/tests/style_values_abi.c
+++ b/src/c_api/tests/style_values_abi.c
@@ -39,7 +39,53 @@ static void style_value_helpers_reject_unsafe_raw_descriptors(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+// Bindings always emit a full struct header, so only raw C callers can present
+// a short size or unknown field bits to the GeoJSON source adders.
+static void geojson_source_options_reject_unsafe_raw_headers(void) {
+  mln_runtime* runtime = mln_test_create_runtime();
+  mln_map* map = mln_test_create_map(runtime);
+  const mln_string_view url = {
+    .data = "https://example.com/points.geojson", .size = 34
+  };
+
+  mln_geojson_source_options short_size = mln_geojson_source_options_default();
+  short_size.size = (uint32_t)(sizeof(mln_geojson_source_options) - 1);
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_add_geojson_source_url(
+      map, (mln_string_view){.data = "short-header", .size = 12}, url,
+      &short_size
+    )
+  );
+
+  mln_geojson_source_options unknown_field =
+    mln_geojson_source_options_default();
+  unknown_field.fields = 1U << 31U;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_add_geojson_source_url(
+      map, (mln_string_view){.data = "unknown-field", .size = 13}, url,
+      &unknown_field
+    )
+  );
+
+  // A rejected descriptor leaves the source ID free for a later valid add.
+  mln_geojson_source_options clustered = mln_geojson_source_options_default();
+  clustered.fields = MLN_GEOJSON_SOURCE_OPTION_CLUSTER;
+  clustered.cluster = true;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_map_add_geojson_source_url(
+                     map, (mln_string_view){.data = "short-header", .size = 12},
+                     url, &clustered
+                   )
+  );
+
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
 void run_style_values_abi_tests(void) {
   UnitySetTestFile(__FILE__);
   RUN_TEST(style_value_helpers_reject_unsafe_raw_descriptors);
+  RUN_TEST(geojson_source_options_reject_unsafe_raw_headers);
 }

--- a/src/c_api/tests/style_values_abi.c
+++ b/src/c_api/tests/style_values_abi.c
@@ -69,6 +69,43 @@ static void geojson_source_options_reject_unsafe_raw_headers(void) {
     )
   );
 
+  mln_geojson_source_options fractional_min_zoom =
+    mln_geojson_source_options_default();
+  fractional_min_zoom.fields = MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM;
+  fractional_min_zoom.min_zoom = 1.5;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_add_geojson_source_url(
+      map, (mln_string_view){.data = "fractional-min", .size = 14}, url,
+      &fractional_min_zoom
+    )
+  );
+
+  mln_geojson_source_options fractional_max_zoom =
+    mln_geojson_source_options_default();
+  fractional_max_zoom.fields = MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM;
+  fractional_max_zoom.max_zoom = 17.9;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_add_geojson_source_url(
+      map, (mln_string_view){.data = "fractional-max", .size = 14}, url,
+      &fractional_max_zoom
+    )
+  );
+
+  mln_geojson_source_options fractional_cluster_max_zoom =
+    mln_geojson_source_options_default();
+  fractional_cluster_max_zoom.fields =
+    MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM;
+  fractional_cluster_max_zoom.cluster_max_zoom = 12.25;
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_add_geojson_source_url(
+      map, (mln_string_view){.data = "fractional-cluster", .size = 18}, url,
+      &fractional_cluster_max_zoom
+    )
+  );
+
   mln_geojson_source_options null_cluster_properties =
     mln_geojson_source_options_default();
   null_cluster_properties.fields = MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -652,6 +652,17 @@ auto validate_geojson_source_options(const mln_geojson_source_options* options)
     return MLN_STATUS_INVALID_ARGUMENT;
   }
   if (
+    has_geojson_source_option(
+      *options, MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+    ) &&
+    effective.cluster_properties == nullptr
+  ) {
+    mln::core::set_thread_error(
+      "cluster_properties must not be null when its field is present"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
     effective.cluster_properties != nullptr &&
     !mln::core::validate_style_json_value(effective.cluster_properties)
   ) {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -623,8 +623,11 @@ auto validate_geojson_source_options(const mln_geojson_source_options* options)
          std::pair{effective.max_zoom, "max_zoom"},
          std::pair{effective.cluster_max_zoom, "cluster_max_zoom"},
        }) {
-    if (!std::isfinite(zoom) || zoom < 0.0 || zoom > 255.0) {
-      auto message = std::string{name} + " must be within [0, 255]";
+    if (
+      !std::isfinite(zoom) || zoom < 0.0 || zoom > 255.0 ||
+      std::floor(zoom) != zoom
+    ) {
+      auto message = std::string{name} + " must be an integer within [0, 255]";
       mln::core::set_thread_error(message.c_str());
       return MLN_STATUS_INVALID_ARGUMENT;
     }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -14,6 +14,7 @@
 #include <ratio>
 #include <span>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -33,9 +34,10 @@
 #include <mbgl/renderer/renderer_observer.hpp>
 #include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/style/conversion.hpp>
-#include <mbgl/style/conversion/layer.hpp>   // IWYU pragma: keep
-#include <mbgl/style/conversion/light.hpp>   // IWYU pragma: keep
-#include <mbgl/style/conversion/source.hpp>  // IWYU pragma: keep
+#include <mbgl/style/conversion/geojson_options.hpp>  // IWYU pragma: keep
+#include <mbgl/style/conversion/layer.hpp>            // IWYU pragma: keep
+#include <mbgl/style/conversion/light.hpp>            // IWYU pragma: keep
+#include <mbgl/style/conversion/source.hpp>           // IWYU pragma: keep
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/style/image.hpp>
 #include <mbgl/style/layer.hpp>
@@ -60,6 +62,7 @@
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/image.hpp>
+#include <mbgl/util/immutable.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/range.hpp>
 #include <mbgl/util/size.hpp>
@@ -515,6 +518,192 @@ auto to_native_tileset(
     tileset.bounds = to_native_lat_lng_bounds(options.bounds);
   }
   return tileset;
+}
+
+auto has_geojson_source_option(
+  const mln_geojson_source_options& options, uint32_t field
+) -> bool {
+  return (options.fields & field) != 0U;
+}
+
+auto effective_geojson_source_options(const mln_geojson_source_options* options)
+  -> mln_geojson_source_options {
+  auto result = mln::core::geojson_source_options_default();
+  if (options == nullptr) {
+    return result;
+  }
+
+  result.fields = options->fields;
+  if (has_geojson_source_option(*options, MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM)) {
+    result.min_zoom = options->min_zoom;
+  }
+  if (has_geojson_source_option(*options, MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM)) {
+    result.max_zoom = options->max_zoom;
+  }
+  if (
+    has_geojson_source_option(*options, MLN_GEOJSON_SOURCE_OPTION_TOLERANCE)
+  ) {
+    result.tolerance = options->tolerance;
+  }
+  if (
+    has_geojson_source_option(
+      *options, MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM
+    )
+  ) {
+    result.cluster_max_zoom = options->cluster_max_zoom;
+  }
+  if (
+    has_geojson_source_option(
+      *options, MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES
+    )
+  ) {
+    result.cluster_properties = options->cluster_properties;
+  }
+  if (
+    has_geojson_source_option(*options, MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE)
+  ) {
+    result.tile_size = options->tile_size;
+  }
+  if (has_geojson_source_option(*options, MLN_GEOJSON_SOURCE_OPTION_BUFFER)) {
+    result.buffer = options->buffer;
+  }
+  if (
+    has_geojson_source_option(
+      *options, MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS
+    )
+  ) {
+    result.cluster_radius = options->cluster_radius;
+  }
+  if (
+    has_geojson_source_option(
+      *options, MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS
+    )
+  ) {
+    result.cluster_min_points = options->cluster_min_points;
+  }
+  if (
+    has_geojson_source_option(*options, MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS)
+  ) {
+    result.line_metrics = options->line_metrics;
+  }
+  if (has_geojson_source_option(*options, MLN_GEOJSON_SOURCE_OPTION_CLUSTER)) {
+    result.cluster = options->cluster;
+  }
+  return result;
+}
+
+auto validate_geojson_source_options(const mln_geojson_source_options* options)
+  -> mln_status {
+  if (options == nullptr) {
+    return MLN_STATUS_OK;
+  }
+  if (options->size < sizeof(mln_geojson_source_options)) {
+    mln::core::set_thread_error("mln_geojson_source_options.size is too small");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  constexpr auto known_fields =
+    static_cast<uint32_t>(MLN_GEOJSON_SOURCE_OPTION_MIN_ZOOM) |
+    MLN_GEOJSON_SOURCE_OPTION_MAX_ZOOM | MLN_GEOJSON_SOURCE_OPTION_TOLERANCE |
+    MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MAX_ZOOM |
+    MLN_GEOJSON_SOURCE_OPTION_CLUSTER_PROPERTIES |
+    MLN_GEOJSON_SOURCE_OPTION_TILE_SIZE | MLN_GEOJSON_SOURCE_OPTION_BUFFER |
+    MLN_GEOJSON_SOURCE_OPTION_CLUSTER_RADIUS |
+    MLN_GEOJSON_SOURCE_OPTION_CLUSTER_MIN_POINTS |
+    MLN_GEOJSON_SOURCE_OPTION_LINE_METRICS | MLN_GEOJSON_SOURCE_OPTION_CLUSTER;
+  if ((options->fields & ~known_fields) != 0U) {
+    mln::core::set_thread_error(
+      "mln_geojson_source_options.fields contains unknown bits"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  const auto effective = effective_geojson_source_options(options);
+  for (const auto& [zoom, name] : {
+         std::pair{effective.min_zoom, "min_zoom"},
+         std::pair{effective.max_zoom, "max_zoom"},
+         std::pair{effective.cluster_max_zoom, "cluster_max_zoom"},
+       }) {
+    if (!std::isfinite(zoom) || zoom < 0.0 || zoom > 255.0) {
+      auto message = std::string{name} + " must be within [0, 255]";
+      mln::core::set_thread_error(message.c_str());
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  if (effective.min_zoom > effective.max_zoom) {
+    mln::core::set_thread_error(
+      "min_zoom must be less than or equal to max_zoom"
+    );
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!std::isfinite(effective.tolerance) || effective.tolerance < 0.0) {
+    mln::core::set_thread_error("tolerance must be finite and non-negative");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (effective.tile_size == 0 || effective.tile_size > 65535U) {
+    mln::core::set_thread_error("tile_size must be within [1, 65535]");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (effective.buffer > 65535U) {
+    mln::core::set_thread_error("buffer must be at most 65535");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (effective.cluster_radius > 65535U) {
+    mln::core::set_thread_error("cluster_radius must be at most 65535");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    effective.cluster_properties != nullptr &&
+    !mln::core::validate_style_json_value(effective.cluster_properties)
+  ) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  return MLN_STATUS_OK;
+}
+
+/**
+ * Converts validated options into mbgl form.
+ *
+ * Cluster properties are handed to Converter<GeoJSONOptions> as a one-member
+ * object so MapLibre Native parses the aggregation expressions.
+ */
+auto to_native_geojson_source_options(const mln_geojson_source_options& options)
+  -> std::optional<mbgl::Immutable<mbgl::style::GeoJSONOptions>> {
+  auto native = mbgl::style::GeoJSONOptions{};
+  native.minzoom = static_cast<uint8_t>(options.min_zoom);
+  native.maxzoom = static_cast<uint8_t>(options.max_zoom);
+  native.tileSize = static_cast<uint16_t>(options.tile_size);
+  native.buffer = static_cast<uint16_t>(options.buffer);
+  native.tolerance = options.tolerance;
+  native.lineMetrics = options.line_metrics;
+  native.cluster = options.cluster;
+  native.clusterRadius = static_cast<uint16_t>(options.cluster_radius);
+  native.clusterMaxZoom = static_cast<uint8_t>(options.cluster_max_zoom);
+  native.clusterMinPoints = options.cluster_min_points;
+
+  if (options.cluster_properties != nullptr) {
+    constexpr auto key = std::string_view{"clusterProperties"};
+    const auto member = mln_json_member{
+      .key = {.data = key.data(), .size = key.size()},
+      .value = options.cluster_properties
+    };
+    const auto wrapper = mln_json_value{
+      .size = sizeof(mln_json_value),
+      .type = MLN_JSON_VALUE_TYPE_OBJECT,
+      .data = {.object_value = {.members = &member, .member_count = 1}}
+    };
+    auto error = mbgl::style::conversion::Error{};
+    auto converted =
+      mbgl::style::conversion::convert<mbgl::style::GeoJSONOptions>(
+        mbgl::style::conversion::Convertible{&wrapper}, error
+      );
+    if (!converted) {
+      mln::core::set_style_conversion_error("GeoJSON source options", error);
+      return std::nullopt;
+    }
+    native.clusterProperties = std::move(converted->clusterProperties);
+  }
+
+  return mbgl::makeMutable<mbgl::style::GeoJSONOptions>(std::move(native));
 }
 
 auto has_custom_geometry_source_option(
@@ -2573,6 +2762,25 @@ auto style_tile_source_options_default() noexcept
   };
 }
 
+auto geojson_source_options_default() noexcept -> mln_geojson_source_options {
+  const auto defaults = mbgl::style::GeoJSONOptions{};
+  return mln_geojson_source_options{
+    .size = sizeof(mln_geojson_source_options),
+    .fields = 0,
+    .min_zoom = static_cast<double>(defaults.minzoom),
+    .max_zoom = static_cast<double>(defaults.maxzoom),
+    .tolerance = defaults.tolerance,
+    .cluster_max_zoom = static_cast<double>(defaults.clusterMaxZoom),
+    .cluster_properties = nullptr,
+    .tile_size = defaults.tileSize,
+    .buffer = defaults.buffer,
+    .cluster_radius = defaults.clusterRadius,
+    .cluster_min_points = static_cast<uint32_t>(defaults.clusterMinPoints),
+    .line_metrics = defaults.lineMetrics,
+    .cluster = defaults.cluster
+  };
+}
+
 auto custom_geometry_source_options_default() noexcept
   -> mln_custom_geometry_source_options {
   return mln_custom_geometry_source_options{
@@ -3187,7 +3395,8 @@ auto map_list_style_source_ids(mln_map* map, mln_style_id_list** out_source_ids)
 }
 
 auto map_add_geojson_source_url(
-  mln_map* map, mln_string_view source_id, mln_string_view url
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_geojson_source_options* options
 ) -> mln_status {
   const auto status = validate_map(map);
   if (status != MLN_STATUS_OK) {
@@ -3204,6 +3413,10 @@ auto map_add_geojson_source_url(
     set_thread_error("url must not be empty");
     return MLN_STATUS_INVALID_ARGUMENT;
   }
+  const auto options_status = validate_geojson_source_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
 
   auto& style = map->map->getStyle();
   const auto id = string_from_view(source_id);
@@ -3212,14 +3425,23 @@ auto map_add_geojson_source_url(
     return add_status;
   }
 
-  auto source = std::make_unique<mbgl::style::GeoJSONSource>(id);
+  auto native_options =
+    to_native_geojson_source_options(effective_geojson_source_options(options));
+  if (!native_options) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto source = std::make_unique<mbgl::style::GeoJSONSource>(
+    id, std::move(*native_options)
+  );
   source->setURL(string_from_view(url));
   style.addSource(std::move(source));
   return MLN_STATUS_OK;
 }
 
 auto map_add_geojson_source_data(
-  mln_map* map, mln_string_view source_id, const mln_geojson* data
+  mln_map* map, mln_string_view source_id, const mln_geojson* data,
+  const mln_geojson_source_options* options
 ) -> mln_status {
   const auto status = validate_map(map);
   if (status != MLN_STATUS_OK) {
@@ -3234,6 +3456,10 @@ auto map_add_geojson_source_data(
   if (!geojson) {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
+  const auto options_status = validate_geojson_source_options(options);
+  if (options_status != MLN_STATUS_OK) {
+    return options_status;
+  }
 
   auto& style = map->map->getStyle();
   const auto id = string_from_view(source_id);
@@ -3242,7 +3468,15 @@ auto map_add_geojson_source_data(
     return add_status;
   }
 
-  auto source = std::make_unique<mbgl::style::GeoJSONSource>(id);
+  auto native_options =
+    to_native_geojson_source_options(effective_geojson_source_options(options));
+  if (!native_options) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto source = std::make_unique<mbgl::style::GeoJSONSource>(
+    id, std::move(*native_options)
+  );
   source->setGeoJSON(*geojson);
   style.addSource(std::move(source));
   return MLN_STATUS_OK;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -662,11 +662,14 @@ auto validate_geojson_source_options(const mln_geojson_source_options* options)
     );
     return MLN_STATUS_INVALID_ARGUMENT;
   }
-  if (
-    effective.cluster_properties != nullptr &&
-    !mln::core::validate_style_json_value(effective.cluster_properties)
-  ) {
-    return MLN_STATUS_INVALID_ARGUMENT;
+  if (effective.cluster_properties != nullptr) {
+    if (!mln::core::validate_style_json_value(effective.cluster_properties)) {
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
+    if (effective.cluster_properties->type != MLN_JSON_VALUE_TYPE_OBJECT) {
+      mln::core::set_thread_error("cluster_properties must be a JSON object");
+      return MLN_STATUS_INVALID_ARGUMENT;
+    }
   }
   return MLN_STATUS_OK;
 }

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -26,6 +26,7 @@ auto map_viewport_options_default() noexcept -> mln_map_viewport_options;
 auto map_tile_options_default() noexcept -> mln_map_tile_options;
 auto style_tile_source_options_default() noexcept
   -> mln_style_tile_source_options;
+auto geojson_source_options_default() noexcept -> mln_geojson_source_options;
 auto custom_geometry_source_options_default() noexcept
   -> mln_custom_geometry_source_options;
 auto premultiplied_rgba8_image_default() noexcept
@@ -70,10 +71,12 @@ auto map_copy_style_source_attribution(
 auto map_list_style_source_ids(mln_map* map, mln_style_id_list** out_source_ids)
   -> mln_status;
 auto map_add_geojson_source_url(
-  mln_map* map, mln_string_view source_id, mln_string_view url
+  mln_map* map, mln_string_view source_id, mln_string_view url,
+  const mln_geojson_source_options* options
 ) -> mln_status;
 auto map_add_geojson_source_data(
-  mln_map* map, mln_string_view source_id, const mln_geojson* data
+  mln_map* map, mln_string_view source_id, const mln_geojson* data,
+  const mln_geojson_source_options* options
 ) -> mln_status;
 auto map_set_geojson_source_url(
   mln_map* map, mln_string_view source_id, mln_string_view url


### PR DESCRIPTION
## Summary

Adds `mln_geojson_source_options` and threads it through `mln_map_add_geojson_source_url()` and `mln_map_add_geojson_source_data()` so the typed GeoJSON adders can express clustering and the other `GeoJSONOptions` constructor arguments, which were previously reachable only by routing the source through `mln_map_add_style_source_json()`.

## Test plan

`mise run test` plus every binding suite that runs on Linux — Rust (186), Python (110), .NET (178), Swift (78), Go, Zig (152), Kotlin JVM — all pass, with the Rust and Zig render tests asserting `point_count == 3` and an aggregated `cluster_properties` value of `6` on a source built through the typed adder.

---

### Details

`GeoJSONOptions` is a constructor argument of `mbgl::style::GeoJSONSource` and is not reconstructible afterwards — `setURL`/`setGeoJSON` do not touch it — so `mln_map_set_geojson_source_*` could never reach it either. Both construction sites in `src/map/map.cpp` now pass converted options.

**Option set** (`size` + `fields` bitmask + scalars, matching `mln_style_tile_source_options`): `min_zoom`, `max_zoom`, `tolerance`, `cluster_max_zoom`, `cluster_properties`, `tile_size`, `buffer`, `cluster_radius`, `cluster_min_points`, `line_metrics`, `cluster`.

**Deliberate omission:** `synchronousUpdate`. It is an internal scheduling knob controlling whether `GeoJSONData::getTile` runs synchronously, not a style concept, and it has no counterpart in the MapLibre Style Spec.

`cluster_properties` is a `const mln_json_value*` handed to `Converter<GeoJSONOptions>` as a one-member object, so MapLibre Native parses the aggregation expressions rather than the C layer reimplementing expression parsing.

This is a breaking change to two existing signatures, which the prerelease policy in `CLAUDE.md` allows in preference to compatibility shims. All seven bindings gained the analogous options type; `bindings/rust/.../render/tests.rs` drops its raw-style-JSON clustered fixture and builds it through the typed adder instead.

### Known gaps

- Go, Swift, .NET, and Kotlin have no render-session fixture in their suites, so their cluster coverage asserts that a valid aggregation expression is accepted and a malformed one is rejected by native rather than querying rendered cluster features. Rust, Zig, and Python assert the rendered result.
- Kotlin `nativeMain` and `androidMain` code is written but untested here — Kotlin/Native targets are Apple-only and Android needs an NDK; CI covers both.
- Pre-existing and untouched: adding a clustered GeoJSON source whose data is non-point geometry surfaces `status -5: in get<T>()`, a leaked internal variant error rather than an invalid-argument diagnostic.

## AI assistance

- **Tools:** Claude Code
- **Context:** Implemented end to end with Claude Code — the native layer, the seven bindings, and the tests.
