### PR TITLE
Split CI targets into individual jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1083,7 +1083,9 @@ jobs:
     timeout-minutes: 30
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
     needs:
+      - target-android-arm64-egl
       - target-android-arm64-vulkan
+      - target-android-x64-egl
       - target-android-x64-vulkan
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1091,13 +1093,13 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-ci-deps
         with:
-          target: android-multi-vulkan
+          target: android-multi
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - name: Download Android native artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: native-package-android-*-vulkan-${{ github.sha }}
+          pattern: native-package-android-*-${{ github.sha }}
           path: build/packages/native/android-multi-input
       - run: >-
           mise run //:kotlin:verify-android-multi-abi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,285 +55,11 @@ jobs:
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
       - run: mise run //docs:build
 
-  target:
-    name: target / ${{ matrix.preset }}
-    runs-on: ${{ matrix.runner }}
+  target-linux-x64-egl:
+    name: target / linux-x64-egl
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - preset: linux-x64-egl
-            runner: ubuntu-24.04
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test linux-x64-egl &&
-              mise run check-glibc-floor linux-x64-egl
-            consumer_commands: >-
-              mise run //bindings/rust:test linux-x64-egl &&
-              mise run //examples/rust-map:check linux-x64-egl &&
-              mise run //bindings/zig:test linux-x64-egl &&
-              mise run //examples/zig-map:build linux-x64-egl &&
-              mise run //examples/zig-readback:run linux-x64-egl &&
-              mise run //bindings/kotlin:jvmTest linux-x64-egl &&
-              mise run //examples/compose-map:build linux-x64-egl &&
-              mise run //examples/lwjgl-map:build linux-x64-egl &&
-              mise run //bindings/swift:test linux-x64-egl &&
-              mise run //bindings/dotnet:test linux-x64-egl &&
-              mise run //bindings/go:test linux-x64-egl &&
-              mise run //bindings/python:test linux-x64-egl
-          - preset: linux-x64-vulkan
-            runner: ubuntu-24.04
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test linux-x64-vulkan &&
-              mise run check-glibc-floor linux-x64-vulkan
-            consumer_commands: >-
-              mise run //bindings/rust:test linux-x64-vulkan &&
-              mise run //examples/rust-map:check linux-x64-vulkan &&
-              mise run //bindings/zig:test linux-x64-vulkan &&
-              mise run //examples/zig-map:build linux-x64-vulkan &&
-              mise run //examples/zig-readback:run linux-x64-vulkan &&
-              mise run //bindings/kotlin:jvmTest linux-x64-vulkan &&
-              mise run //examples/compose-map:build linux-x64-vulkan &&
-              mise run //examples/lwjgl-map:build linux-x64-vulkan &&
-              mise run //bindings/swift:test linux-x64-vulkan &&
-              mise run //bindings/dotnet:test linux-x64-vulkan &&
-              mise run //bindings/go:test linux-x64-vulkan &&
-              mise run //bindings/python:test linux-x64-vulkan
-          - preset: linux-arm64-egl
-            runner: ubuntu-24.04-arm
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test linux-arm64-egl &&
-              mise run check-glibc-floor linux-arm64-egl
-            consumer_commands: >-
-              mise run //bindings/rust:test linux-arm64-egl &&
-              mise run //examples/rust-map:check linux-arm64-egl &&
-              mise run //bindings/zig:test linux-arm64-egl &&
-              mise run //examples/zig-map:build linux-arm64-egl &&
-              mise run //examples/zig-readback:run linux-arm64-egl &&
-              mise run //bindings/kotlin:jvmTest linux-arm64-egl &&
-              mise run //examples/compose-map:build linux-arm64-egl &&
-              mise run //examples/lwjgl-map:build linux-arm64-egl &&
-              mise run //bindings/swift:test linux-arm64-egl &&
-              mise run //bindings/dotnet:test linux-arm64-egl &&
-              mise run //bindings/go:test linux-arm64-egl &&
-              mise run //bindings/python:test linux-arm64-egl
-          - preset: linux-arm64-vulkan
-            runner: ubuntu-24.04-arm
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test linux-arm64-vulkan &&
-              mise run check-glibc-floor linux-arm64-vulkan
-            consumer_commands: >-
-              mise run //bindings/rust:test linux-arm64-vulkan &&
-              mise run //examples/rust-map:check linux-arm64-vulkan &&
-              mise run //bindings/zig:test linux-arm64-vulkan &&
-              mise run //examples/zig-map:build linux-arm64-vulkan &&
-              mise run //examples/zig-readback:run linux-arm64-vulkan &&
-              mise run //bindings/kotlin:jvmTest linux-arm64-vulkan &&
-              mise run //examples/compose-map:build linux-arm64-vulkan &&
-              mise run //examples/lwjgl-map:build linux-arm64-vulkan &&
-              mise run //bindings/swift:test linux-arm64-vulkan &&
-              mise run //bindings/dotnet:test linux-arm64-vulkan &&
-              mise run //bindings/go:test linux-arm64-vulkan &&
-              mise run //bindings/python:test linux-arm64-vulkan
-          - preset: macos-arm64-metal
-            runner: macos-26
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test macos-arm64-metal
-            consumer_commands: >-
-              mise run //bindings/rust:test macos-arm64-metal &&
-              mise run //examples/rust-map:check macos-arm64-metal &&
-              mise run //bindings/zig:test macos-arm64-metal &&
-              mise run //examples/zig-map:build macos-arm64-metal &&
-              mise run //examples/zig-readback:run macos-arm64-metal &&
-              mise run //bindings/kotlin:jvmTest macos-arm64-metal &&
-              mise run //bindings/kotlin:nativeTest macos-arm64-metal &&
-              mise run //examples/compose-map:build macos-arm64-metal &&
-              mise run //examples/lwjgl-map:build macos-arm64-metal &&
-              mise run //bindings/swift:test macos-arm64-metal &&
-              mise run //examples/swift-map:build macos-arm64-metal &&
-              mise run //bindings/dotnet:test macos-arm64-metal &&
-              mise run //bindings/go:test macos-arm64-metal &&
-              mise run //bindings/python:test macos-arm64-metal
-          - preset: macos-arm64-vulkan
-            runner: macos-26
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test macos-arm64-vulkan
-            consumer_commands: >-
-              mise run //bindings/rust:test macos-arm64-vulkan &&
-              mise run //examples/rust-map:check macos-arm64-vulkan &&
-              mise run //bindings/zig:test macos-arm64-vulkan &&
-              mise run //examples/zig-map:build macos-arm64-vulkan &&
-              mise run //examples/zig-readback:run macos-arm64-vulkan &&
-              mise run //bindings/kotlin:jvmTest macos-arm64-vulkan &&
-              mise run //bindings/kotlin:nativeTest macos-arm64-vulkan &&
-              mise run //examples/compose-map:build macos-arm64-vulkan &&
-              mise run //examples/lwjgl-map:build macos-arm64-vulkan &&
-              mise run //bindings/swift:test macos-arm64-vulkan &&
-              mise run //bindings/dotnet:test macos-arm64-vulkan &&
-              mise run //bindings/go:test macos-arm64-vulkan &&
-              mise run //bindings/python:test macos-arm64-vulkan
-          - preset: macos-arm64-egl
-            runner: macos-26
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test macos-arm64-egl
-            consumer_commands: >-
-              mise run //bindings/rust:test macos-arm64-egl &&
-              mise run //bindings/zig:test macos-arm64-egl &&
-              mise run //examples/zig-map:build macos-arm64-egl &&
-              mise run //examples/zig-readback:run macos-arm64-egl &&
-              mise run //bindings/kotlin:jvmTest macos-arm64-egl &&
-              mise run //bindings/kotlin:nativeTest macos-arm64-egl &&
-              mise run //examples/compose-map:build macos-arm64-egl &&
-              mise run //examples/lwjgl-map:build macos-arm64-egl &&
-              mise run //bindings/swift:test macos-arm64-egl &&
-              mise run //bindings/dotnet:test macos-arm64-egl &&
-              mise run //bindings/go:test macos-arm64-egl &&
-              mise run //bindings/python:test macos-arm64-egl
-          - preset: ios-arm64-metal
-            runner: macos-26
-            package: true
-            zig: false
-            native_commands: >-
-              mise run build ios-arm64-metal
-            consumer_commands: >-
-              mise run //bindings/kotlin:iosBuild ios-arm64-metal &&
-              mise run //bindings/swift:build:ios &&
-              mise run //examples/swift-map:build:ios
-          - preset: ios-simulator-arm64-metal
-            runner: macos-26
-            package: true
-            zig: false
-            native_commands: >-
-              mise run test ios-simulator-arm64-metal
-            consumer_commands: >-
-              mise run //bindings/kotlin:iosBuild ios-simulator-arm64-metal &&
-              mise run //bindings/swift:build:ios-simulator &&
-              mise run //bindings/zig:test:ios-simulator &&
-              bash scripts/run-ios-simulator-test.sh bindings/swift/.build/ios-simulator/arm64-apple-ios-simulator/debug/MaplibreNativeIOSSimulatorTests 120 &&
-              mise run //examples/swift-map:build:ios-simulator
-          - preset: android-arm64-egl
-            runner: ubuntu-latest
-            package: true
-            zig: false
-            native_commands: >-
-              mise run build android-arm64-egl
-            consumer_commands: >-
-              mise run //bindings/kotlin:androidBuild opengl arm64-v8a --prebuilt &&
-              mise run //examples/android-map:build opengl arm64-v8a --prebuilt
-          - preset: android-arm64-vulkan
-            runner: ubuntu-latest
-            package: true
-            zig: false
-            native_commands: >-
-              mise run build android-arm64-vulkan
-            consumer_commands: >-
-              mise run //bindings/kotlin:androidBuild vulkan arm64-v8a --prebuilt
-          - preset: android-x64-egl
-            runner: ubuntu-latest
-            package: true
-            zig: false
-            native_commands: >-
-              mise run build android-x64-egl
-            consumer_commands: >-
-              mise run //bindings/kotlin:androidBuild opengl x86_64 --prebuilt &&
-              mise run //examples/android-map:build opengl x86_64 --prebuilt
-          - preset: android-x64-vulkan
-            runner: ubuntu-latest
-            package: true
-            zig: false
-            native_commands: >-
-              mise run build android-x64-vulkan
-            consumer_commands: >-
-              mise run //bindings/kotlin:androidBuild vulkan x86_64 --prebuilt
-          - preset: ohos-arm64-egl
-            runner: ubuntu-latest
-            package: false
-            zig: false
-            native_commands: >-
-              mise run //bindings/rust:build:ohos ohos-arm64-egl
-          - preset: ohos-arm64-vulkan
-            runner: ubuntu-latest
-            package: false
-            zig: false
-            native_commands: >-
-              mise run //bindings/rust:build:ohos ohos-arm64-vulkan
-          - preset: windows-x64-wgl
-            runner: windows-2022
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test windows-x64-wgl
-            consumer_commands: >-
-              mise run //bindings/rust:test windows-x64-wgl &&
-              mise run //examples/rust-map:check windows-x64-wgl &&
-              mise run //bindings/zig:test windows-x64-wgl &&
-              mise run //examples/zig-map:build windows-x64-wgl &&
-              mise run //examples/zig-readback:run windows-x64-wgl &&
-              mise run //bindings/kotlin:jvmTest windows-x64-wgl &&
-              mise run //examples/compose-map:build windows-x64-wgl &&
-              mise run //examples/lwjgl-map:build windows-x64-wgl &&
-              mise run //bindings/dotnet:test windows-x64-wgl &&
-              mise run //bindings/python:test windows-x64-wgl
-          - preset: windows-x64-vulkan
-            runner: windows-2022
-            package: true
-            zig: true
-            native_commands: >-
-              mise run test windows-x64-vulkan
-            consumer_commands: >-
-              mise run //bindings/rust:test windows-x64-vulkan &&
-              mise run //examples/rust-map:check windows-x64-vulkan &&
-              mise run //bindings/zig:test windows-x64-vulkan &&
-              mise run //examples/zig-map:build windows-x64-vulkan &&
-              mise run //examples/zig-readback:run windows-x64-vulkan &&
-              mise run //bindings/kotlin:jvmTest windows-x64-vulkan &&
-              mise run //examples/compose-map:build windows-x64-vulkan &&
-              mise run //examples/lwjgl-map:build windows-x64-vulkan &&
-              mise run //bindings/dotnet:test windows-x64-vulkan &&
-              mise run //bindings/python:test windows-x64-vulkan
-          - preset: windows-arm64-wgl
-            runner: windows-11-arm
-            package: true
-            zig: false
-            native_commands: >-
-              mise run test windows-arm64-wgl
-            consumer_commands: >-
-              mise run //bindings/rust:test windows-arm64-wgl &&
-              mise run //examples/rust-map:check windows-arm64-wgl &&
-              mise run //bindings/kotlin:jvmTest windows-arm64-wgl &&
-              mise run //examples/compose-map:build windows-arm64-wgl &&
-              mise run //examples/lwjgl-map:build windows-arm64-wgl &&
-              mise run //bindings/dotnet:test windows-arm64-wgl &&
-              mise run //bindings/python:test windows-arm64-wgl
-          - preset: windows-arm64-vulkan
-            runner: windows-11-arm
-            package: true
-            zig: false
-            native_commands: >-
-              mise run test windows-arm64-vulkan
-            consumer_commands: >-
-              mise run //bindings/rust:test windows-arm64-vulkan &&
-              mise run //examples/rust-map:check windows-arm64-vulkan &&
-              mise run //bindings/kotlin:jvmTest windows-arm64-vulkan &&
-              mise run //examples/compose-map:build windows-arm64-vulkan &&
-              mise run //examples/lwjgl-map:build windows-arm64-vulkan &&
-              mise run //bindings/dotnet:test windows-arm64-vulkan &&
-              mise run //bindings/python:test windows-arm64-vulkan
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -341,28 +67,57 @@ jobs:
       - uses: ./.github/actions/setup-ci-deps
         id: setup
         with:
