### PR TITLE
Keep Metal rendered-query fixture on screen

### DIFF
--- a/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
+++ b/bindings/kotlin/src/appleTest/kotlin/org/maplibre/nativeffi/render/RenderSessionHandleTest.kt
@@ -131,6 +131,9 @@ class RenderSessionHandleTest {
             )
           )
         try {
+          val featureCoordinate = LatLng(37.7749, -122.4194)
+          // Rendered box queries clip to the viewport, so put the fixture feature on screen.
+          map.jumpTo(CameraOptions().apply { center = featureCoordinate })
           assertSame(map, session.map())
           assertFailsWith<InvalidStateException> { session.textureImageInfo() }
           assertFailsWith<InvalidStateException> {
@@ -189,7 +192,7 @@ class RenderSessionHandleTest {
             assertEquals(info.byteLength.toInt(), buffer.toByteArray().size)
           }
 
-          val queryPoint = map.pixelForLatLng(LatLng(37.7749, -122.4194))
+          val queryPoint = map.pixelForLatLng(featureCoordinate)
           val queryGeometry =
             RenderedQueryGeometry.Box(
               ScreenBox(


### PR DESCRIPTION
## Summary

Centers the macOS Metal rendered-query fixture on its GeoJSON feature so its viewport-clipped query terminates instead of hanging shared Kotlin CI.

## Test plan

Validated formatting and linting with `mise run check`; macOS Metal CI provides the target-specific verification.

## AI assistance

- **Tools:** Codex
- **Context:** Diagnosed the shared macOS Metal test hang and prepared the focused fixture correction.