### PR TITLE
Lease the resource provider outside the runtime registry lock

### DIFF
--- a/include/maplibre_native_c/runtime.h
+++ b/include/maplibre_native_c/runtime.h
@@ -729,6 +729,18 @@ MLN_API mln_status mln_runtime_offline_operation_discard(
  * returns quickly and calls no C API function other than
  * mln_resource_transform_response_set_url().
  *
+ * A registered resource provider is waited on the same way: this call blocks
+ * until every in-flight mln_resource_provider_callback invocation returns,
+ * matching mln_runtime_set_resource_provider() and
+ * mln_runtime_clear_resource_provider(). The callback and its user_data stay
+ * valid until that point and are unreferenced once this call returns, so a
+ * host frees provider-owned state only after it does.
+ *
+ * Both waits run with no runtime-internal lock that other runtimes need, so a
+ * slow callback delays only this runtime. Do not call this while holding a
+ * host lock that a provider or transform callback also acquires; the callback
+ * cannot finish, and this call cannot return.
+ *
  * Returns:
  * - MLN_STATUS_OK on success.
  * - MLN_STATUS_INVALID_ARGUMENT when runtime is null or not a live runtime

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -119,6 +119,23 @@ auto lease_resource_transform_state(void* platform_context) noexcept
   return runtime->resource_transform_state;
 }
 
+// Leases the resource provider registration, matching the transform lookup:
+// the registry lock covers only a reference count increment, and the caller
+// takes the state's lock after it is released.
+auto lease_resource_provider_state(void* platform_context) noexcept
+  -> std::shared_ptr<mln::core::ResourceProviderState> {
+  if (platform_context == nullptr) {
+    return nullptr;
+  }
+
+  auto* runtime = static_cast<mln_runtime*>(platform_context);
+  const std::scoped_lock registry_lock(runtime_registry_mutex());
+  if (!runtime_registry().contains(runtime)) {
+    return nullptr;
+  }
+  return runtime->resource_provider_state;
+}
+
 using OfflineRegionSnapshotRegistry = std::unordered_map<
   const mln_offline_region_snapshot*,
   std::unique_ptr<mln_offline_region_snapshot>>;