-          target: ${{ matrix.preset }}
-          zig: ${{ matrix.zig }}
+          target: linux-x64-egl
+          zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - name: Run native checks
-        run: ${{ matrix.native_commands }}
+      - run: mise run test linux-x64-egl
+      - run: mise run check-glibc-floor linux-x64-egl
       - name: Archive native artifact
-        if: ${{ matrix.package }}
-        run: mise run archive-native ${{ matrix.preset }}
+        run: mise run archive-native linux-x64-egl
       - name: Install packaged native artifact
-        if: ${{ matrix.package }}
         run: >-
           mise run install-native-package
-          ${{ matrix.preset }}
-          build/packages/native/dist/maplibre-native-c-${{ matrix.preset }}.tar.gz
-      - name: Run binding and example checks
-        if: ${{ matrix.package }}
+          linux-x64-egl
+          build/packages/native/dist/maplibre-native-c-linux-x64-egl.tar.gz
+      - run: mise run //bindings/rust:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-        run: ${{ matrix.consumer_commands }}
+      - run: mise run //examples/rust-map:check linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:test linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/go:test linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test linux-x64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
-        if: ${{ matrix.zig && steps.setup.outputs.zig-cache-hit != 'true' }}
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -370,11 +125,956 @@ jobs:
             ~/AppData/Local/zig
           key: ${{ steps.setup.outputs.zig-cache-key }}
       - name: Upload native artifact
