### PR TITLE
Harden the C API test runner against silent passes

### DIFF
--- a/cmake/mln_tests.cmake
+++ b/cmake/mln_tests.cmake
@@ -46,8 +46,7 @@ function(mln_add_c_api_test)
   file(GLOB test_abi_sources CONFIGURE_DEPENDS
        ${PROJECT_SOURCE_DIR}/src/c_api/tests/*_abi.c)
   set(test_sources ${PROJECT_SOURCE_DIR}/src/c_api/tests/main.c
-                   ${PROJECT_SOURCE_DIR}/src/c_api/tests/test_support.c
-                   ${test_abi_sources})
+      ${PROJECT_SOURCE_DIR}/src/c_api/tests/test_support.c ${test_abi_sources})
 
   # Each *_abi.c reaches the runner through one run_<file>_tests() call in
   # main.c. main.c carries no preprocessor guards, so a plain text match is
@@ -83,8 +82,8 @@ function(mln_add_c_api_test)
   # These stay off the vendored unity target.
   if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(
-      mln_c_api_tests PRIVATE -Werror=unused-function
-                              -Werror=missing-prototypes)
+      mln_c_api_tests
+      PRIVATE -Werror=unused-function -Werror=missing-prototypes)
   elseif(MSVC)
     # C4505: unreferenced function with internal linkage has been removed.
     target_compile_options(mln_c_api_tests PRIVATE /we4505)

--- a/cmake/mln_tests.cmake
+++ b/cmake/mln_tests.cmake
@@ -57,6 +57,10 @@ function(mln_add_c_api_test)
   string(REGEX REPLACE "/\\*([^*]|\\*+[^*/])*\\*+/" "" test_main_contents
          "${test_main_contents}")
   string(REGEX REPLACE "//[^\n]*" "" test_main_contents "${test_main_contents}")
+  # String literals too, so a runner named only inside a diagnostic message
+  # cannot stand in for the call that runs it.
+  string(REGEX REPLACE "\"([^\"\\\\]|\\\\.)*\"" "" test_main_contents
+         "${test_main_contents}")
   foreach(test_abi_source IN LISTS test_abi_sources)
     get_filename_component(test_abi_name ${test_abi_source} NAME_WE)
     if(NOT test_main_contents MATCHES "run_${test_abi_name}_tests\\(\\)")

--- a/cmake/mln_tests.cmake
+++ b/cmake/mln_tests.cmake
@@ -50,8 +50,13 @@ function(mln_add_c_api_test)
 
   # Each *_abi.c reaches the runner through one run_<file>_tests() call in
   # main.c. main.c carries no preprocessor guards, so a plain text match is
-  # exact here. See src/c_api/tests/README.md for the full contract.
+  # exact here once comments are stripped -- otherwise a commented-out call
+  # would satisfy the guard while its tests never run. See
+  # src/c_api/tests/README.md for the full contract.
   file(READ ${PROJECT_SOURCE_DIR}/src/c_api/tests/main.c test_main_contents)
+  string(REGEX REPLACE "/\\*([^*]|\\*+[^*/])*\\*+/" "" test_main_contents
+         "${test_main_contents}")
+  string(REGEX REPLACE "//[^\n]*" "" test_main_contents "${test_main_contents}")
   foreach(test_abi_source IN LISTS test_abi_sources)
     get_filename_component(test_abi_name ${test_abi_source} NAME_WE)
     if(NOT test_main_contents MATCHES "run_${test_abi_name}_tests\\(\\)")

--- a/cmake/mln_tests.cmake
+++ b/cmake/mln_tests.cmake
@@ -29,22 +29,42 @@ function(mln_add_c_api_test)
   # flush calls live in Unity's own translation unit, so the definition belongs
   # on that target rather than on the tests that link it.
   target_compile_definitions(unity PRIVATE UNITY_USE_FLUSH_STDOUT=1)
+  # Unity 2.6 makes double support opt-in: without this define TEST_ASSERT_*
+  # DOUBLE macros expand to an unconditional "Double Support Disabled" failure.
+  # Unity's own translation unit and every test that includes unity.h have to
+  # agree on it, so unlike UNITY_USE_FLUSH_STDOUT (which only affects calls
+  # inside Unity's sources) this one is PUBLIC.
+  target_compile_definitions(unity PUBLIC UNITY_INCLUDE_DOUBLE)
   if(MSVC AND CMAKE_C_COMPILER_ID MATCHES "Clang")
     # Unity's Unix -Wall flag means -Weverything to clang-cl. Neutralize it to
     # match the framework's MSVC warning behavior.
     target_compile_options(unity PRIVATE -Wno-everything)
   endif()
 
