### PR TITLE
Reject clustered GeoJSON data that is not a feature collection

### DIFF
--- a/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/StyleHandleTest.kt
+++ b/bindings/kotlin/src/nativeTest/kotlin/org/maplibre/nativeffi/map/StyleHandleTest.kt
@@ -558,7 +558,27 @@ class StyleHandleTest : org.maplibre.nativeffi.NativeTestBase() {
         },
       )
       assertEquals(SourceType.GEOJSON, map.styleSourceType("points"))
-      map.setGeoJsonSourceData("points", GeoJson.GeometryValue(Geometry.Point(LatLng(1.0, 1.0))))
+
+      // A clustered source indexes every feature as a point, so native rejects
+      // replacement data that is not a feature collection.
+      assertFailsWith<InvalidArgumentException> {
+        map.setGeoJsonSourceData("points", GeoJson.GeometryValue(Geometry.Point(LatLng(1.0, 1.0))))
+      }
+      map.setGeoJsonSourceData(
+        "points",
+        GeoJson.FeatureCollection(
+          listOf(Feature(Geometry.Point(LatLng(1.0, 1.0)), emptyList(), FeatureIdentifier.Null))
+        ),
+      )
+
+      // An unclustered source still materializes a bare geometry descriptor.
+      map.addGeoJsonSourceData(
+        "bare",
+        GeoJson.GeometryValue(Geometry.Point(LatLng(2.0, 2.0))),
+        null,
+      )
+      map.setGeoJsonSourceData("bare", GeoJson.GeometryValue(Geometry.Point(LatLng(3.0, 3.0))))
+      assertTrue(map.removeStyleSource("bare"))
 
       // Option values reach native validation rather than being dropped by the binding.
       assertFailsWith<InvalidArgumentException> {

--- a/bindings/rust/crates/maplibre-native/src/map/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/map/tests.rs
@@ -277,6 +277,54 @@ fn geojson_source_helpers_accept_options_and_keep_them_across_updates() {
 
 #[test]
 // Spec coverage: BND-060 and BND-061.
+fn clustered_geojson_source_requires_a_feature_collection() {
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::default()).unwrap();
+    map.set_style_json(VALID_STYLE_JSON).unwrap();
+
+    let mut options = GeoJsonSourceOptions::default();
+    options.cluster = Some(true);
+
+    // MapLibre Native engages clustering for feature collections only, so these
+    // used to tile unclustered instead of honouring the requested option.
+    let bare = GeoJson::Geometry(Geometry::Point(LatLng::new(0.0, 0.0)));
+    let error = map
+        .add_geojson_source_data("quakes", &bare, Some(&options))
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+    let message = error.to_string();
+    assert!(message.contains("quakes"), "{message}");
+    assert!(
+        message.contains("requires a feature collection"),
+        "{message}"
+    );
+    assert!(message.contains("a bare geometry"), "{message}");
+
+    let single = GeoJson::Feature(Feature::new(
+        Geometry::Point(LatLng::new(0.0, 0.0)),
+        Vec::new(),
+    ));
+    let error = map
+        .add_geojson_source_data("quakes", &single, Some(&options))
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+    assert!(error.to_string().contains("a single feature"), "{error}");
+
+    // The constraint belongs to clustering alone, and the rejected ID stays free.
+    map.add_geojson_source_data("quakes", &bare, None).unwrap();
+
+    // An empty feature collection carries nothing to cluster, so it stays
+    // accepted and a later update supplies the features to cluster.
+    let empty = GeoJson::FeatureCollection(Vec::new());
+    map.add_geojson_source_data("pending", &empty, Some(&options))
+        .unwrap();
+
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
+#[test]
+// Spec coverage: BND-060 and BND-061.
 fn clustered_geojson_source_reports_non_point_geometry() {
     let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
     let map = MapHandle::with_options(&runtime, &MapOptions::default()).unwrap();

--- a/include/maplibre_native_c/style.h
+++ b/include/maplibre_native_c/style.h
@@ -173,10 +173,11 @@ typedef struct mln_geojson_source_options {
    * Clusters point features. Defaults to false.
    *
    * Clustering applies to feature collections whose every feature carries point
-   * geometry. Feature collections that mix in other geometry are rejected by
-   * mln_map_add_geojson_source_data() and mln_map_set_geojson_source_data().
-   * MapLibre Native clusters feature collections only, so a source given a bare
-   * geometry or a single feature tiles that data without clustering it.
+   * geometry. MapLibre Native clusters feature collections only, so
+   * mln_map_add_geojson_source_data() and mln_map_set_geojson_source_data()
+   * reject a bare geometry or a single feature, along with a feature collection
+   * that mixes in other geometry. An empty feature collection stays accepted
+   * and carries nothing to cluster.
    */
   bool cluster;
 } mln_geojson_source_options;
@@ -466,17 +467,18 @@ MLN_API mln_status mln_map_add_geojson_source_url(
  * descriptor is copied into MapLibre Native before return. options may be null
  * for defaults, and the options are fixed for the lifetime of the source.
  *
- * When options enable clustering, every feature in a feature collection must
- * carry point geometry. This call checks that before handing the data to
- * MapLibre Native and names the source, the feature, and the constraint in the
- * thread-local diagnostic when a feature carries other geometry.
+ * When options enable clustering, the data must be a feature collection whose
+ * every feature carries point geometry. This call checks that before handing
+ * the data to MapLibre Native and names the source and the constraint in the
+ * thread-local diagnostic, so data MapLibre Native would tile without
+ * clustering is reported rather than accepted.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
  *   invalid or empty, data is null or invalid, options is invalid, the source
- *   ID already exists, or clustering is enabled and a feature carries geometry
- *   other than a point.
+ *   ID already exists, or clustering is enabled and the data is a bare geometry
+ *   or a single feature, or a feature carries geometry other than a point.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.
@@ -512,18 +514,19 @@ MLN_API mln_status mln_map_set_geojson_source_url(
  * is copied into MapLibre Native before return. The source keeps the
  * mln_geojson_source_options it was added with.
  *
- * When the source was added with clustering enabled, every feature in a feature
- * collection must carry point geometry. This call checks that before handing
- * the data to MapLibre Native and names the source, the feature, and the
- * constraint in the thread-local diagnostic when a feature carries other
- * geometry.
+ * When the source was added with clustering enabled, the data must be a feature
+ * collection whose every feature carries point geometry. This call checks that
+ * before handing the data to MapLibre Native and names the source and the
+ * constraint in the thread-local diagnostic, so data MapLibre Native would tile
+ * without clustering is reported rather than accepted.
  *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when map is null or not live, source_id is
  *   invalid or empty, data is null or invalid, the source does not exist, the
- *   source is not a GeoJSON source, or the source clusters and a feature
- *   carries geometry other than a point.
+ *   source is not a GeoJSON source, or the source clusters and the data is a
+ *   bare geometry or a single feature, or a feature carries geometry other than
+ *   a point.
  * - MLN_STATUS_WRONG_THREAD when called from a thread other than the map owner
  *   thread.
  * - MLN_STATUS_NATIVE_ERROR when an internal exception is converted to status.

--- a/src/c_api/tests/style_values_abi.c
+++ b/src/c_api/tests/style_values_abi.c
@@ -230,9 +230,89 @@ static void clustered_geojson_data_reports_non_point_geometry(void) {
   mln_test_destroy_runtime(runtime);
 }
 
+static void clustered_geojson_data_requires_a_feature_collection(void) {
+  mln_runtime* runtime = mln_test_create_runtime();
+  mln_map* map = mln_test_create_map(runtime);
+
+  const mln_geometry point = {
+    .size = sizeof(mln_geometry),
+    .type = MLN_GEOMETRY_TYPE_POINT,
+    .data = {.point = {.latitude = 37.7, .longitude = -122.5}}
+  };
+  const mln_feature feature = {.size = sizeof(mln_feature), .geometry = &point};
+  const mln_geojson bare_geometry = {
+    .size = sizeof(mln_geojson),
+    .type = MLN_GEOJSON_TYPE_GEOMETRY,
+    .data = {.geometry = &point}
+  };
+  const mln_geojson single_feature = {
+    .size = sizeof(mln_geojson),
+    .type = MLN_GEOJSON_TYPE_FEATURE,
+    .data = {.feature = &feature}
+  };
+
+  mln_geojson_source_options clustered = mln_geojson_source_options_default();
+  clustered.fields = MLN_GEOJSON_SOURCE_OPTION_CLUSTER;
+  clustered.cluster = true;
+
+  // MapLibre Native clusters feature collections only, so both of these would
+  // tile unclustered rather than honouring the requested cluster option.
+  const mln_string_view geometry_id = {.data = "quakes", .size = 6};
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT, mln_map_add_geojson_source_data(
+                                   map, geometry_id, &bare_geometry, &clustered
+                                 )
+  );
+  const char* message = mln_thread_last_error_message();
+  TEST_ASSERT_NOT_NULL(message);
+  TEST_ASSERT_NOT_NULL(strstr(message, "\"quakes\""));
+  TEST_ASSERT_NOT_NULL(strstr(message, "requires a feature collection"));
+  TEST_ASSERT_NOT_NULL(strstr(message, "a bare geometry"));
+
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT, mln_map_add_geojson_source_data(
+                                   map, geometry_id, &single_feature, &clustered
+                                 )
+  );
+  TEST_ASSERT_NOT_NULL(
+    strstr(mln_thread_last_error_message(), "a single feature")
+  );
+
+  // The constraint belongs to clustering alone, so the same data tiles fine on
+  // an unclustered source, and the rejected ID stays free.
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK,
+    mln_map_add_geojson_source_data(map, geometry_id, &bare_geometry, NULL)
+  );
+
+  // An empty feature collection carries nothing to cluster, so it stays
+  // accepted and a later update supplies the features to cluster.
+  const mln_geojson empty = {
+    .size = sizeof(mln_geojson),
+    .type = MLN_GEOJSON_TYPE_FEATURE_COLLECTION,
+    .data = {.feature_collection = {.features = NULL, .feature_count = 0}}
+  };
+  const mln_string_view empty_id = {.data = "pending", .size = 7};
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_OK,
+    mln_map_add_geojson_source_data(map, empty_id, &empty, &clustered)
+  );
+
+  // A source added with clustering rejects a bare geometry on update too.
+  TEST_ASSERT_EQUAL_INT(
+    MLN_STATUS_INVALID_ARGUMENT,
+    mln_map_set_geojson_source_data(map, empty_id, &bare_geometry)
+  );
+  TEST_ASSERT_NOT_NULL(strstr(mln_thread_last_error_message(), "\"pending\""));
+
+  mln_test_destroy_map(map);
+  mln_test_destroy_runtime(runtime);
+}
+
 void run_style_values_abi_tests(void) {
   UnitySetTestFile(__FILE__);
   RUN_TEST(style_value_helpers_reject_unsafe_raw_descriptors);
   RUN_TEST(geojson_source_options_reject_unsafe_raw_headers);
   RUN_TEST(clustered_geojson_data_reports_non_point_geometry);
+  RUN_TEST(clustered_geojson_data_requires_a_feature_collection);
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -746,20 +746,45 @@ auto geojson_geometry_type_name(const mbgl::Geometry<double>& geometry)
   );
 }
 