-        if: ${{ matrix.package }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: native-package-${{ matrix.preset }}-${{ github.sha }}
-          path: build/packages/native/dist/maplibre-native-c-${{ matrix.preset }}.tar.gz
+          name: native-package-linux-x64-egl-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-linux-x64-egl.tar.gz
+          if-no-files-found: error
+
+  target-linux-x64-vulkan:
+    name: target / linux-x64-vulkan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        id: setup
+        with:
+          target: linux-x64-vulkan
+          zig: true
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test linux-x64-vulkan
+      - run: mise run check-glibc-floor linux-x64-vulkan
+      - name: Archive native artifact
+        run: mise run archive-native linux-x64-vulkan
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          linux-x64-vulkan
+          build/packages/native/dist/maplibre-native-c-linux-x64-vulkan.tar.gz
+      - run: mise run //bindings/rust:test linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:test linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/go:test linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test linux-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Save Zig packages
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-linux-x64-vulkan-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-linux-x64-vulkan.tar.gz
+          if-no-files-found: error
+
+  target-linux-arm64-egl:
+    name: target / linux-arm64-egl
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        id: setup
+        with:
+          target: linux-arm64-egl
+          zig: true
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test linux-arm64-egl
+      - run: mise run check-glibc-floor linux-arm64-egl
+      - name: Archive native artifact
+        run: mise run archive-native linux-arm64-egl
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          linux-arm64-egl
+          build/packages/native/dist/maplibre-native-c-linux-arm64-egl.tar.gz
+      - run: mise run //bindings/rust:test linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:test linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/go:test linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test linux-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Save Zig packages
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-linux-arm64-egl-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-linux-arm64-egl.tar.gz
+          if-no-files-found: error
+
+  target-linux-arm64-vulkan:
+    name: target / linux-arm64-vulkan
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        id: setup
+        with:
+          target: linux-arm64-vulkan
+          zig: true
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test linux-arm64-vulkan
+      - run: mise run check-glibc-floor linux-arm64-vulkan
+      - name: Archive native artifact
+        run: mise run archive-native linux-arm64-vulkan
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          linux-arm64-vulkan
+          build/packages/native/dist/maplibre-native-c-linux-arm64-vulkan.tar.gz
+      - run: mise run //bindings/rust:test linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:test linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/go:test linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test linux-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Save Zig packages
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-linux-arm64-vulkan-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-linux-arm64-vulkan.tar.gz
+          if-no-files-found: error
+
+  target-macos-arm64-metal:
+    name: target / macos-arm64-metal
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        id: setup
+        with:
+          target: macos-arm64-metal
+          zig: true
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test macos-arm64-metal
+      - name: Archive native artifact
+        run: mise run archive-native macos-arm64-metal
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          macos-arm64-metal
+          build/packages/native/dist/maplibre-native-c-macos-arm64-metal.tar.gz
+      - run: mise run //bindings/rust:test macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:nativeTest macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:test macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/swift-map:build macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/go:test macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test macos-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Save Zig packages
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-macos-arm64-metal-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-macos-arm64-metal.tar.gz
+          if-no-files-found: error
+
+  target-macos-arm64-vulkan:
+    name: target / macos-arm64-vulkan
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        id: setup
+        with:
+          target: macos-arm64-vulkan
+          zig: true
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test macos-arm64-vulkan
+      - name: Archive native artifact
+        run: mise run archive-native macos-arm64-vulkan
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          macos-arm64-vulkan
+          build/packages/native/dist/maplibre-native-c-macos-arm64-vulkan.tar.gz
+      - run: mise run //bindings/rust:test macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:nativeTest macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:test macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/go:test macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test macos-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Save Zig packages
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-macos-arm64-vulkan-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-macos-arm64-vulkan.tar.gz
+          if-no-files-found: error
+
+  target-macos-arm64-egl:
+    name: target / macos-arm64-egl
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        id: setup
+        with:
+          target: macos-arm64-egl
+          zig: true
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test macos-arm64-egl
+      - name: Archive native artifact
+        run: mise run archive-native macos-arm64-egl
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          macos-arm64-egl
+          build/packages/native/dist/maplibre-native-c-macos-arm64-egl.tar.gz
+      - run: mise run //bindings/rust:test macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:nativeTest macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:test macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/go:test macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test macos-arm64-egl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Save Zig packages
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-macos-arm64-egl-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-macos-arm64-egl.tar.gz
+          if-no-files-found: error
+
+  target-ios-arm64-metal:
+    name: target / ios-arm64-metal
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: ios-arm64-metal
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run build ios-arm64-metal
+      - name: Archive native artifact
+        run: mise run archive-native ios-arm64-metal
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          ios-arm64-metal
+          build/packages/native/dist/maplibre-native-c-ios-arm64-metal.tar.gz
+      - run: mise run //bindings/kotlin:iosBuild ios-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:build:ios
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/swift-map:build:ios
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-ios-arm64-metal-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-ios-arm64-metal.tar.gz
+          if-no-files-found: error
+
+  target-ios-simulator-arm64-metal:
+    name: target / ios-simulator-arm64-metal
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: ios-simulator-arm64-metal
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test ios-simulator-arm64-metal
+      - name: Archive native artifact
+        run: mise run archive-native ios-simulator-arm64-metal
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          ios-simulator-arm64-metal
+          build/packages/native/dist/maplibre-native-c-ios-simulator-arm64-metal.tar.gz
+      - run: mise run //bindings/kotlin:iosBuild ios-simulator-arm64-metal
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/swift:build:ios-simulator
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test:ios-simulator
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: bash scripts/run-ios-simulator-test.sh bindings/swift/.build/ios-simulator/arm64-apple-ios-simulator/debug/MaplibreNativeIOSSimulatorTests 120
+      - run: mise run //examples/swift-map:build:ios-simulator
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-ios-simulator-arm64-metal-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-ios-simulator-arm64-metal.tar.gz
+          if-no-files-found: error
+
+  target-android-arm64-egl:
+    name: target / android-arm64-egl
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: android-arm64-egl
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run build android-arm64-egl
+      - name: Archive native artifact
+        run: mise run archive-native android-arm64-egl
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          android-arm64-egl
+          build/packages/native/dist/maplibre-native-c-android-arm64-egl.tar.gz
+      - run: mise run //bindings/kotlin:androidBuild opengl arm64-v8a --prebuilt
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/android-map:build opengl arm64-v8a --prebuilt
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-android-arm64-egl-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-android-arm64-egl.tar.gz
+          if-no-files-found: error
+
+  target-android-arm64-vulkan:
+    name: target / android-arm64-vulkan
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: android-arm64-vulkan
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run build android-arm64-vulkan
+      - name: Archive native artifact
+        run: mise run archive-native android-arm64-vulkan
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          android-arm64-vulkan
+          build/packages/native/dist/maplibre-native-c-android-arm64-vulkan.tar.gz
+      - run: mise run //bindings/kotlin:androidBuild vulkan arm64-v8a --prebuilt
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-android-arm64-vulkan-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-android-arm64-vulkan.tar.gz
+          if-no-files-found: error
+
+  target-android-x64-egl:
+    name: target / android-x64-egl
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: android-x64-egl
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run build android-x64-egl
+      - name: Archive native artifact
+        run: mise run archive-native android-x64-egl
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          android-x64-egl
+          build/packages/native/dist/maplibre-native-c-android-x64-egl.tar.gz
+      - run: mise run //bindings/kotlin:androidBuild opengl x86_64 --prebuilt
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/android-map:build opengl x86_64 --prebuilt
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-android-x64-egl-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-android-x64-egl.tar.gz
+          if-no-files-found: error
+
+  target-android-x64-vulkan:
+    name: target / android-x64-vulkan
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: android-x64-vulkan
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run build android-x64-vulkan
+      - name: Archive native artifact
+        run: mise run archive-native android-x64-vulkan
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          android-x64-vulkan
+          build/packages/native/dist/maplibre-native-c-android-x64-vulkan.tar.gz
+      - run: mise run //bindings/kotlin:androidBuild vulkan x86_64 --prebuilt
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-android-x64-vulkan-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-android-x64-vulkan.tar.gz
+          if-no-files-found: error
+
+  target-ohos-arm64-egl:
+    name: target / ohos-arm64-egl
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: ohos-arm64-egl
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run //bindings/rust:build:ohos ohos-arm64-egl
+
+  target-ohos-arm64-vulkan:
+    name: target / ohos-arm64-vulkan
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: ohos-arm64-vulkan
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run //bindings/rust:build:ohos ohos-arm64-vulkan
+
+  target-windows-x64-wgl:
+    name: target / windows-x64-wgl
+    runs-on: windows-2022
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        id: setup
+        with:
+          target: windows-x64-wgl
+          zig: true
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test windows-x64-wgl
+      - name: Archive native artifact
+        run: mise run archive-native windows-x64-wgl
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          windows-x64-wgl
+          build/packages/native/dist/maplibre-native-c-windows-x64-wgl.tar.gz
+      - run: mise run //bindings/rust:test windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test windows-x64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Save Zig packages
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-windows-x64-wgl-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-windows-x64-wgl.tar.gz
+          if-no-files-found: error
+
+  target-windows-x64-vulkan:
+    name: target / windows-x64-vulkan
+    runs-on: windows-2022
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        id: setup
+        with:
+          target: windows-x64-vulkan
+          zig: true
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test windows-x64-vulkan
+      - name: Archive native artifact
+        run: mise run archive-native windows-x64-vulkan
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          windows-x64-vulkan
+          build/packages/native/dist/maplibre-native-c-windows-x64-vulkan.tar.gz
+      - run: mise run //bindings/rust:test windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/zig:test windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-map:build windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/zig-readback:run windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test windows-x64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Save Zig packages
+        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: ${{ steps.setup.outputs.zig-cache-key }}
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-windows-x64-vulkan-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-windows-x64-vulkan.tar.gz
+          if-no-files-found: error
+
+  target-windows-arm64-wgl:
+    name: target / windows-arm64-wgl
+    runs-on: windows-11-arm
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: windows-arm64-wgl
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test windows-arm64-wgl
+      - name: Archive native artifact
+        run: mise run archive-native windows-arm64-wgl
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          windows-arm64-wgl
+          build/packages/native/dist/maplibre-native-c-windows-arm64-wgl.tar.gz
+      - run: mise run //bindings/rust:test windows-arm64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check windows-arm64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest windows-arm64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build windows-arm64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build windows-arm64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test windows-arm64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test windows-arm64-wgl
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-windows-arm64-wgl-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-windows-arm64-wgl.tar.gz
+          if-no-files-found: error
+
+  target-windows-arm64-vulkan:
+    name: target / windows-arm64-vulkan
+    runs-on: windows-11-arm
+    timeout-minutes: 120
+    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci-deps
+        with:
+          target: windows-arm64-vulkan
+          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+      - run: mise run test windows-arm64-vulkan
+      - name: Archive native artifact
+        run: mise run archive-native windows-arm64-vulkan
+      - name: Install packaged native artifact
+        run: >-
+          mise run install-native-package
+          windows-arm64-vulkan
+          build/packages/native/dist/maplibre-native-c-windows-arm64-vulkan.tar.gz
+      - run: mise run //bindings/rust:test windows-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/rust-map:check windows-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/kotlin:jvmTest windows-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/compose-map:build windows-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //examples/lwjgl-map:build windows-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/dotnet:test windows-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - run: mise run //bindings/python:test windows-arm64-vulkan
+        env:
+          MISE_TASK_SKIP: "//:build"
+      - name: Upload native artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-package-windows-arm64-vulkan-${{ github.sha }}
+          path: build/packages/native/dist/maplibre-native-c-windows-arm64-vulkan.tar.gz
           if-no-files-found: error
 
   android-multi:
@@ -383,7 +1083,8 @@ jobs:
     timeout-minutes: 30
     environment: ${{ github.event_name == 'push' && 'sccache' || '' }}
     needs:
-      - target
+      - target-android-arm64-vulkan
+      - target-android-x64-vulkan
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -410,7 +1111,25 @@ jobs:
     needs:
       - hygiene
       - docs
-      - target
+      - target-linux-x64-egl
+      - target-linux-x64-vulkan
+      - target-linux-arm64-egl
+      - target-linux-arm64-vulkan
+      - target-macos-arm64-metal
+      - target-macos-arm64-vulkan
+      - target-macos-arm64-egl
+      - target-ios-arm64-metal
+      - target-ios-simulator-arm64-metal
+      - target-android-arm64-egl
+      - target-android-arm64-vulkan
+      - target-android-x64-egl
+      - target-android-x64-vulkan
+      - target-ohos-arm64-egl
+      - target-ohos-arm64-vulkan
+      - target-windows-x64-wgl
+      - target-windows-x64-vulkan
+      - target-windows-arm64-wgl
+      - target-windows-arm64-vulkan
       - android-multi
     steps:
       - name: Fail if required jobs failed

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -136,12 +136,10 @@ def target_job(row: dict[str, object]) -> list[str]:
 def render(source: dict[str, object], presets: dict[str, object]) -> str:
     rows = target_rows(source, presets)
     target_ids = [job_id(str(row["preset"])) for row in rows]
-    android_vulkan_ids = [
+    android_package_ids = [
         job_id(str(row["preset"]))
         for row in rows
-        if str(row["preset"]).startswith("android-")
-        and str(row["preset"]).endswith("-vulkan")
-        and row["package"]
+        if str(row["preset"]).startswith("android-") and row["package"]
     ]
 
     lines = [
@@ -204,13 +202,13 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
             "    timeout-minutes: 30",
             SCCACHE_ENVIRONMENT,
             "    needs:",
-            *[f"      - {job}" for job in android_vulkan_ids],
+            *[f"      - {job}" for job in android_package_ids],
             "    steps:",
-            *setup("android-multi-vulkan"),
+            *setup("android-multi"),
             "      - name: Download Android native artifacts",
             f"        uses: {DOWNLOAD}",
             "        with:",
-            "          pattern: native-package-android-*-vulkan-${{ github.sha }}",
+            "          pattern: native-package-android-*-${{ github.sha }}",
             "          path: build/packages/native/android-multi-input",
             "      - run: >-",
             "          mise run //:kotlin:verify-android-multi-abi",

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -21,30 +21,15 @@ CACHE_SAVE = PINS["actions/cache/save"]
 DOWNLOAD = PINS["actions/download-artifact"]
 UPLOAD = PINS["actions/upload-artifact"]
 
-
-def matrix(rows: list[dict[str, object]], indent: int = 8) -> list[str]:
-    lines = [" " * indent + "include:"]
-    for row in rows:
-        first, *rest = row.items()
-        key, value = first
-        lines.append(" " * (indent + 2) + f"- {key}: {value}")
-        for key, value in rest:
-            if isinstance(value, list):
-                lines.append(" " * (indent + 4) + f"{key}: >-")
-                for index, command in enumerate(value):
-                    suffix = " &&" if index < len(value) - 1 else ""
-                    lines.append(" " * (indent + 6) + f"{command}{suffix}")
-            else:
-                scalar = str(value).lower() if isinstance(value, bool) else value
-                lines.append(" " * (indent + 4) + f"{key}: {scalar}")
-    return lines
-
-
 # Environment secrets for R2 writes live in the GitHub Environment `sccache`
 # (main only). PRs omit the environment and fall back to public read-only.
 SCCACHE_ENVIRONMENT = (
     "    environment: ${{ github.event_name == 'push' && 'sccache' || '' }}"
 )
+
+
+def job_id(preset: str) -> str:
+    return f"target-{preset}"
 
 
 def setup(target: str | None = None, zig: bool = False) -> list[str]:
@@ -60,7 +45,7 @@ def setup(target: str | None = None, zig: bool = False) -> list[str]:
     if target:
         lines.append(f"          target: {target}")
     if zig:
-        lines.append("          zig: ${{ matrix.zig }}")
+        lines.append("          zig: true")
     lines.extend(
         [
             "          sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}",
@@ -70,8 +55,94 @@ def setup(target: str | None = None, zig: bool = False) -> list[str]:
     return lines
 
 
+def run_step(command: str, *, env: dict[str, str] | None = None) -> list[str]:
+    lines = [f"      - run: {command}"]
+    if env:
+        lines.append("        env:")
+        for key, value in env.items():
+            lines.append(f"          {key}: {value}")
+    return lines
+
+
+CONSUMER_ENV = {"MISE_TASK_SKIP": '"//:build"'}
+
+
+def target_job(row: dict[str, object]) -> list[str]:
+    preset = str(row["preset"])
+    package = bool(row["package"])
+    zig = bool(row["zig"])
+    native = list(row["native_commands"])
+    consumers = list(row.get("consumer_commands", []))
+
+    lines = [
+        f"  {job_id(preset)}:",
+        f"    name: target / {preset}",
+        f"    runs-on: {row['runner']}",
+        "    timeout-minutes: 120",
+        SCCACHE_ENVIRONMENT,
+        "    steps:",
+        *setup(preset, zig=zig),
+    ]
+    for command in native:
+        lines.extend(run_step(command))
+    if package:
+        lines.extend(
+            [
+                "      - name: Archive native artifact",
+                f"        run: mise run archive-native {preset}",
+                "      - name: Install packaged native artifact",
+                "        run: >-",
+                "          mise run install-native-package",
+                f"          {preset}",
+                f"          build/packages/native/dist/maplibre-native-c-{preset}.tar.gz",
+            ]
+        )
+        for command in consumers:
+            env = CONSUMER_ENV if command.startswith("mise run") else None
+            lines.extend(run_step(command, env=env))
+    # Only rows that fetch every Zig project the key covers may claim it;
+    # see `uses_zig`. No status function in the `if`, so `success()` is
+    # implied: a job that fetched only part of its Zig packages before
+    # failing saves nothing, leaving the key free for a later run that
+    # completes the fetch.
+    if zig:
+        lines.extend(
+            [
+                "      - name: Save Zig packages",
+                "        if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}",
+                f"        uses: {CACHE_SAVE}",
+                "        with:",
+                "          path: |",
+                "            ~/.cache/zig",
+                "            ~/AppData/Local/zig",
+                "          key: ${{ steps.setup.outputs.zig-cache-key }}",
+            ]
+        )
+    if package:
+        lines.extend(
+            [
+                "      - name: Upload native artifact",
+                f"        uses: {UPLOAD}",
+                "        with:",
+                f"          name: native-package-{preset}-${{{{ github.sha }}}}",
+                f"          path: build/packages/native/dist/maplibre-native-c-{preset}.tar.gz",
+                "          if-no-files-found: error",
+            ]
+        )
+    lines.append("")
+    return lines
+
+
 def render(source: dict[str, object], presets: dict[str, object]) -> str:
     rows = target_rows(source, presets)
+    target_ids = [job_id(str(row["preset"])) for row in rows]
+    android_vulkan_ids = [
+        job_id(str(row["preset"]))
+        for row in rows
+        if str(row["preset"]).startswith("android-")
+        and str(row["preset"]).endswith("-vulkan")
+        and row["package"]
+    ]
 
     lines = [
         "# Generated by `mise run ci:generate-workflow`. Do not edit directly.",
@@ -121,91 +192,50 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         *setup(),
         "      - run: mise run //docs:build",
         "",
-        "  target:",
-        "    name: target / ${{ matrix.preset }}",
-        "    runs-on: ${{ matrix.runner }}",
-        "    timeout-minutes: 120",
-        SCCACHE_ENVIRONMENT,
-        "    strategy:",
-        "      fail-fast: false",
-        "      matrix:",
-        *matrix(rows),
-        "    steps:",
-        *setup("${{ matrix.preset }}", zig=True),
-        "      - name: Run native checks",
-        "        run: ${{ matrix.native_commands }}",
-        "      - name: Archive native artifact",
-        "        if: ${{ matrix.package }}",
-        "        run: mise run archive-native ${{ matrix.preset }}",
-        "      - name: Install packaged native artifact",
-        "        if: ${{ matrix.package }}",
-        "        run: >-",
-        "          mise run install-native-package",
-        "          ${{ matrix.preset }}",
-        "          build/packages/native/dist/maplibre-native-c-${{ matrix.preset }}.tar.gz",
-        "      - name: Run binding and example checks",
-        "        if: ${{ matrix.package }}",
-        "        env:",
-        '          MISE_TASK_SKIP: "//:build"',
-        "        run: ${{ matrix.consumer_commands }}",
-        # Only rows that fetch every Zig project the key covers may claim it;
-        # see `uses_zig`. No status function in the `if`, so `success()` is
-        # implied: a job that fetched only part of its Zig packages before
-        # failing saves nothing, leaving the key free for a later run that
-        # completes the fetch.
-        "      - name: Save Zig packages",
-        "        if: ${{ matrix.zig && steps.setup.outputs.zig-cache-hit != 'true' }}",
-        f"        uses: {CACHE_SAVE}",
-        "        with:",
-        "          path: |",
-        "            ~/.cache/zig",
-        "            ~/AppData/Local/zig",
-        "          key: ${{ steps.setup.outputs.zig-cache-key }}",
-        "      - name: Upload native artifact",
-        "        if: ${{ matrix.package }}",
-        f"        uses: {UPLOAD}",
-        "        with:",
-        "          name: native-package-${{ matrix.preset }}-${{ github.sha }}",
-        "          path: build/packages/native/dist/maplibre-native-c-${{ matrix.preset }}.tar.gz",
-        "          if-no-files-found: error",
-        "",
-        "  android-multi:",
-        "    name: Android multi-ABI packaging",
-        "    runs-on: ubuntu-latest",
-        "    timeout-minutes: 30",
-        SCCACHE_ENVIRONMENT,
-        "    needs:",
-        "      - target",
-        "    steps:",
-        *setup("android-multi-vulkan"),
-        "      - name: Download Android native artifacts",
-        f"        uses: {DOWNLOAD}",
-        "        with:",
-        "          pattern: native-package-android-*-vulkan-${{ github.sha }}",
-        "          path: build/packages/native/android-multi-input",
-        "      - run: >-",
-        "          mise run //:kotlin:verify-android-multi-abi",
-        "          build/packages/native/android-multi-input",
-        "",
-        "  required:",
-        "    name: ci-required",
-        "    runs-on: ubuntu-latest",
-        "    timeout-minutes: 5",
-        "    if: ${{ always() }}",
-        "    needs:",
-        "      - hygiene",
-        "      - docs",
-        "      - target",
-        "      - android-multi",
-        "    steps:",
-        "      - name: Fail if required jobs failed",
-        "        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}",
-        "        run: |",
-        "          echo '${{ toJSON(needs) }}'",
-        "          exit 1",
-        '      - run: "true"',
-        "",
     ]
+    for row in rows:
+        lines.extend(target_job(row))
+
+    lines.extend(
+        [
+            "  android-multi:",
+            "    name: Android multi-ABI packaging",
+            "    runs-on: ubuntu-latest",
+            "    timeout-minutes: 30",
+            SCCACHE_ENVIRONMENT,
+            "    needs:",
+            *[f"      - {job}" for job in android_vulkan_ids],
+            "    steps:",
+            *setup("android-multi-vulkan"),
+            "      - name: Download Android native artifacts",
+            f"        uses: {DOWNLOAD}",
+            "        with:",
+            "          pattern: native-package-android-*-vulkan-${{ github.sha }}",
+            "          path: build/packages/native/android-multi-input",
+            "      - run: >-",
+            "          mise run //:kotlin:verify-android-multi-abi",
+            "          build/packages/native/android-multi-input",
+            "",
+            "  required:",
+            "    name: ci-required",
+            "    runs-on: ubuntu-latest",
+            "    timeout-minutes: 5",
+            "    if: ${{ always() }}",
+            "    needs:",
+            "      - hygiene",
+            "      - docs",
+            *[f"      - {job}" for job in target_ids],
+            "      - android-multi",
+            "    steps:",
+            "      - name: Fail if required jobs failed",
+            "        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}",
+            "        run: |",
+            "          echo '${{ toJSON(needs) }}'",
+            "          exit 1",
+            '      - run: "true"',
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 

--- a/.mise/tasks/kotlin/verify-android-multi-abi
+++ b/.mise/tasks/kotlin/verify-android-multi-abi
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Verify the multi-ABI Android runtime from packaged native artifacts."
+#MISE description="Verify multi-ABI Android runtime AARs from packaged native artifacts."
 #MISE tools={java="{{vars.java_version}}"}
 
 set -euo pipefail
@@ -11,7 +11,12 @@ fi
 
 input_root="$1"
 install_root="${MISE_MONOREPO_ROOT}/build/packages/kotlin/android-multi-install"
-presets=(android-arm64-vulkan android-x64-vulkan)
+presets=(
+  android-arm64-egl
+  android-arm64-vulkan
+  android-x64-egl
+  android-x64-vulkan
+)
 
 rm -rf "$install_root"
 mkdir -p "$install_root"
@@ -36,8 +41,10 @@ for preset in "${presets[@]}"; do
   mv "${install_root}/${archive_root}" "${install_root}/${preset}"
 done
 
-./gradlew \
-  -Pmaplibre.android.prebuiltInstallRoot="$install_root" \
-  -Pmaplibre.android.backend=vulkan \
-  -Pmaplibre.android.abis=arm64-v8a,x86_64 \
-  :bindings:kotlin:androidBuild
+for backend in opengl vulkan; do
+  ./gradlew \
+    -Pmaplibre.android.prebuiltInstallRoot="$install_root" \
+    -Pmaplibre.android.backend="$backend" \
+    -Pmaplibre.android.abis=arm64-v8a,x86_64 \
+    :bindings:kotlin:androidBuild
+done


### PR DESCRIPTION
## Summary

- Replace the matrix-based target CI job with one job per platform, architecture, and renderer.
- Run native, binding, example, packaging, caching, and artifact steps independently for clearer failures.
- Update workflow generation and simplify Kotlin lifecycle, callback, and resource handling.
- Remove the obsolete Android API floor check and related Gradle/Mise configuration.

## Testing

- Not run locally; CI workflow changes are intended to provide validation across all targets.