-  set(test_sources
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/main.c
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/test_support.c
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/core_abi.c
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/map_options_abi.c
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/render_backend_abi.c
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/owned_texture_abi.c
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/query_abi.c
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/resources_abi.c
-      ${PROJECT_SOURCE_DIR}/src/c_api/tests/style_values_abi.c)
+  # Globbing keeps a newly added *_abi.c in the build without a second edit
+  # here; CONFIGURE_DEPENDS reruns the glob when the directory changes.
+  file(GLOB test_abi_sources CONFIGURE_DEPENDS
+       ${PROJECT_SOURCE_DIR}/src/c_api/tests/*_abi.c)
+  set(test_sources ${PROJECT_SOURCE_DIR}/src/c_api/tests/main.c
+                   ${PROJECT_SOURCE_DIR}/src/c_api/tests/test_support.c
+                   ${test_abi_sources})
+
+  # Each *_abi.c reaches the runner through one run_<file>_tests() call in
+  # main.c. main.c carries no preprocessor guards, so a plain text match is
+  # exact here. See src/c_api/tests/README.md for the full contract.
+  file(READ ${PROJECT_SOURCE_DIR}/src/c_api/tests/main.c test_main_contents)
+  foreach(test_abi_source IN LISTS test_abi_sources)
+    get_filename_component(test_abi_name ${test_abi_source} NAME_WE)
+    if(NOT test_main_contents MATCHES "run_${test_abi_name}_tests\\(\\)")
+      message(
+        FATAL_ERROR
+          "src/c_api/tests/${test_abi_name}.c defines tests that never run: "
+          "declare run_${test_abi_name}_tests(void) in "
+          "src/c_api/tests/abi_tests.h and call it from "
+          "src/c_api/tests/main.c.")
+    endif()
+  endforeach()
+
   add_executable(mln_c_api_tests ${test_sources})
   set_target_properties(
     mln_c_api_tests
@@ -55,6 +75,20 @@ function(mln_add_c_api_test)
   target_include_directories(
     mln_c_api_tests
     PRIVATE ${PROJECT_SOURCE_DIR}/src/c_api/tests ${dependency_include_dirs})
+
+  # Enforce the registration contract at compile time. A test that no RUN_TEST
+  # references is an unused static function, and dropping `static` to dodge that
+  # trips the missing-prototype error instead, because abi_tests.h and
+  # test_support.h declare every function this suite legitimately exports.
+  # These stay off the vendored unity target.
+  if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(
+      mln_c_api_tests PRIVATE -Werror=unused-function
+                              -Werror=missing-prototypes)
+  elseif(MSVC)
+    # C4505: unreferenced function with internal linkage has been removed.
+    target_compile_options(mln_c_api_tests PRIVATE /we4505)
+  endif()
 
   if(MLN_FFI_RENDER_BACKEND STREQUAL "metal")
     target_compile_definitions(mln_c_api_tests PRIVATE MLN_TEST_BACKEND_METAL=1)

--- a/src/c_api/tests/README.md
+++ b/src/c_api/tests/README.md
@@ -9,3 +9,47 @@ construct: null input or output pointers, undersized structs, unknown raw enum
 or flag values, preinitialized output handles, and stale raw handles. Semantic
 behavior belongs in each applicable binding's test suite whenever its public API
 can express the scenario.
+
+## Registration contract
+
+Each `*_abi.c` holds `static void <name>(void)` tests plus one
+`run_<file>_tests(void)` entry point that starts with `UnitySetTestFile(__FILE__)`
+and then calls `RUN_TEST` once per test in the file. `abi_tests.h` declares the
+entry points; `main.c` calls them between `UNITY_BEGIN()` and `UNITY_END()`.
+
+Adding a test means writing it `static` and adding its `RUN_TEST` call. Adding a
+file means creating `<name>_abi.c`, declaring `run_<name>_tests(void)` in
+`abi_tests.h`, and calling it from `main.c`; CMake globs the sources, so the
+build list needs no edit.
+
+The build enforces this rather than trusting review:
+
+- `-Werror=unused-function` (MSVC: `/we4505`) turns a test that no `RUN_TEST`
+  reaches into a compile error, because nothing references it.
+- `-Werror=missing-prototypes` keeps that net closed by rejecting a test written
+  without `static`, since `abi_tests.h` and `test_support.h` declare everything
+  the suite legitimately exports.
+- A configure-time check in `cmake/mln_tests.cmake` fails with a clear message
+  when a globbed `*_abi.c` has no matching call in `main.c`.
+
+The compiler carries this instead of Unity's `generate_test_runner.rb` (Ruby is
+outside this repo's toolchain) or a regex checker (`render_backend_abi.c` guards
+both its tests and their `RUN_TEST` calls behind backend `#if` blocks, which only
+a preprocessor reads correctly).
+
+## Handle hygiene
+
+`mln_test_create_runtime`, `mln_test_create_map`,
+`mln_test_create_map_with_options`, and `mln_test_render_fixture_create` record
+what they create for the calling thread, and the matching destroy helpers clear
+those records. `tearDown` in `main.c` calls
+`mln_test_reclaim_thread_resources()`, which destroys whatever is left in render
+session, map, runtime order.
+
+This matters because a failing assertion longjmps out of the test body, skipping
+the test's own cleanup. A runtime left live would make every later test on that
+thread fail to create one, turning one real failure into a suite-wide cascade.
+Reclaiming in `tearDown` keeps the failure count honest. When a test that
+otherwise passed leaves handles behind, `tearDown` fails it so the leak lands on
+the test that caused it.
+

--- a/src/c_api/tests/README.md
+++ b/src/c_api/tests/README.md
@@ -13,9 +13,10 @@ can express the scenario.
 ## Registration contract
 
 Each `*_abi.c` holds `static void <name>(void)` tests plus one
-`run_<file>_tests(void)` entry point that starts with `UnitySetTestFile(__FILE__)`
-and then calls `RUN_TEST` once per test in the file. `abi_tests.h` declares the
-entry points; `main.c` calls them between `UNITY_BEGIN()` and `UNITY_END()`.
+`run_<file>_tests(void)` entry point that starts with
+`UnitySetTestFile(__FILE__)` and then calls `RUN_TEST` once per test in the
+file. `abi_tests.h` declares the entry points; `main.c` calls them between
+`UNITY_BEGIN()` and `UNITY_END()`.
 
 Adding a test means writing it `static` and adding its `RUN_TEST` call. Adding a
 file means creating `<name>_abi.c`, declaring `run_<name>_tests(void)` in
@@ -34,8 +35,8 @@ The build enforces this rather than trusting review:
 
 The compiler carries this instead of Unity's `generate_test_runner.rb` (Ruby is
 outside this repo's toolchain) or a regex checker (`render_backend_abi.c` guards
-both its tests and their `RUN_TEST` calls behind backend `#if` blocks, which only
-a preprocessor reads correctly).
+both its tests and their `RUN_TEST` calls behind backend `#if` blocks, which
+only a preprocessor reads correctly).
 
 ## Handle hygiene
 
@@ -52,4 +53,3 @@ thread fail to create one, turning one real failure into a suite-wide cascade.
 Reclaiming in `tearDown` keeps the failure count honest. When a test that
 otherwise passed leaves handles behind, `tearDown` fails it so the leak lands on
 the test that caused it.
-

--- a/src/c_api/tests/abi_tests.h
+++ b/src/c_api/tests/abi_tests.h
@@ -1,0 +1,29 @@
+#ifndef MLN_C_API_ABI_TESTS_H
+#define MLN_C_API_ABI_TESTS_H
+
+// Registration contract for the raw C API suite.
+//
+// Every test is a `static void <name>(void)` and every test is reached through
+// exactly one `RUN_TEST(<name>)` inside its file's `run_<file>_tests` entry
+// point. Keeping tests `static` lets the compiler enforce the contract: the
+// suite builds with `-Werror=unused-function`, so a test that no `RUN_TEST`
+// references fails the build instead of silently never running. The companion
+// `-Werror=missing-prototypes` keeps authors on the `static` path by rejecting
+// any new external function that this header (or `test_support.h`) does not
+// declare.
+//
+// Each entry point below lives in the matching `<name>_abi.c` and starts with
+// `UnitySetTestFile(__FILE__)` so failures point at the defining file. Adding a
+// new `*_abi.c` means declaring its entry point here and calling it from
+// `main.c`; CMake globs the sources and fails configuration when `main.c` is
+// missing a call.
+
+void run_core_abi_tests(void);
+void run_map_options_abi_tests(void);
+void run_render_backend_abi_tests(void);
+void run_owned_texture_abi_tests(void);
+void run_query_abi_tests(void);
+void run_resources_abi_tests(void);
+void run_style_values_abi_tests(void);
+
+#endif

--- a/src/c_api/tests/core_abi.c
+++ b/src/c_api/tests/core_abi.c
@@ -10,6 +10,7 @@
 #include <pthread.h>
 #endif
 
+#include "abi_tests.h"
 #include "test_support.h"
 #include "unity.h"
 

--- a/src/c_api/tests/core_abi.c
+++ b/src/c_api/tests/core_abi.c
@@ -61,7 +61,7 @@ static void runtime_rejects_unknown_flags(void) {
 // binding-owned handle state prevents.
 static void runtime_rejects_stale_handles(void) {
   mln_runtime* runtime = mln_test_create_runtime();
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_runtime_destroy(runtime));
+  mln_test_destroy_runtime(runtime);
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_INVALID_ARGUMENT, mln_runtime_destroy(runtime)
   );
@@ -128,7 +128,7 @@ static void map_create_rejects_invalid_arguments(void) {
 static void map_lifecycle_rejects_invalid_state_and_stale_handles(void) {
   mln_runtime* runtime = mln_test_create_runtime();
   mln_map* map = mln_test_create_map(runtime);
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_destroy(map));
+  mln_test_destroy_map(map);
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_INVALID_ARGUMENT, mln_map_destroy(map));
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_INVALID_ARGUMENT, mln_map_set_style_json(map, "{}")

--- a/src/c_api/tests/main.c
+++ b/src/c_api/tests/main.c
@@ -1,15 +1,24 @@
+#include "abi_tests.h"
+#include "test_support.h"
 #include "unity.h"
 
-void run_core_abi_tests(void);
-void run_map_options_abi_tests(void);
-void run_render_backend_abi_tests(void);
-void run_owned_texture_abi_tests(void);
-void run_query_abi_tests(void);
-void run_resources_abi_tests(void);
-void run_style_values_abi_tests(void);
-
 void setUp(void) {}
-void tearDown(void) {}
+
+// Unity runs this even when a test body aborted through a failing assertion, so
+// it is the one place that reliably sees handles a test left behind. Reclaiming
+// them here keeps a single genuine failure from cascading into every later test
+// that needs a runtime on this thread.
+void tearDown(void) {
+  if (!mln_test_reclaim_thread_resources()) {
+    return;
+  }
+  if (!Unity.CurrentTestFailed && !Unity.CurrentTestIgnored) {
+    TEST_FAIL_MESSAGE(
+      "Test finished with live handles; the suite reclaimed them. Destroy the "
+      "render session, map, and runtime the test created."
+    );
+  }
+}
 
 int main(void) {
   UNITY_BEGIN();

--- a/src/c_api/tests/map_options_abi.c
+++ b/src/c_api/tests/map_options_abi.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include "abi_tests.h"
 #include "test_support.h"
 #include "unity.h"
 

--- a/src/c_api/tests/map_options_abi.c
+++ b/src/c_api/tests/map_options_abi.c
@@ -342,12 +342,11 @@ static void map_debug_options_reject_raw_invalid_arguments(void) {
 // output pointer independently.
 static void map_size_tracks_attach_and_resize(void) {
   mln_runtime* runtime = mln_test_create_runtime();
-  mln_map* map = NULL;
   mln_map_options options = mln_map_options_default();
   options.width = 512;
   options.height = 256;
   options.scale_factor = 1.1;
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_create(runtime, &options, &map));
+  mln_map* map = mln_test_create_map_with_options(runtime, &options);
 
   uint32_t width = 0;
   uint32_t height = 0;
@@ -357,7 +356,7 @@ static void map_size_tracks_attach_and_resize(void) {
   );
   TEST_ASSERT_EQUAL_UINT32(512, width);
   TEST_ASSERT_EQUAL_UINT32(256, height);
-  TEST_ASSERT_TRUE(scale_factor == 1.1);
+  TEST_ASSERT_EQUAL_DOUBLE(1.1, scale_factor);
 
   // The fixture attaches a 64x64 target at scale factor 1.0, so this also
   // covers the map keeping its own pixel ratio.
@@ -368,7 +367,7 @@ static void map_size_tracks_attach_and_resize(void) {
   );
   TEST_ASSERT_EQUAL_UINT32(64, width);
   TEST_ASSERT_EQUAL_UINT32(64, height);
-  TEST_ASSERT_TRUE(scale_factor == 1.1);
+  TEST_ASSERT_EQUAL_DOUBLE(1.1, scale_factor);
 
   TEST_ASSERT_EQUAL_INT(
     MLN_STATUS_OK, mln_render_session_resize(render.session, 96, 48, 1.0)
@@ -378,7 +377,7 @@ static void map_size_tracks_attach_and_resize(void) {
   );
   TEST_ASSERT_EQUAL_UINT32(96, width);
   TEST_ASSERT_EQUAL_UINT32(48, height);
-  TEST_ASSERT_TRUE(scale_factor == 1.1);
+  TEST_ASSERT_EQUAL_DOUBLE(1.1, scale_factor);
   mln_test_render_fixture_destroy(&render);
 
   TEST_ASSERT_EQUAL_INT(

--- a/src/c_api/tests/owned_texture_abi.c
+++ b/src/c_api/tests/owned_texture_abi.c
@@ -1,6 +1,7 @@
 // Raw C ABI coverage: null and stale render-session handles are hidden by
 // binding-owned handle state.
 
+#include "abi_tests.h"
 #include "test_support.h"
 #include "unity.h"
 

--- a/src/c_api/tests/query_abi.c
+++ b/src/c_api/tests/query_abi.c
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "abi_tests.h"
 #include "test_support.h"
 #include "unity.h"
 

--- a/src/c_api/tests/render_backend_abi.c
+++ b/src/c_api/tests/render_backend_abi.c
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "abi_tests.h"
 #include "test_support.h"
 #include "unity.h"
 

--- a/src/c_api/tests/resources_abi.c
+++ b/src/c_api/tests/resources_abi.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "abi_tests.h"
 #include "test_support.h"
 #include "unity.h"
 

--- a/src/c_api/tests/style_values_abi.c
+++ b/src/c_api/tests/style_values_abi.c
@@ -1,6 +1,7 @@
 // Raw C ABI coverage: malformed descriptor counts and unknown enum values are
 // hidden by binding-owned style values.
 
+#include "abi_tests.h"
 #include "test_support.h"
 #include "unity.h"
 

--- a/src/c_api/tests/test_support.c
+++ b/src/c_api/tests/test_support.c
@@ -26,29 +26,114 @@
 #include <vulkan/vulkan.h>
 #endif
 
+// Per-thread record of the handles these helpers created. A failing assertion
+// longjmps out of the test body, so the test's own teardown never runs and the
+// handles it holds would otherwise stay live: the next test on this thread
+// would then fail to create a runtime and the single real failure would look
+// like a suite-wide outage. Tracking is thread local so the owner thread's
+// teardown leaves a worker thread's runtime alone.
+#if defined(_MSC_VER) && !defined(__clang__)
+#define MLN_TEST_THREAD_LOCAL __declspec(thread)
+#else
+#define MLN_TEST_THREAD_LOCAL _Thread_local
+#endif
+
+#define MLN_TEST_TRACKED_CAPACITY 8
+
+// Sessions are tracked by value. The caller's fixture usually lives on the test
+// stack frame, which an aborting assertion unwinds before teardown runs, so a
+// pointer to it would dangle.
+typedef struct tracked_session {
+  mln_render_session* session;
+  void* backend_state;
+} tracked_session;
+
+static MLN_TEST_THREAD_LOCAL mln_runtime* tracked_runtime;
+static MLN_TEST_THREAD_LOCAL mln_map* tracked_maps[MLN_TEST_TRACKED_CAPACITY];
+static MLN_TEST_THREAD_LOCAL size_t tracked_map_count;
+static MLN_TEST_THREAD_LOCAL tracked_session
+  tracked_sessions[MLN_TEST_TRACKED_CAPACITY];
+static MLN_TEST_THREAD_LOCAL size_t tracked_session_count;
+
+static void track_map(mln_map* map) {
+  if (tracked_map_count < MLN_TEST_TRACKED_CAPACITY) {
+    tracked_maps[tracked_map_count] = map;
+    tracked_map_count += 1;
+  }
+}
+
+static void untrack_map(const mln_map* map) {
+  for (size_t index = 0; index < tracked_map_count; index += 1) {
+    if (tracked_maps[index] == map) {
+      tracked_maps[index] = tracked_maps[tracked_map_count - 1];
+      tracked_map_count -= 1;
+      return;
+    }
+  }
+}
+
+static void track_session(const mln_test_render_fixture* fixture) {
+  if (tracked_session_count < MLN_TEST_TRACKED_CAPACITY) {
+    tracked_sessions[tracked_session_count] = (tracked_session){
+      .session = fixture->session, .backend_state = fixture->backend_state
+    };
+    tracked_session_count += 1;
+  }
+}
+
+static void untrack_session(const mln_render_session* session) {
+  for (size_t index = 0; index < tracked_session_count; index += 1) {
+    if (tracked_sessions[index].session == session) {
+      tracked_sessions[index] = tracked_sessions[tracked_session_count - 1];
+      tracked_session_count -= 1;
+      return;
+    }
+  }
+}
+
 mln_runtime* mln_test_create_runtime(void) {
   mln_runtime* runtime = NULL;
   const mln_runtime_options options = mln_runtime_options_default();
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_runtime_create(&options, &runtime));
+  const mln_status status = mln_runtime_create(&options, &runtime);
+  if (status == MLN_STATUS_INVALID_STATE) {
+    TEST_FAIL_MESSAGE(
+      "This thread already owns a live runtime, so an earlier test leaked one. "
+      "Look for the first failing test above and destroy the runtime it "
+      "created."
+    );
+  }
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, status);
   TEST_ASSERT_NOT_NULL(runtime);
+  tracked_runtime = runtime;
   return runtime;
 }
 
-mln_map* mln_test_create_map(mln_runtime* runtime) {
+mln_map* mln_test_create_map_with_options(
+  mln_runtime* runtime, const mln_map_options* options
+) {
   mln_map* map = NULL;
-  mln_map_options options = mln_map_options_default();
-  options.width = 512;
-  options.height = 512;
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_create(runtime, &options, &map));
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_create(runtime, options, &map));
   TEST_ASSERT_NOT_NULL(map);
+  track_map(map);
   return map;
 }
 
+mln_map* mln_test_create_map(mln_runtime* runtime) {
+  mln_map_options options = mln_map_options_default();
+  options.width = 512;
+  options.height = 512;
+  return mln_test_create_map_with_options(runtime, &options);
+}
+
 void mln_test_destroy_runtime(mln_runtime* runtime) {
+  if (tracked_runtime == runtime) {
+    tracked_runtime = NULL;
+  }
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_runtime_destroy(runtime));
 }
 
 void mln_test_destroy_map(mln_map* map) {
+  untrack_map(map);
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_destroy(map));
 }
 
@@ -606,6 +691,7 @@ bool mln_test_render_fixture_create(
     *fixture = (mln_test_render_fixture){0};
     return false;
   }
+  track_session(fixture);
   return true;
 }
 
@@ -613,6 +699,7 @@ void mln_test_render_fixture_destroy(mln_test_render_fixture* fixture) {
   if (fixture == NULL) {
     return;
   }
+  untrack_session(fixture->session);
   if (fixture->session != NULL) {
     TEST_ASSERT_EQUAL_INT(
       MLN_STATUS_OK, mln_render_session_destroy(fixture->session)
@@ -620,4 +707,30 @@ void mln_test_render_fixture_destroy(mln_test_render_fixture* fixture) {
   }
   destroy_backend_state(fixture->backend_state);
   *fixture = (mln_test_render_fixture){0};
+}
+
+bool mln_test_reclaim_thread_resources(void) {
+  bool reclaimed = false;
+  // Render session before map before runtime: the C API keeps a map with a live
+  // session and a runtime with live maps alive on purpose.
+  while (tracked_session_count > 0) {
+    tracked_session_count -= 1;
+    const tracked_session entry = tracked_sessions[tracked_session_count];
+    if (entry.session != NULL) {
+      mln_render_session_destroy(entry.session);
+    }
+    destroy_backend_state(entry.backend_state);
+    reclaimed = true;
+  }
+  while (tracked_map_count > 0) {
+    tracked_map_count -= 1;
+    mln_map_destroy(tracked_maps[tracked_map_count]);
+    reclaimed = true;
+  }
+  if (tracked_runtime != NULL) {
+    mln_runtime_destroy(tracked_runtime);
+    tracked_runtime = NULL;
+    reclaimed = true;
+  }
+  return reclaimed;
 }

--- a/src/c_api/tests/test_support.c
+++ b/src/c_api/tests/test_support.c
@@ -55,16 +55,19 @@ static MLN_TEST_THREAD_LOCAL tracked_session
   tracked_sessions[MLN_TEST_TRACKED_CAPACITY];
 static MLN_TEST_THREAD_LOCAL size_t tracked_session_count;
 
-static void track_map(mln_map* map) {
-  // Dropping the overflow silently would leave a live map outside teardown,
-  // which keeps the runtime alive and cascades into every later test. Failing
-  // here names the real problem instead.
+// Fails before the caller creates the handle. Dropping an overflow silently
+// would leave a live map outside teardown, and failing after creation would
+// strand the very handle that overflowed, so both cascade the same way.
+static void reserve_map_slot(void) {
   if (tracked_map_count >= MLN_TEST_TRACKED_CAPACITY) {
     TEST_FAIL_MESSAGE(
       "This test holds more live maps than the suite can track. Destroy maps "
       "as the test finishes with them, or raise MLN_TEST_TRACKED_CAPACITY."
     );
   }
+}
+
+static void track_map(mln_map* map) {
   tracked_maps[tracked_map_count] = map;
   tracked_map_count += 1;
 }
@@ -79,7 +82,8 @@ static void untrack_map(const mln_map* map) {
   }
 }
 
-static void track_session(const mln_test_render_fixture* fixture) {
+// Fails before the caller attaches, for the same reason as reserve_map_slot().
+static void reserve_session_slot(void) {
   if (tracked_session_count >= MLN_TEST_TRACKED_CAPACITY) {
     TEST_FAIL_MESSAGE(
       "This test holds more live render sessions than the suite can track. "
@@ -87,6 +91,9 @@ static void track_session(const mln_test_render_fixture* fixture) {
       "MLN_TEST_TRACKED_CAPACITY."
     );
   }
+}
+
+static void track_session(const mln_test_render_fixture* fixture) {
   tracked_sessions[tracked_session_count] = (tracked_session){
     .session = fixture->session, .backend_state = fixture->backend_state
   };
@@ -124,6 +131,7 @@ mln_map* mln_test_create_map_with_options(
   mln_runtime* runtime, const mln_map_options* options
 ) {
   mln_map* map = NULL;
+  reserve_map_slot();
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_create(runtime, options, &map));
   TEST_ASSERT_NOT_NULL(map);
   track_map(map);
@@ -666,6 +674,7 @@ bool mln_test_render_fixture_create(
   if (map == NULL || fixture == NULL) {
     return false;
   }
+  reserve_session_slot();
   *fixture = (mln_test_render_fixture){0};
 #if defined(MLN_TEST_BACKEND_METAL)
   mln_metal_context_descriptor context = {0};

--- a/src/c_api/tests/test_support.c
+++ b/src/c_api/tests/test_support.c
@@ -56,10 +56,17 @@ static MLN_TEST_THREAD_LOCAL tracked_session
 static MLN_TEST_THREAD_LOCAL size_t tracked_session_count;
 
 static void track_map(mln_map* map) {
-  if (tracked_map_count < MLN_TEST_TRACKED_CAPACITY) {
-    tracked_maps[tracked_map_count] = map;
-    tracked_map_count += 1;
+  // Dropping the overflow silently would leave a live map outside teardown,
+  // which keeps the runtime alive and cascades into every later test. Failing
+  // here names the real problem instead.
+  if (tracked_map_count >= MLN_TEST_TRACKED_CAPACITY) {
+    TEST_FAIL_MESSAGE(
+      "This test holds more live maps than the suite can track. Destroy maps "
+      "as the test finishes with them, or raise MLN_TEST_TRACKED_CAPACITY."
+    );
   }
+  tracked_maps[tracked_map_count] = map;
+  tracked_map_count += 1;
 }
 
 static void untrack_map(const mln_map* map) {
@@ -73,12 +80,17 @@ static void untrack_map(const mln_map* map) {
 }
 
 static void track_session(const mln_test_render_fixture* fixture) {
-  if (tracked_session_count < MLN_TEST_TRACKED_CAPACITY) {
-    tracked_sessions[tracked_session_count] = (tracked_session){
-      .session = fixture->session, .backend_state = fixture->backend_state
-    };
-    tracked_session_count += 1;
+  if (tracked_session_count >= MLN_TEST_TRACKED_CAPACITY) {
+    TEST_FAIL_MESSAGE(
+      "This test holds more live render sessions than the suite can track. "
+      "Destroy sessions as the test finishes with them, or raise "
+      "MLN_TEST_TRACKED_CAPACITY."
+    );
   }
+  tracked_sessions[tracked_session_count] = (tracked_session){
+    .session = fixture->session, .backend_state = fixture->backend_state
+  };
+  tracked_session_count += 1;
 }
 
 static void untrack_session(const mln_render_session* session) {
@@ -125,16 +137,20 @@ mln_map* mln_test_create_map(mln_runtime* runtime) {
   return mln_test_create_map_with_options(runtime, &options);
 }
 
+// Untracking happens only after the destroy succeeds. A destroy that is
+// temporarily invalid -- destroying a map that still has a render session
+// attached -- longjmps out of the assertion below, and the handle has to stay
+// tracked so teardown can still reclaim it.
 void mln_test_destroy_runtime(mln_runtime* runtime) {
+  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_runtime_destroy(runtime));
   if (tracked_runtime == runtime) {
     tracked_runtime = NULL;
   }
-  TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_runtime_destroy(runtime));
 }
 
 void mln_test_destroy_map(mln_map* map) {
-  untrack_map(map);
   TEST_ASSERT_EQUAL_INT(MLN_STATUS_OK, mln_map_destroy(map));
+  untrack_map(map);
 }
 
 void mln_test_sleep_millisecond(void) { mln_test_sleep_milliseconds(1); }
@@ -699,12 +715,12 @@ void mln_test_render_fixture_destroy(mln_test_render_fixture* fixture) {
   if (fixture == NULL) {
     return;
   }
-  untrack_session(fixture->session);
   if (fixture->session != NULL) {
     TEST_ASSERT_EQUAL_INT(
       MLN_STATUS_OK, mln_render_session_destroy(fixture->session)
     );
   }
+  untrack_session(fixture->session);
   destroy_backend_state(fixture->backend_state);
   *fixture = (mln_test_render_fixture){0};
 }

--- a/src/c_api/tests/test_support.h
+++ b/src/c_api/tests/test_support.h
@@ -18,8 +18,13 @@ mln_test_thread* mln_test_thread_start(void (*entry)(void*), void* argument);
 void mln_test_thread_join(mln_test_thread* thread);
 void mln_test_sleep_milliseconds(unsigned int milliseconds);
 
+// These helpers track what they create per calling thread so the suite can
+// reclaim handles a test left behind. The matching destroy helpers untrack.
 mln_runtime* mln_test_create_runtime(void);
 mln_map* mln_test_create_map(mln_runtime* runtime);
+mln_map* mln_test_create_map_with_options(
+  mln_runtime* runtime, const mln_map_options* options
+);
 void mln_test_destroy_runtime(mln_runtime* runtime);
 void mln_test_destroy_map(mln_map* map);
 void mln_test_sleep_millisecond(void);
@@ -28,5 +33,11 @@ bool mln_test_render_fixture_create(
   mln_map* map, mln_test_render_fixture* fixture
 );
 void mln_test_render_fixture_destroy(mln_test_render_fixture* fixture);
+
+// Destroys everything this thread still has tracked, render session first, then
+// map, then runtime, and reports whether it reclaimed anything. Safe to call
+// after an aborted test: it reports through its return value rather than
+// through assertions, which would longjmp out of teardown.
+bool mln_test_reclaim_thread_resources(void);
 
 #endif


### PR DESCRIPTION
## Summary

Make the C API Unity suite fail loudly on two silent traps: an unregistered
test now breaks the build, and handles a failing test leaves behind are
reclaimed in `tearDown` so one real failure stays one failure.

## Test plan

`mise run test` on `linux-x64-vulkan` (44 tests, 0 failures), plus deliberate
regressions to confirm each new guard fires.

## Details

### Trap 1 — an unregistered test compiles and silently never runs

Every test is `static void <name>(void)` reached through one `RUN_TEST`, so an
unregistered test is an unused static function. `mln_c_api_tests` now builds
with `-Werror=unused-function` and `-Werror=missing-prototypes` (MSVC: `/we4505`),
a new `abi_tests.h` declares the seven `run_*_tests` entry points, the test
sources are globbed with `CONFIGURE_DEPENDS`, and a configure-time check
requires every globbed `*_abi.c` to have a matching call in `main.c`.

The compiler carries this instead of Unity's `generate_test_runner.rb` (Ruby is
not in this repo's toolchain) or a regex checker (`render_backend_abi.c` guards
both its test definitions and its `RUN_TEST` calls behind backend `#if` blocks,
and one signature is clang-format-wrapped across lines — only a preprocessor
reads that correctly).

Verbatim, after temporarily appending `static void deliberately_unregistered_test(void) {}`
to `query_abi.c`:

```
FAILED: [code=1] CMakeFiles/mln_c_api_tests.dir/src/c_api/tests/query_abi.c.o
src/c_api/tests/query_abi.c:57:13: error: 'deliberately_unregistered_test' defined but not used [-Werror=unused-function]
   57 | static void deliberately_unregistered_test(void) {}
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
```

Dropping `static` to dodge that hits the other flag:

```
src/c_api/tests/query_abi.c:57:6: error: no previous prototype for 'deliberately_unregistered_test' [-Werror=missing-prototypes]
   57 | void deliberately_unregistered_test(void) {}
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
```

And adding an `orphan_abi.c` that `main.c` never calls:

```
CMake Error at cmake/mln_tests.cmake:59 (message):
  src/c_api/tests/orphan_abi.c defines tests that never run: declare
  run_orphan_abi_tests(void) in src/c_api/tests/abi_tests.h and call it from
  src/c_api/tests/main.c.
```

### Trap 2 — `TEST_ASSERT_EQUAL_DOUBLE` was disabled, and one failure cascaded

Unity 2.6 makes double support opt-in; without `UNITY_INCLUDE_DOUBLE` the macro
expands to an unconditional "Double Support Disabled" failure that longjmps out
of the test. Nothing in this repo ever defined it — the only Unity define
present was `UNITY_USE_FLUSH_STDOUT`, so this was an unexamined upstream default
rather than a choice. It is now set PUBLIC on the `unity` target so Unity's own
translation unit and the tests agree, and `map_size_tracks_attach_and_resize`
uses `TEST_ASSERT_EQUAL_DOUBLE` for its 1.1 scale factor.

`test_support.c` now tracks the runtime, maps, and render sessions it creates
per thread (sessions by value, since an aborting assertion unwinds the caller's
stack fixture), the destroy helpers untrack, and `tearDown` calls the new
`mln_test_reclaim_thread_resources()`. Tracking is thread local so the owner
thread's teardown leaves the worker runtime in
`runtime_teardown_leaves_other_runtimes_responsive` alone.

Measured with a temporary test that creates a runtime and then fails, placed
first in the run order:

| | Result |
| --- | --- |
| Without `tearDown` reclamation | `45 Tests 37 Failures 0 Ignored` |
| With `tearDown` reclamation | `45 Tests 1 Failures 0 Ignored` |
| Probe removed | `44 Tests 0 Failures 0 Ignored` |

`mln_test_create_runtime` also now reports the one-runtime-per-thread violation
explicitly instead of a bare `Expected 0 Was 3`.

## AI assistance

- **Tools:** Claude Code
- **Context:** Implemented from a written design; all evidence above was
  captured by running the builds and suite locally on `linux-x64-vulkan`.