+auto geojson_alternative_name(const mbgl::GeoJSON& geojson)
+  -> std::string_view {
+  return geojson.match(
+    [](const mbgl::Geometry<double>&) -> std::string_view {
+      return "a bare geometry";
+    },
+    [](const mbgl::GeoJSONFeature&) -> std::string_view {
+      return "a single feature";
+    },
+    [](const mbgl::FeatureCollection&) -> std::string_view {
+      return "a feature collection";
+    }
+  );
+}
+
 /**
- * Reports whether clustered data satisfies supercluster's point-only input.
+ * Reports whether clustered data satisfies supercluster's input requirements.
  *
- * MapLibre Native clusters a feature collection by reading each feature's
- * geometry as a point, so any other geometry raises a variant access error
- * inside supercluster while mln_map_add_geojson_source_data() or
- * mln_map_set_geojson_source_data() builds the index. Checking here reports the
- * source, the feature, and the constraint instead.
+ * MapLibre Native engages clustering for feature collections only, and it reads
+ * each feature's geometry as a point. A bare geometry or a single feature tiles
+ * without clustering, and a feature carrying other geometry raises a variant
+ * access error inside supercluster while mln_map_add_geojson_source_data() or
+ * mln_map_set_geojson_source_data() builds the index. Checking here names the
+ * source and the constraint instead of clustering silently or failing deep
+ * inside MapLibre Native.
+ *
+ * An empty feature collection stays accepted: it carries nothing to cluster,
+ * and a later mln_map_set_geojson_source_data() clusters the features it
+ * supplies.
  */
 auto validate_clustered_geojson(
   const std::string& source_id, const mbgl::GeoJSON& geojson
 ) -> bool {
   if (!geojson.is<mbgl::FeatureCollection>()) {
-    return true;
+    const auto message = "clustered GeoJSON source \"" + source_id +
+                         "\" requires a feature collection; the data is " +
+                         std::string{geojson_alternative_name(geojson)};
+    mln::core::set_thread_error(message.c_str());
+    return false;
   }
 
   const auto& features = geojson.get<mbgl::FeatureCollection>();


### PR DESCRIPTION
## Summary

Clustered GeoJSON sources now reject a bare geometry or a single feature instead
of accepting data MapLibre Native would tile without clustering.

## Test plan

`mise run test` and `mise run //bindings/rust:test`

## Notes

`GeoJSONData::create()` engages supercluster only for a non-empty feature
collection (`geojson_source_impl.cpp:101`), so a source configured with
`cluster = true` and given a bare geometry or a single feature tiled unclustered
with no diagnostic — the requested option was silently ignored. #370 documented
that behavior on the `cluster` field; this rejects it instead, which is why that
paragraph changes here.

`validate_clustered_geojson()` already ran for both inline-data entry points and
returned early for anything that was not a feature collection. That early return
was the hole, so the check now names which alternative arrived:

```
clustered GeoJSON source "quakes" requires a feature collection; the data is a bare geometry
clustered GeoJSON source "quakes" requires a feature collection; the data is a single feature
```

An empty feature collection stays accepted. It carries nothing to cluster, it is
a legitimate initial state for a source populated later, and a subsequent
`mln_map_set_geojson_source_data()` clusters the features it supplies — so
rejecting it would break a reasonable workflow without preventing a wrong answer.

URL-backed sources remain unchecked, unchanged from #370: `GeoJSONData::create()`
runs later inside a background scheduler task for those, so there is no add-time
input to inspect.

## AI assistance

- **Tools:** Claude Code
- **Context:** Found while writing the cluster tests for #370, which documented
  the silent behavior rather than changing it.
