### PR TITLE
Reject non-point geometry on clustered GeoJSON sources

### DIFF
--- a/bindings/rust/crates/maplibre-native/src/map/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/map/tests.rs
@@ -276,6 +276,45 @@ fn geojson_source_helpers_accept_options_and_keep_them_across_updates() {
 }
 
 #[test]
+// Spec coverage: BND-060 and BND-061.
+fn clustered_geojson_source_reports_non_point_geometry() {
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::default()).unwrap();
+    map.set_style_json(VALID_STYLE_JSON).unwrap();
+
+    let mut options = GeoJsonSourceOptions::default();
+    options.cluster = Some(true);
+
+    let mixed = GeoJson::FeatureCollection(vec![
+        Feature::new(Geometry::Point(LatLng::new(0.0, 0.0)), Vec::new()),
+        Feature::new(
+            Geometry::GeometryCollection(vec![Geometry::Point(LatLng::new(1.0, 1.0))]),
+            Vec::new(),
+        ),
+    ]);
+
+    // Supercluster reads every feature geometry as a point, so this used to
+    // surface a bare variant access message from inside MapLibre Native.
+    let error = map
+        .add_geojson_source_data("quakes", &mixed, Some(&options))
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+    let message = error.to_string();
+    assert!(message.contains("quakes"), "{message}");
+    assert!(
+        message.contains("point geometry on every feature"),
+        "{message}"
+    );
+    assert!(message.contains("geometry collection"), "{message}");
+
+    // The constraint belongs to clustering alone, and the rejected ID stays free.
+    map.add_geojson_source_data("quakes", &mixed, None).unwrap();
+
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
 // Spec coverage: BND-105.
 fn style_source_type_and_info_call_real_c_api() {
     let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();

--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -169,7 +169,15 @@ typedef struct mln_geojson_source_options {
   uint32_t cluster_min_points;
   /** Adds line distance metrics to line features. Defaults to false. */
   bool line_metrics;
-  /** Clusters point features. Defaults to false. */
+  /**
+   * Clusters point features. Defaults to false.
+   *
+   * Clustering applies to feature collections whose every feature carries point
+   * geometry. Feature collections that mix in other geometry are rejected by
+   * mln_map_add_geojson_source_data() and mln_map_set_geojson_source_data().
+   * MapLibre Native clusters feature collections only, so a source given a bare
+   * geometry or a single feature tiles that data without clustering it.
+   */
   bool cluster;
 } mln_geojson_source_options;
 
@@ -458,11 +466,17 @@ MLN_API mln_status mln_map_add_geojson_source_url(
  * descriptor is copied into MapLibre Native before return. options may be null
  * for defaults, and the options are fixed for the lifetime of the source.
  *
+ * When options enable clustering, every feature in a feature collection must
+ * carry point geometry. This call checks that before handing the data to
+ * MapLibre Native and names the source, the feature, and the constraint in the
+ * thread-local diagnostic when a feature carries other geometry.
+ *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
- *   invalid or empty, data is null or invalid, options is invalid, or the
- *   source ID already exists.
+ *   invalid or empty, data is null or invalid, options is invalid, the source
+ *   ID already exists, or clustering is enabled and a feature carries geometry
+ *   other than a point.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
@@ -498,11 +512,18 @@ MLN_API mln_status mln_map_set_geojson_source_url(
  * is copied into MapLibre Native before return. The source keeps the
  * mln_geojson_source_options it was added with.
  *
+ * When the source was added with clustering enabled, every feature in a feature
+ * collection must carry point geometry. This call checks that before handing
+ * the data to MapLibre Native and names the source, the feature, and the
+ * constraint in the thread-local diagnostic when a feature carries other
+ * geometry.
+ *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
- *   invalid or empty, data is null or invalid, the source does not exist, or
- *   the source is not a GeoJSON source.
+ *   invalid or empty, data is null or invalid, the source does not exist, the
+ *   source is not a GeoJSON source, or the source clusters and a feature
+ *   carries geometry other than a point.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.

--- a/src/c_api/tests/style_values_abi.c
+++ b/src/c_api/tests/style_values_abi.c
@@ -1,6 +1,8 @@
 // Raw C ABI coverage: malformed descriptor counts and unknown enum values are
 // hidden by binding-owned style values.
 
+#include <string.h>
+
 #include "test_support.h"
 #include "unity.h"
 
@@ -150,8 +152,87 @@ static void geojson_source_options_reject_unsafe_raw_headers(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+// Supercluster reads every feature geometry as a point, so clustered data
+// carrying other geometry used to surface a bare variant access message. The
+// C API rejects it up front and names the source, feature, and constraint.
+static void clustered_geojson_data_reports_non_point_geometry(void) {
+  mln_runtime* runtime = mln_test_create_runtime();
+  mln_map* map = mln_test_create_map(runtime);
+
+  const mln_geometry child = {
+    .size = sizeof(mln_geometry),
+    .type = MLN_GEOMETRY_TYPE_POINT,
+    .data = {.point = {.latitude = 37.8, .longitude = -122.4}}
+  };
+  const mln_geometry point = {
+    .size = sizeof(mln_geometry),
+    .type = MLN_GEOMETRY_TYPE_POINT,
+    .data = {.point = {.latitude = 37.7, .longitude = -122.5}}
+  };
+  const mln_geometry collection = {
+    .size = sizeof(mln_geometry),
+    .type = MLN_GEOMETRY_TYPE_GEOMETRY_COLLECTION,
+    .data = {.geometry_collection = {.geometries = &child, .geometry_count = 1}}
+  };
+  const mln_feature features[] = {
+    {.size = sizeof(mln_feature), .geometry = &point},
+    {.size = sizeof(mln_feature), .geometry = &collection},
+  };
+  const mln_geojson data = {
+    .size = sizeof(mln_geojson),
+    .type = MLN_GEOJSON_TYPE_FEATURE_COLLECTION,
+    .data = {.feature_collection = {.features = features, .feature_count = 2}}
+  };
+
+  mln_geojson_source_options clustered = mln_geojson_source_options_default();
+  clustered.fields = MLN_GEOJSON_SOURCE_OPTION_CLUSTER;
+  clustered.cluster = true;
+  const mln_string_view clustered_id = {.data = "quakes", .size = 6};
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_add_geojson_source_data(map, clustered_id, &data, &clustered)
+  );
+
+  const char* message = mln_thread_last_error_message();
+  TEST_ASSERT_NOT_NULL(message);
+  TEST_ASSERT_NOT_NULL(strstr(message, "\"quakes\""));
+  TEST_ASSERT_NOT_NULL(strstr(message, "point geometry on every feature"));
+  TEST_ASSERT_NOT_NULL(strstr(message, "feature 1"));
+  TEST_ASSERT_NOT_NULL(strstr(message, "geometry collection"));
+
+  // The constraint belongs to clustering alone, so the same data tiles fine on
+  // an unclustered source, and the rejected ID stays free.
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK,
+    mln_map_add_geojson_source_data(map, clustered_id, &data, NULL)
+  );
+
+  // A source added with clustering rejects the same data on update.
+  const mln_string_view updated_id = {.data = "clustered-quakes", .size = 16};
+  const mln_geojson points = {
+    .size = sizeof(mln_geojson),
+    .type = MLN_GEOJSON_TYPE_FEATURE_COLLECTION,
+    .data = {.feature_collection = {.features = features, .feature_count = 1}}
+  };
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK,
+    mln_map_add_geojson_source_data(map, updated_id, &points, &clustered)
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_set_geojson_source_data(map, updated_id, &data)
+  );
+  TEST_ASSERT_NOT_NULL(
+    strstr(mln_thread_last_error_message(), "\"clustered-quakes\"")
+  );
+
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
 void run_style_values_abi_tests(void) {
   UnitySetTestFile(__FILE__);
   RUN_TEST(style_value_helpers_reject_unsafe_raw_descriptors);
   RUN_TEST(geojson_source_options_reject_unsafe_raw_headers);
+  RUN_TEST(clustered_geojson_data_reports_non_point_geometry);
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -723,6 +723,62 @@ auto to_native_geojson_source_options(const mln_geojson_source_options& options)
   return mbgl::makeMutable<mbgl::style::GeoJSONOptions>(std::move(native));
 }
 
+auto geojson_geometry_type_name(const mbgl::Geometry<double>& geometry)
+  -> std::string_view {
+  return geometry.match(
+    [](const mbgl::EmptyGeometry&) -> std::string_view { return "empty"; },
+    [](const mbgl::Point<double>&) -> std::string_view { return "point"; },
+    [](const mbgl::LineString<double>&) -> std::string_view {
+      return "line string";
+    },
+    [](const mbgl::Polygon<double>&) -> std::string_view { return "polygon"; },
+    [](const mbgl::MultiPoint<double>&) -> std::string_view {
+      return "multi-point";
+    },
+    [](const mbgl::MultiLineString<double>&) -> std::string_view {
+      return "multi-line string";
+    },
+    [](const mbgl::MultiPolygon<double>&) -> std::string_view {
+      return "multi-polygon";
+    },
+    [](const mapbox::geometry::geometry_collection<double>&)
+      -> std::string_view { return "geometry collection"; }
+  );
+}
+
+/**
+ * Reports whether clustered data satisfies supercluster's point-only input.
+ *
+ * MapLibre Native clusters a feature collection by reading each feature's
+ * geometry as a point, so any other geometry raises a variant access error
+ * inside supercluster while mln_map_add_geojson_source_data() or
+ * mln_map_set_geojson_source_data() builds the index. Checking here reports the
+ * source, the feature, and the constraint instead.
+ */
+auto validate_clustered_geojson(
+  const std::string& source_id, const mbgl::GeoJSON& geojson
+) -> bool {
+  if (!geojson.is<mbgl::FeatureCollection>()) {
+    return true;
+  }
+
+  const auto& features = geojson.get<mbgl::FeatureCollection>();
+  for (std::size_t index = 0; index < features.size(); ++index) {
+    const auto& geometry = features.at(index).geometry;
+    if (geometry.is<mbgl::Point<double>>()) {
+      continue;
+    }
+    const auto message =
+      "clustered GeoJSON source \"" + source_id +
+      "\" requires point geometry on every feature; feature " +
+      std::to_string(index) + " has " +
+      std::string{geojson_geometry_type_name(geometry)} + " geometry";
+    mln::core::set_thread_error(message.c_str());
+    return false;
+  }
+  return true;
+}
+
 auto has_custom_geometry_source_option(
   const mln_custom_geometry_source_options& options, uint32_t field
 ) -> bool {
@@ -3485,8 +3541,12 @@ auto map_add_geojson_source_data(
     return add_status;
   }
 
-  auto native_options =
-    to_native_geojson_source_options(effective_geojson_source_options(options));
+  const auto effective = effective_geojson_source_options(options);
+  if (effective.cluster && !validate_clustered_geojson(id, *geojson)) {
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+
+  auto native_options = to_native_geojson_source_options(effective);
   if (!native_options) {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
@@ -3558,6 +3618,12 @@ auto map_set_geojson_source_data(
   auto* geojson_source = source->as<mbgl::style::GeoJSONSource>();
   if (geojson_source == nullptr) {
     set_thread_error("source is not a GeoJSON source");
+    return MLN_STATUS_INVALID_ARGUMENT;
+  }
+  if (
+    geojson_source->getOptions().cluster &&
+    !validate_clustered_geojson(string_from_view(source_id), *geojson)
+  ) {
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 


### PR DESCRIPTION
## Summary

Clustered GeoJSON sources now reject feature collections whose features carry
non-point geometry with `MLN_STATUS_INVALID_ARGUMENT` and a diagnostic naming
the source, the feature, and the constraint, instead of surfacing supercluster's
bare `in get<T>()` variant access message as `MLN_STATUS_NATIVE_ERROR`.

## Test plan

`mise run test`

## AI assistance

- **Tools:** Claude Code
- **Context:** Traced the throw to supercluster's unconditional
  `f.geometry.get<GeoJSONPoint>()`, confirmed `GeoJSONSource::setGeoJSON` builds
  the index synchronously, then added the add-time check and a C test.