### PR TITLE
Lease the resource transform outside the runtime registry lock

### DIFF
--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -11,6 +11,10 @@
 #include "unity.h"
 
 static const char offline_style_url[] = "http://example.com/offline-style.json";
+static const char lookup_blocking_style_url[] =
+  "http://example.com/lookup-blocking-style.json";
+static const char lookup_probe_style_url[] =
+  "http://example.com/lookup-probe-style.json";
 static const char unsupported_scheme_style_url[] =
   "jar:file:/packaged/style.json";
 static const char credentialed_unsupported_scheme_style_url[] =
@@ -100,14 +104,16 @@ static bool wait_for_map_loading_failure(
   return false;
 }
 
-static mln_offline_region_definition offline_tile_definition(void) {
+static mln_offline_region_definition offline_tile_definition_for_style(
+  const char* style_url
+) {
   return (mln_offline_region_definition){
     .size = sizeof(mln_offline_region_definition),
     .type = MLN_OFFLINE_REGION_DEFINITION_TILE_PYRAMID,
     .data = {
       .tile_pyramid = {
         .size = sizeof(mln_offline_tile_pyramid_region_definition),
-        .style_url = offline_style_url,
+        .style_url = style_url,
         .bounds =
           {
             .southwest = {.latitude = 1.0, .longitude = 2.0},
@@ -120,6 +126,10 @@ static mln_offline_region_definition offline_tile_definition(void) {
       }
     },
   };
+}
+
+static mln_offline_region_definition offline_tile_definition(void) {
+  return offline_tile_definition_for_style(offline_style_url);
 }
 
 static mln_offline_region_definition offline_geometry_definition(
@@ -463,10 +473,14 @@ static void other_runtime_entry(void* argument) {
   mln_runtime_destroy(runtime);
 }
 
-static bool start_offline_region_download(
-  mln_runtime* runtime, teardown_probe* probe
+// Creates a region for `style_url` and activates its download. The download
+// requests the style from a MapLibre file source thread, which is where the
+// resource provider and resource transform callbacks run.
+static bool activate_style_download(
+  mln_runtime* runtime, const char* style_url
 ) {
-  const mln_offline_region_definition definition = offline_tile_definition();
+  const mln_offline_region_definition definition =
+    offline_tile_definition_for_style(style_url);
   const uint8_t metadata[] = {1, 2, 3};
   mln_offline_operation_id operation_id = 0;
   if (
@@ -504,12 +518,14 @@ static bool start_offline_region_download(
   ) {
     return false;
   }
+  return true;
+}
 
-  // The download requests the region style URL from a MapLibre file source
-  // thread, which is where the transform callback runs.
+// Pumps the owner thread's run loop until `flag` is set by a MapLibre thread.
+static bool pump_until_flag(mln_runtime* runtime, atomic_bool* flag) {
   for (size_t attempt = 0; attempt < teardown_probe_wait_attempts;
        attempt += 1) {
-    if (atomic_load(&probe->transform_entered)) {
+    if (atomic_load(flag)) {
       return true;
     }
     if (mln_runtime_run_once(runtime) != MLN_STATUS_OK) {
@@ -518,6 +534,13 @@ static bool start_offline_region_download(
     mln_test_sleep_millisecond();
   }
   return false;
+}
+
+static bool start_offline_region_download(
+  mln_runtime* runtime, teardown_probe* probe
+) {
+  return activate_style_download(runtime, offline_style_url) &&
+         pump_until_flag(runtime, &probe->transform_entered);
 }
 
 // This verifies that runtime teardown waits for an in-flight resource transform
@@ -555,6 +578,169 @@ static void runtime_teardown_leaves_other_runtimes_responsive(void) {
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_OK, atomic_load(&probe.other_runtime_status)
   );
+}
+
+// Shared state for the file-source lookup lock-scope test below. The provider
+// callback, the transform callback, and the second runtime's owner thread are
+// three separate threads, so every field crosses a thread boundary.
+typedef struct lookup_probe {
+  atomic_bool transform_entered;
+  atomic_bool provider_entered;
+  atomic_bool writer_pending;
+  atomic_bool lookup_reached;
+  atomic_bool other_runtime_ready;
+  atomic_bool other_runtime_call_done;
+  atomic_bool other_runtime_call_observed;
+  atomic_int other_runtime_status;
+} lookup_probe;
+
+// Blocks the transform for the first region's style so its shared transform
+// lock stays held, which is what makes the pending writer below wait. It calls
+// no C API function while blocked.
+static mln_status lookup_blocking_transform(
+  void* user_data, uint32_t kind, const char* url,
+  mln_resource_transform_response* out_response
+) {
+  (void)kind;
+  lookup_probe* probe = user_data;
+  if (out_response != NULL) {
+    out_response->url = NULL;
+  }
+  if (url == NULL || strstr(url, "lookup-blocking") == NULL) {
+    return MLN_STATUS_OK;
+  }
+
+  atomic_store(&probe->transform_entered, true);
+  for (size_t attempt = 0; attempt < teardown_transform_block_attempts;
+       attempt += 1) {
+    if (atomic_load(&probe->other_runtime_call_done)) {
+      break;
+    }
+    mln_test_sleep_millisecond();
+  }
+  atomic_store(
+    &probe->other_runtime_call_observed,
+    atomic_load(&probe->other_runtime_call_done)
+  );
+  return MLN_STATUS_OK;
+}
+
+// Runs on the file source thread immediately before that thread looks up the
+// resource transform, so holding it here parks the thread until the owner
+// thread has a transform writer waiting. Passing the request through is what
+// sends the thread into the lookup under test.
+static uint32_t lookup_probe_resource_provider(
+  void* user_data, const mln_resource_request* request,
+  mln_resource_request_handle* handle
+) {
+  (void)handle;
+  lookup_probe* probe = user_data;
+  if (
+    request == NULL || request->url == NULL ||
+    strstr(request->url, "lookup-probe") == NULL
+  ) {
+    return MLN_RESOURCE_PROVIDER_DECISION_PASS_THROUGH;
+  }
+
+  atomic_store(&probe->provider_entered, true);
+  for (size_t attempt = 0; attempt < teardown_probe_wait_attempts;
+       attempt += 1) {
+    if (atomic_load(&probe->writer_pending)) {
+      break;
+    }
+    mln_test_sleep_millisecond();
+  }
+  // Give the owner thread time to reach the exclusive transform lock, so the
+  // lookup this thread is about to make queues behind a waiting writer.
+  mln_test_sleep_milliseconds(teardown_call_delay_milliseconds);
+  atomic_store(&probe->lookup_reached, true);
+  return MLN_RESOURCE_PROVIDER_DECISION_PASS_THROUGH;
+}
+
+// Owns a second runtime and calls into it while a file source thread is inside
+// the resource transform lookup for the first runtime.
+static void lookup_other_runtime_entry(void* argument) {
+  lookup_probe* probe = argument;
+  mln_runtime* runtime = NULL;
+  const mln_runtime_options options = mln_runtime_options_default();
+  const mln_status create_status = mln_runtime_create(&options, &runtime);
+  if (create_status != MLN_STATUS_OK) {
+    atomic_store(&probe->other_runtime_status, create_status);
+    atomic_store(&probe->other_runtime_call_done, true);
+    return;
+  }
+
+  atomic_store(&probe->other_runtime_ready, true);
+  wait_for_flag(&probe->lookup_reached);
+  // Give the file source thread time to reach the lookup itself.
+  mln_test_sleep_milliseconds(teardown_call_delay_milliseconds);
+  atomic_store(&probe->other_runtime_status, mln_runtime_run_once(runtime));
+  atomic_store(&probe->other_runtime_call_done, true);
+  mln_runtime_destroy(runtime);
+}
+
+// This verifies that a file source resource transform lookup releases the
+// process-global runtime registry lock before it waits on the per-runtime
+// transform lock. A transform callback holds the shared transform lock, the
+// owner thread waits for the exclusive lock, and a second file source thread
+// then makes the lookup, which a writer-preferring shared mutex queues behind
+// that waiting writer. Holding the registry lock across that wait stalls every
+// unrelated runtime, so an ordinary call on a second runtime must still finish
+// while the lookup waits.
+static void resource_transform_lookup_leaves_other_runtimes_responsive(void) {
+  lookup_probe probe = {0};
+  atomic_store(&probe.other_runtime_status, MLN_STATUS_NATIVE_ERROR);
+  mln_runtime* runtime = mln_test_create_runtime();
+  mln_test_thread* other_thread =
+    mln_test_thread_start(lookup_other_runtime_entry, &probe);
+  TEST_ASSERT_TRUE(wait_for_flag(&probe.other_runtime_ready));
+
+  const mln_resource_provider provider = {
+    .size = sizeof(mln_resource_provider),
+    .callback = lookup_probe_resource_provider,
+    .user_data = &probe,
+  };
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_runtime_set_resource_provider(runtime, &provider)
+  );
+  const mln_resource_transform transform = {
+    .size = sizeof(mln_resource_transform),
+    .callback = lookup_blocking_transform,
+    .user_data = &probe,
+  };
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_runtime_set_resource_transform(runtime, &transform)
+  );
+
+  // The first download parks a transform callback inside the shared lock.
+  TEST_ASSERT_TRUE(activate_style_download(runtime, lookup_blocking_style_url));
+  TEST_ASSERT_TRUE(pump_until_flag(runtime, &probe.transform_entered));
+
+  // The second download parks a file source thread in the provider callback,
+  // one step ahead of the lookup under test.
+  TEST_ASSERT_TRUE(activate_style_download(runtime, lookup_probe_style_url));
+  TEST_ASSERT_TRUE(pump_until_flag(runtime, &probe.provider_entered));
+
+  atomic_store(&probe.writer_pending, true);
+  // Clearing waits for the in-flight transform callback to return, so it is
+  // the pending writer the lookup queues behind.
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, mln_runtime_clear_resource_transform(runtime)
+  );
+  mln_test_thread_join(other_thread);
+
+  TEST_ASSERT_TRUE_MESSAGE(
+    atomic_load(&probe.lookup_reached),
+    "the file source thread never reached the resource transform lookup"
+  );
+  TEST_ASSERT_TRUE_MESSAGE(
+    atomic_load(&probe.other_runtime_call_observed),
+    "a call on an unrelated runtime was stalled by a resource transform lookup"
+  );
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK, atomic_load(&probe.other_runtime_status)
+  );
+  mln_test_destroy_runtime(runtime);
 }
 
 // This verifies null, undersized, and missing-callback provider descriptors
@@ -687,6 +873,7 @@ void run_resources_abi_tests(void) {
   RUN_TEST(offline_take_rejects_mismatched_result_kind);
   RUN_TEST(resource_transform_rejects_raw_invalid_descriptors);
   RUN_TEST(runtime_teardown_leaves_other_runtimes_responsive);
+  RUN_TEST(resource_transform_lookup_leaves_other_runtimes_responsive);
   RUN_TEST(resource_provider_rejects_raw_invalid_descriptors);
   RUN_TEST(unsupported_style_url_scheme_names_scheme_and_url);
   RUN_TEST(unsupported_style_url_diagnostic_redacts_credentials);

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -98,6 +98,27 @@ auto runtime_registry() -> RuntimeRegistry& {
   return value;
 }
 
+// Leases the resource transform registration for a MapLibre-owned thread.
+//
+// The registry lock proves the platform context is a live runtime, and the
+// work done under it is a reference count increment that completes without
+// waiting on any per-runtime lock. Callers take the returned state's lock
+// afterwards, so a writer waiting on that lock delays this runtime alone
+// rather than every `mln_*` call in the process.
+auto lease_resource_transform_state(void* platform_context) noexcept
+  -> std::shared_ptr<mln::core::ResourceTransformState> {
+  if (platform_context == nullptr) {
+    return nullptr;
+  }
+
+  auto* runtime = static_cast<mln_runtime*>(platform_context);
+  const std::scoped_lock registry_lock(runtime_registry_mutex());
+  if (!runtime_registry().contains(runtime)) {
+    return nullptr;
+  }
+  return runtime->resource_transform_state;
+}
+
 using OfflineRegionSnapshotRegistry = std::unordered_map<
   const mln_offline_region_snapshot*,
   std::unique_ptr<mln_offline_region_snapshot>>;
@@ -1010,6 +1031,8 @@ auto create_runtime(
     std::make_shared<OfflineOperationEventState>();
   owned_runtime->offline_operation_state->runtime = owned_runtime.get();
   owned_runtime->offline_operation_state->alive = true;
+  owned_runtime->resource_transform_state =
+    std::make_shared<ResourceTransformState>();
   auto* runtime = owned_runtime.get();
   {
     const std::scoped_lock lock(runtime_registry_mutex());
@@ -1040,9 +1063,10 @@ auto set_resource_transform(
     return MLN_STATUS_INVALID_ARGUMENT;
   }
 
-  const std::unique_lock lock(runtime->resource_transform_mutex);
-  runtime->resource_transform_callback = transform->callback;
-  runtime->resource_transform_user_data = transform->user_data;
+  auto& state = *runtime->resource_transform_state;
+  const std::unique_lock lock(state.mutex);
+  state.callback = transform->callback;
+  state.user_data = transform->user_data;
   return MLN_STATUS_OK;
 }
 
@@ -1090,9 +1114,10 @@ auto clear_resource_transform(mln_runtime* runtime) -> mln_status {
     return status;
   }
 
-  const std::unique_lock lock(runtime->resource_transform_mutex);
-  runtime->resource_transform_callback = nullptr;
-  runtime->resource_transform_user_data = nullptr;
+  auto& state = *runtime->resource_transform_state;
+  const std::unique_lock lock(state.mutex);
+  state.callback = nullptr;
+  state.user_data = nullptr;
   return MLN_STATUS_OK;
 }
 
@@ -2357,13 +2382,15 @@ auto destroy_runtime(mln_runtime* runtime) -> mln_status {
 
   // A resource transform callback that entered `invoke_resource_transform()`
   // before the erase above holds a shared transform lock, so this wait covers
-  // every callback that can still observe the runtime.
+  // every callback that can still observe the runtime. A lookup that leased
+  // the state before the erase and reaches the shared lock after this block
+  // reads the cleared registration and calls nothing. The lease keeps the
+  // state object alive on its own, so it stays readable past the runtime.
   {
-    const std::unique_lock transform_lock(
-      owned_runtime->resource_transform_mutex
-    );
-    owned_runtime->resource_transform_callback = nullptr;
-    owned_runtime->resource_transform_user_data = nullptr;
+    auto& transform_state = *owned_runtime->resource_transform_state;
+    const std::unique_lock transform_lock(transform_state.mutex);
+    transform_state.callback = nullptr;
+    transform_state.user_data = nullptr;
   }
 
   {
@@ -2526,46 +2553,31 @@ auto find_runtime_for_platform_context(void* platform_context) noexcept
 auto has_resource_transform_for_platform_context(
   void* platform_context
 ) noexcept -> bool {
-  if (platform_context == nullptr) {
+  const auto state = lease_resource_transform_state(platform_context);
+  if (state == nullptr) {
     return false;
   }
 
-  auto* runtime = static_cast<mln_runtime*>(platform_context);
-  // The registry lock stays held across the read: releasing it first would
-  // leave an unowned pointer, and this locks a mutex inside the runtime.
-  const std::scoped_lock registry_lock(runtime_registry_mutex());
-  if (!runtime_registry().contains(runtime)) {
-    return false;
-  }
-  const std::shared_lock transform_lock(runtime->resource_transform_mutex);
-  return runtime->resource_transform_callback != nullptr;
+  const std::shared_lock transform_lock(state->mutex);
+  return state->callback != nullptr;
 }
 
 auto invoke_resource_transform(
   void* platform_context, uint32_t kind, const char* url,
   std::string& out_replacement_url
 ) noexcept -> mln_status {
-  if (platform_context == nullptr) {
+  const auto state = lease_resource_transform_state(platform_context);
+  if (state == nullptr) {
     return MLN_STATUS_OK;
   }
 
-  auto* runtime = static_cast<mln_runtime*>(platform_context);
-  std::shared_lock<std::shared_mutex> transform_lock;
-  {
-    // Taking the shared transform lock while the registry lock is held is the
-    // handoff that keeps the runtime alive for the callback:
-    // `destroy_runtime()` removes the registry entry under the same registry
-    // lock and then waits for the exclusive transform lock. A callback that
-    // reaches the shared lock first holds teardown until it returns, and one
-    // that arrives after the erase finds no entry and skips the transform.
-    const std::scoped_lock registry_lock(runtime_registry_mutex());
-    if (!runtime_registry().contains(runtime)) {
-      return MLN_STATUS_OK;
-    }
-    transform_lock = std::shared_lock{runtime->resource_transform_mutex};
-  }
-
-  const auto callback = runtime->resource_transform_callback;
+  // The lease keeps this state readable on its own, so the shared lock is
+  // taken with the registry lock released. `destroy_runtime()` erases the
+  // registry entry and then clears the registration under the exclusive lock,
+  // so a callback that reaches the shared lock first holds teardown until it
+  // returns, and one that arrives later finds an empty registration.
+  const std::shared_lock transform_lock(state->mutex);
+  const auto callback = state->callback;
   if (callback == nullptr) {
     return MLN_STATUS_OK;
   }
@@ -2576,8 +2588,7 @@ auto invoke_resource_transform(
     .context = &out_replacement_url,
   };
   try {
-    const auto status =
-      callback(runtime->resource_transform_user_data, kind, url, &response);
+    const auto status = callback(state->user_data, kind, url, &response);
     if (
       status == MLN_STATUS_OK && response.url != nullptr &&
       *response.url != '\0'

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -28,6 +28,26 @@ struct ResourceProvider {
   void* user_data = nullptr;
 };
 
+// Holds the resource transform registration in its own reference-counted
+// object so a file-source lookup can keep the registration alive on its own.
+//
+// A lookup copies the runtime's handle to this state while it holds the
+// process-global runtime registry lock, which proves the runtime is live, and
+// takes `mutex` after releasing that lock. The copy is what keeps the state
+// readable, so the registry lock covers a non-blocking pointer copy instead of
+// a lock acquisition that a pending writer can delay.
+//
+// `callback` and `user_data` live here rather than on the runtime, so a lease
+// holder reads and invokes the registration without touching the runtime.
+// Runtime teardown clears both under the exclusive lock: a callback already
+// inside the shared lock keeps teardown waiting until it returns, and a lease
+// that takes the shared lock later observes an empty registration.
+struct ResourceTransformState {
+  std::shared_mutex mutex;
+  mln_resource_transform_callback callback = nullptr;
+  void* user_data = nullptr;
+};
+
 struct OfflineRegionEventState {
   std::mutex mutex;
   mln_runtime* runtime = nullptr;
@@ -66,9 +86,7 @@ struct mln_runtime {
   std::shared_ptr<mln::core::OfflineRegionEventState> offline_event_state;
   std::shared_ptr<mln::core::OfflineOperationEventState>
     offline_operation_state;
-  mutable std::shared_mutex resource_transform_mutex;
-  mln_resource_transform_callback resource_transform_callback = nullptr;
-  void* resource_transform_user_data = nullptr;
+  std::shared_ptr<mln::core::ResourceTransformState> resource_transform_state;
   std::size_t live_maps = 0;
   mutable std::mutex event_mutex;
   std::unordered_set<const mln_map*> event_maps;
@@ -203,8 +221,10 @@ auto resource_options_for_runtime(mln_runtime* runtime)
   -> mbgl::ResourceOptions;
 auto find_runtime_for_platform_context(void* platform_context) noexcept
   -> mln_runtime*;
-// Reads resource transform presence under the registry lock, so MapLibre-owned
-// threads observe a value instead of a runtime pointer teardown may retire.
+// Reports whether a resource transform is registered. MapLibre-owned threads
+// observe a value instead of a runtime pointer teardown may retire, and the
+// process-global registry lock is released before the per-runtime transform
+// lock is taken. See `ResourceTransformState`.
 auto has_resource_transform_for_platform_context(
   void* platform_context
 ) noexcept -> bool;


### PR DESCRIPTION
## Summary

Resource transform lookups on MapLibre file source threads now lease a
reference-counted registration object under the process-global runtime registry
lock, so they take the per-runtime transform lock with the registry lock already
released.

## Test plan

`mise run test`

## Notes

`has_resource_transform_for_platform_context()` and `invoke_resource_transform()`
both held `runtime_registry_mutex()` across a `std::shared_lock` acquisition on
`runtime->resource_transform_mutex`. `std::shared_mutex` is typically
writer-preferring, so a shared acquisition that arrives while
`set_resource_transform()`, `clear_resource_transform()`, or `destroy_runtime()`
is waiting for the exclusive lock queues behind that writer — and each of those
writers waits for in-flight callbacks. The lookup therefore blocked while pinning
the process-global lock, stalling every `mln_*` call in the process across all
runtimes. That is the failure mode #351 fixed for teardown, surviving at a
different call site. Both functions shared the exposure, so both are fixed.

The fix moves the liveness proof out of the registry. `callback` and `user_data`
now live in a `ResourceTransformState` held by `std::shared_ptr`, and a lookup
copies that handle under the registry lock — a reference count increment that
cannot block — then takes the transform lock with the registry lock released.
The lease keeps the state readable on its own, so no lease holder touches the
runtime. Keeping the runtime itself in a `shared_ptr` was the alternative, but it
would let a lease outlive `mln_runtime_destroy()` and move run loop and database
file source teardown onto a MapLibre thread; `try_lock_shared` was rejected
because every fallback either reports "no transform" when one is registered or
reintroduces the wait.

Interleavings:

- **Callback in flight during teardown.** The callback holds the shared lock, so
  `destroy_runtime()` blocks on the exclusive lock until it returns. The registry
  entry is already erased, and the erase happens under the registry lock while
  nothing else is held, so unrelated runtimes are unaffected. `mln_runtime_destroy()`
  still returns only after the host callback is quiescent.
- **Clear racing a lookup.** A lookup that takes the shared lock first makes the
  clear wait and observes the old registration; one that arrives later observes the
  cleared registration and calls nothing. Either order is a consistent snapshot,
  and the lookup's wait now delays that runtime alone.
- **Runtime destroyed between lookup and use.** The lease pins the state, not the
  runtime, so the state stays readable after the runtime is freed. Teardown clears
  the registration under the exclusive lock before dropping the runtime, so a late
  lease reads a null callback and returns without dereferencing anything the
  runtime owned.
- **Handle address reused.** A lease identifies one registration, so a new runtime
  allocated at a freed runtime's address cannot be reached through an old lease.

#360 (`agent/clear-resource-provider`) adds the same shape for the resource
provider via a `ResourceProviderLease` used from `canRequest()`. It should rebase
onto this and give the provider its own leased state alongside
`ResourceTransformState`, rather than proving provider liveness with the registry
lock.

## AI assistance

- **Tools:** Claude Code
- **Context:** Claude Code diagnosed the surviving lock-scope shape, implemented
  the leased transform state, and wrote the regression test.
