### PR TITLE
fix(ci): restore mise shell defaults

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -285,6 +285,19 @@ runs:
           throw "no vulkan-1.dll in $($candidates -join ', ') or on PATH"
         }
 
+    # mise 2026.7.14 made project-local default shell settings global-only.
+    # Keep CI on the repository's Bash contract until a trusted project-scoped
+    # replacement is available: https://github.com/maplibre/maplibre-native-ffi/issues/366
+    - name: Configure mise shells
+      shell: bash
+      run: |
+        {
+          echo 'MISE_UNIX_DEFAULT_FILE_SHELL_ARGS=bash'
+          echo 'MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS=bash -e -c'
+          echo 'MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS="C:/Program Files/Git/bin/bash.exe"'
+          echo 'MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS="C:/Program Files/Git/bin/bash.exe" -e -lc'
+        } >> "$GITHUB_ENV"
+
     - name: Bootstrap repository
       uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       with:

--- a/mise.toml
+++ b/mise.toml
@@ -19,10 +19,6 @@ lockfile_platforms = [
 ]
 pin = true
 experimental = true
-windows_default_file_shell_args = '"C:/Program Files/Git/bin/bash.exe"'
-windows_default_inline_shell_args = '"C:/Program Files/Git/bin/bash.exe" -e -lc'
-unix_default_file_shell_args = "bash"
-unix_default_inline_shell_args = "bash -e -c"
 # On Windows, the Microsoft Store Python alias in WindowsApps can appear before
 # mise-managed Python. Keep mise tool paths first so file tasks run pinned tools.
 activate_aggressive = true


### PR DESCRIPTION
## Summary

Restore CI's cross-platform Bash contract through operator-owned environment variables after [mise #11293](https://github.com/jdx/mise/pull/11293) made the project settings global-only, remove the now-ignored settings, and track the contributor-facing replacement in #366.

## Test plan

Ran `hk check mise.toml .github/actions/setup-ci-deps/action.yml`, `git diff --check`, and a shell probe confirming the four `$GITHUB_ENV` values preserve the quoted Git Bash path.

## AI assistance

- **Tools:** Codex
- **Context:** Codex investigated the upstream mise change, implemented the CI-only environment workaround, ran the targeted checks, and prepared this draft PR.