@@ -1033,6 +1050,8 @@ auto create_runtime(
   owned_runtime->offline_operation_state->alive = true;
   owned_runtime->resource_transform_state =
     std::make_shared<ResourceTransformState>();
+  owned_runtime->resource_provider_state =
+    std::make_shared<ResourceProviderState>();
   auto* runtime = owned_runtime.get();
   {
     const std::scoped_lock lock(runtime_registry_mutex());
@@ -2337,9 +2356,10 @@ auto set_resource_provider(
   // that already leased the previous provider, so the previous callback and its
   // `user_data` are unreferenced once this returns. The registry lock is not
   // held across that wait, so one runtime's callback cannot stall others.
-  const std::unique_lock lock(runtime->resource_provider_mutex);
-  runtime->has_resource_provider = true;
-  runtime->resource_provider = ResourceProvider{
+  auto& state = *runtime->resource_provider_state;
+  const std::unique_lock lock(state.mutex);
+  state.registered = true;
+  state.provider = ResourceProvider{
     .callback = provider->callback,
     .user_data = provider->user_data,
   };
@@ -2352,9 +2372,10 @@ auto clear_resource_provider(mln_runtime* runtime) -> mln_status {
     return status;
   }
 
-  const std::unique_lock lock(runtime->resource_provider_mutex);
-  runtime->has_resource_provider = false;
-  runtime->resource_provider = ResourceProvider{};
+  auto& state = *runtime->resource_provider_state;
+  const std::unique_lock lock(state.mutex);
+  state.registered = false;
+  state.provider = ResourceProvider{};
   return MLN_STATUS_OK;
 }
 
@@ -2392,17 +2413,6 @@ auto destroy_runtime(mln_runtime* runtime) -> mln_status {
     runtime_registry().erase(found);
   }
 
-  {
-    // A file-source thread that found this runtime under the registry lock
-    // holds a shared provider lock through the callback. Taking the exclusive
-    // lock here keeps callback and user_data lifetime inside runtime lifetime.
-    const std::unique_lock provider_lock(
-      owned_runtime->resource_provider_mutex
-    );
-    owned_runtime->has_resource_provider = false;
-    owned_runtime->resource_provider = ResourceProvider{};
-  }
-
   // A resource transform callback that entered `invoke_resource_transform()`
   // before the erase above holds a shared transform lock, so this wait covers
   // every callback that can still observe the runtime. A lookup that leased
@@ -2420,11 +2430,10 @@ auto destroy_runtime(mln_runtime* runtime) -> mln_status {
   // above holds a shared provider lock, so this wait covers every callback that
   // can still observe the runtime.
   {
-    const std::unique_lock provider_lock(
-      owned_runtime->resource_provider_mutex
-    );
-    owned_runtime->has_resource_provider = false;
-    owned_runtime->resource_provider = ResourceProvider{};
+    auto& provider_state = *owned_runtime->resource_provider_state;
+    const std::unique_lock provider_lock(provider_state.mutex);
+    provider_state.registered = false;
+    provider_state.provider = ResourceProvider{};
   }
 
   {
@@ -2576,31 +2585,22 @@ auto resource_options_for_runtime(mln_runtime* runtime)
 auto acquire_resource_provider_for_platform_context(
   void* platform_context
 ) noexcept -> std::optional<ResourceProviderLease> {
-  if (platform_context == nullptr) {
+  const auto state = lease_resource_provider_state(platform_context);
+  if (state == nullptr) {
     return std::nullopt;
   }
 
-  auto* runtime = static_cast<mln_runtime*>(platform_context);
-  std::shared_lock<std::shared_mutex> provider_lock;
-  {
-    // Taking the shared provider lock while the registry lock is held is the
-    // handoff that keeps the runtime alive for the callback:
-    // `destroy_runtime()` removes the registry entry under the same registry
-    // lock and then waits for the exclusive provider lock. A caller that
-    // reaches the shared lock first holds teardown until the lease ends, and
-    // one that arrives after the erase finds no entry and skips the provider.
-    const std::scoped_lock registry_lock(runtime_registry_mutex());
-    if (!runtime_registry().contains(runtime)) {
-      return std::nullopt;
-    }
-    provider_lock = std::shared_lock{runtime->resource_provider_mutex};
-  }
-
-  if (!runtime->has_resource_provider) {
+  // The lease keeps this state readable on its own, so the shared lock is
+  // taken with the registry lock released. `destroy_runtime()` erases the
+  // registry entry and then clears the registration under the exclusive lock,
+  // so a callback that reaches the shared lock first holds teardown until it
+  // returns, and one that arrives later finds an empty registration.
+  std::shared_lock provider_lock(state->mutex);
+  if (!state->registered) {
     return std::nullopt;
   }
   return ResourceProviderLease{
-    std::move(provider_lock), runtime->resource_provider
+    state, std::move(provider_lock), state->provider
   };
 }
 

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -50,17 +50,35 @@ struct ResourceTransformState {
   void* user_data = nullptr;
 };
 
+// Holds the resource provider registration in its own reference-counted object,
+// mirroring `ResourceTransformState`.
+//
+// A file-source lookup copies the runtime's handle to this state under the
+// process-global registry lock, which proves the runtime is live, and takes
+// `mutex` only after releasing it. Acquiring the shared lock while still
+// holding the registry lock would queue behind a pending writer and stall every
+// unrelated runtime for the duration of the in-flight callback, because
+// `validate_runtime()` and every other file-source lookup need that same
+// process-global mutex.
+struct ResourceProviderState {
+  std::shared_mutex mutex;
+  bool registered = false;
+  ResourceProvider provider;
+};
+
 // Borrows the resource provider registered on a runtime for the duration of one
-// provider callback. The lease holds a shared lock on the runtime's provider
-// mutex, so `set_resource_provider()`, `clear_resource_provider()`, and
+// provider callback. The lease holds a shared lock on the state's mutex, so
+// `set_resource_provider()`, `clear_resource_provider()`, and
 // `destroy_runtime()` wait for every live lease before they retire a callback
-// and its `user_data`.
+// and its `user_data`. The lease also retains the state itself, so it stays
+// readable even after the runtime it came from is gone.
 class ResourceProviderLease {
  public:
   ResourceProviderLease(
+    std::shared_ptr<ResourceProviderState> state,
     std::shared_lock<std::shared_mutex> lock, ResourceProvider provider
   )
-      : lock_(std::move(lock)), provider_(provider) {}
+      : state_(std::move(state)), lock_(std::move(lock)), provider_(provider) {}
 
   [[nodiscard]] auto callback() const -> mln_resource_provider_callback {
     return provider_.callback;
@@ -68,6 +86,7 @@ class ResourceProviderLease {
   [[nodiscard]] auto user_data() const -> void* { return provider_.user_data; }
 
  private:
+  std::shared_ptr<ResourceProviderState> state_;
   std::shared_lock<std::shared_mutex> lock_;
   ResourceProvider provider_;
 };
@@ -105,9 +124,7 @@ struct mln_runtime {
   std::shared_ptr<mbgl::DatabaseFileSource> database_source;
   bool has_maximum_cache_size = false;
   std::uint64_t maximum_cache_size = 0;
-  mutable std::shared_mutex resource_provider_mutex;
-  bool has_resource_provider = false;
-  mln::core::ResourceProvider resource_provider;
+  std::shared_ptr<mln::core::ResourceProviderState> resource_provider_state;
   std::shared_ptr<mln::core::OfflineRegionEventState> offline_event_state;
   std::shared_ptr<mln::core::OfflineOperationEventState>
     offline_operation_state;


### PR DESCRIPTION
## Summary

Move the resource provider registration into a reference-counted state object so a file-source lookup takes the per-runtime provider lock only after releasing the process-global registry lock, matching the resource transform lookup, and document the provider wait on `mln_runtime_destroy()`.

## Test plan

`mise run test` (49 C API tests), plus the Rust and Python binding suites.