### PR TITLE
Resolve the Vulkan loader at runtime

### DIFF
--- a/.mise/tasks/verify-native-package
+++ b/.mise/tasks/verify-native-package
@@ -36,8 +36,16 @@ MACHO_ALLOWED_PREFIXES = (
 MACHO_SEARCH_PATH_ROOTS = ("@loader_path", "@executable_path")
 ELF_SEARCH_PATH_ROOTS = ("$ORIGIN", "${ORIGIN}")
 
-MACHO_NAME = re.compile(r"^\s*name (?P<name>\S+) \(offset \d+\)$")
-MACHO_PATH = re.compile(r"^\s*path (?P<path>\S+) \(offset \d+\)$")
+# 64- and 32-bit thin Mach-O, then the 32- and 64-bit universal headers.
+MACHO_MAGICS = frozenset(
+    {b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe", b"\xca\xfe\xba\xbe", b"\xca\xfe\xba\xbf"}
+)
+
+# A path may contain spaces, so it runs to the trailing offset field, which
+# otool always prints. Anything narrower drops the build-host paths that live
+# under a home directory holding a full name.
+MACHO_NAME = re.compile(r"^\s*name (?P<name>.+) \(offset \d+\)$")
+MACHO_PATH = re.compile(r"^\s*path (?P<path>.+) \(offset \d+\)$")
 MACHO_COMMAND = re.compile(r"^\s*cmd (?P<command>LC_\w+)$")
 ELF_ENTRY = re.compile(r"^\s*0x[0-9a-f]+\s+\((?P<tag>\w+)\)\s+.*\[(?P<value>[^\]]*)\]")
 
@@ -104,9 +112,10 @@ def binary_problems(binary: pathlib.Path) -> list[str]:
         magic = file.read(4)
     if magic == b"\x7fELF":
         return elf_problems(binary)
-    # Mach-O, thin or universal. Windows PE imports name a DLL without a
-    # directory, so there is no build-host path for them to carry.
-    if magic in {b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe", b"\xbe\xba\xfe\xca"}:
+    # Mach-O, thin or universal. otool reads every slice of a universal binary,
+    # whose header is big-endian on disk. Windows PE imports name a DLL without
+    # a directory, so there is no build-host path for them to carry.
+    if magic in MACHO_MAGICS:
         return macho_problems(binary)
     return []
 

--- a/.mise/tasks/verify-native-package
+++ b/.mise/tasks/verify-native-package
@@ -31,10 +31,10 @@ MACHO_ALLOWED_PREFIXES = (
     "/usr/lib/",
     "/System/Library/",
 )
-# Run paths carry no absolute component, so the bundle stays relocatable.
-MACHO_ALLOWED_RUN_PATHS = ("@loader_path", "@executable_path")
-# ELF search paths resolve against the loading object for the same reason.
-ELF_ALLOWED_SEARCH_PATH_PREFIXES = ("$ORIGIN", "${ORIGIN}")
+# Search paths anchor to the loading binary, either exactly or as the root of a
+# relative path, so the bundle stays relocatable.
+MACHO_SEARCH_PATH_ROOTS = ("@loader_path", "@executable_path")
+ELF_SEARCH_PATH_ROOTS = ("$ORIGIN", "${ORIGIN}")
 
 MACHO_NAME = re.compile(r"^\s*name (?P<name>\S+) \(offset \d+\)$")
 MACHO_PATH = re.compile(r"^\s*path (?P<path>\S+) \(offset \d+\)$")
@@ -49,6 +49,11 @@ def run(command: list[str]) -> str:
             f"{command[0]} failed for {command[-1]}:\n{result.stderr.strip()}"
         )
     return result.stdout
+
+
+def anchored(path: str, roots: tuple[str, ...]) -> bool:
+    """Whether a search path resolves against the binary that loads it."""
+    return any(path == root or path.startswith(f"{root}/") for root in roots)
 
 
 def macho_problems(binary: pathlib.Path) -> list[str]:
@@ -68,7 +73,7 @@ def macho_problems(binary: pathlib.Path) -> list[str]:
                 problems.append(f"{command} {name.group('name')}")
         elif command == "LC_RPATH":
             path = MACHO_PATH.match(line)
-            if path and path.group("path") not in MACHO_ALLOWED_RUN_PATHS:
+            if path and not anchored(path.group("path"), MACHO_SEARCH_PATH_ROOTS):
                 problems.append(f"LC_RPATH {path.group('path')}")
     return problems
 
@@ -89,7 +94,7 @@ def elf_problems(binary: pathlib.Path) -> list[str]:
             problems.extend(
                 f"DT_{tag} {entry}"
                 for entry in value.split(":")
-                if entry and not entry.startswith(ELF_ALLOWED_SEARCH_PATH_PREFIXES)
+                if entry and not anchored(entry, ELF_SEARCH_PATH_ROOTS)
             )
     return problems
 

--- a/.mise/tasks/verify-native-package
+++ b/.mise/tasks/verify-native-package
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# MISE description="Reject build-host paths in a packaged native artifact."
+# USAGE arg "<preset>" help="Native CMake preset"
+
+"""Check that a packaged shared library only names portable dependencies.
+
+A dependency recorded by absolute path resolves against the build host's
+layout, so an artifact carrying one loads on the machine that produced it and
+nowhere else. Package managers make this easy to get wrong: Homebrew's Vulkan
+loader, for one, has an absolute install name, and linking it is enough to
+stamp `/opt/homebrew/opt/...` into the result.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+
+# Load commands may name the system libraries every macOS host has at a fixed
+# location, or resolve relative to the loading binary.
+MACHO_ALLOWED_PREFIXES = (
+    "@rpath/",
+    "@loader_path/",
+    "@executable_path/",
+    "/usr/lib/",
+    "/System/Library/",
+)
+# Run paths carry no absolute component, so the bundle stays relocatable.
+MACHO_ALLOWED_RUN_PATHS = ("@loader_path", "@executable_path")
+# ELF search paths resolve against the loading object for the same reason.
+ELF_ALLOWED_SEARCH_PATH_PREFIXES = ("$ORIGIN", "${ORIGIN}")
+
+MACHO_NAME = re.compile(r"^\s*name (?P<name>\S+) \(offset \d+\)$")
+MACHO_PATH = re.compile(r"^\s*path (?P<path>\S+) \(offset \d+\)$")
+MACHO_COMMAND = re.compile(r"^\s*cmd (?P<command>LC_\w+)$")
+ELF_ENTRY = re.compile(r"^\s*0x[0-9a-f]+\s+\((?P<tag>\w+)\)\s+.*\[(?P<value>[^\]]*)\]")
+
+
+def run(command: list[str]) -> str:
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise SystemExit(
+            f"{command[0]} failed for {command[-1]}:\n{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def macho_problems(binary: pathlib.Path) -> list[str]:
+    """Dependencies and run paths from the Mach-O load commands."""
+    problems = []
+    command = ""
+    for line in run(["otool", "-l", str(binary)]).splitlines():
+        match = MACHO_COMMAND.match(line)
+        if match:
+            command = match.group("command")
+            continue
+        if command.endswith("_DYLIB"):
+            name = MACHO_NAME.match(line)
+            # LC_ID_DYLIB names the library itself, which install_name_dir
+            # already pins to @rpath, so it goes through the same check.
+            if name and not name.group("name").startswith(MACHO_ALLOWED_PREFIXES):
+                problems.append(f"{command} {name.group('name')}")
+        elif command == "LC_RPATH":
+            path = MACHO_PATH.match(line)
+            if path and path.group("path") not in MACHO_ALLOWED_RUN_PATHS:
+                problems.append(f"LC_RPATH {path.group('path')}")
+    return problems
+
+
+def elf_problems(binary: pathlib.Path) -> list[str]:
+    """Needed libraries and search paths from the ELF dynamic section."""
+    problems = []
+    for line in run(["readelf", "--dynamic", "--wide", str(binary)]).splitlines():
+        match = ELF_ENTRY.match(line)
+        if not match:
+            continue
+        tag, value = match.group("tag"), match.group("value")
+        # A needed library is a soname the dynamic loader resolves through the
+        # host's own search path; one carrying a directory bypasses it.
+        if tag == "NEEDED" and "/" in value:
+            problems.append(f"DT_NEEDED {value}")
+        elif tag in {"RPATH", "RUNPATH"}:
+            problems.extend(
+                f"DT_{tag} {entry}"
+                for entry in value.split(":")
+                if entry and not entry.startswith(ELF_ALLOWED_SEARCH_PATH_PREFIXES)
+            )
+    return problems
+
+
+def binary_problems(binary: pathlib.Path) -> list[str]:
+    with binary.open("rb") as file:
+        magic = file.read(4)
+    if magic == b"\x7fELF":
+        return elf_problems(binary)
+    # Mach-O, thin or universal. Windows PE imports name a DLL without a
+    # directory, so there is no build-host path for them to carry.
+    if magic in {b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe", b"\xbe\xba\xfe\xca"}:
+        return macho_problems(binary)
+    return []
+
+
+def main() -> int:
+    preset = os.environ["usage_preset"]
+    root = pathlib.Path(os.environ["MISE_MONOREPO_ROOT"])
+    archive = root / "build/packages/native/dist" / f"maplibre-native-c-{preset}.tar.gz"
+    if not archive.is_file():
+        print(f"error: native package does not exist: {archive}", file=sys.stderr)
+        return 1
+
+    problems = {}
+    with tempfile.TemporaryDirectory() as directory:
+        with tarfile.open(archive) as tar:
+            tar.extractall(directory, filter="data")
+        for binary in sorted(pathlib.Path(directory).rglob("*")):
+            if not binary.is_file() or binary.suffix in {".a", ".lib"}:
+                continue
+            found = binary_problems(binary)
+            if found:
+                problems[binary.name] = found
+
+    if not problems:
+        return 0
+    for name, found in problems.items():
+        for problem in found:
+            print(
+                f"error: {name} depends on a build-host path: {problem}",
+                file=sys.stderr,
+            )
+    print(
+        f"\n{archive.name} only loads on hosts that reproduce the paths above. "
+        "Resolve the dependency at runtime, or give it a relocatable install "
+        "name and ship it in the package.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cmake/mln_tests.cmake
+++ b/cmake/mln_tests.cmake
@@ -8,11 +8,18 @@ function(mln_add_c_api_test)
                       MLN_FFI_RUNTIME_DIRS)
   get_target_property(dependency_include_dirs mln_ffi_render_dependencies
                       MLN_FFI_INCLUDE_DIRS)
+  # Libraries the harness links for the graphics API it drives itself, which the
+  # C API resolves at runtime rather than linking.
+  get_target_property(dependency_test_libraries mln_ffi_render_dependencies
+                      MLN_FFI_TEST_LINK_LIBRARIES)
   if("${dependency_runtime_dirs}" MATCHES "-NOTFOUND$")
     set(dependency_runtime_dirs "")
   endif()
   if("${dependency_include_dirs}" MATCHES "-NOTFOUND$")
     set(dependency_include_dirs "")
+  endif()
+  if("${dependency_test_libraries}" MATCHES "-NOTFOUND$")
+    set(dependency_test_libraries "")
   endif()
 
   include(FetchContent)
@@ -79,7 +86,9 @@ function(mln_add_c_api_test)
     PROPERTIES C_STANDARD 23 C_STANDARD_REQUIRED YES C_EXTENSIONS OFF)
   target_link_libraries(
     mln_c_api_tests
-    PRIVATE maplibre_native_c unity::framework MLN_FFI::RenderDependencies)
+    PRIVATE
+      maplibre_native_c unity::framework MLN_FFI::RenderDependencies
+      ${dependency_test_libraries})
   target_include_directories(
     mln_c_api_tests
     PRIVATE ${PROJECT_SOURCE_DIR}/src/c_api/tests ${dependency_include_dirs})

--- a/cmake/render/vulkan.cmake
+++ b/cmake/render/vulkan.cmake
@@ -12,6 +12,9 @@ function(mln_configure_render_dependencies target)
      OR CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$")
     set(MLN_FFI_VULKAN_LIBRARY_SUFFIXES Lib/arm64 Lib Lib32)
   endif()
+  # The loader belongs to the test harness, which drives Vulkan directly the way
+  # a host does. The library resolves it at runtime, so build-host loader paths
+  # stay out of the shipped binary.
   find_library(
     MLN_FFI_VULKAN_LOADER_LIBRARY
     NAMES vulkan vulkan-1 vulkan.1
@@ -21,7 +24,9 @@ function(mln_configure_render_dependencies target)
   set_target_properties(
     mln_ffi_vulkan_loader
     PROPERTIES IMPORTED_LOCATION "${MLN_FFI_VULKAN_LOADER_LIBRARY}")
-  target_link_libraries(${target} INTERFACE mln_ffi_vulkan_loader)
+  set_property(
+    TARGET ${target}
+    PROPERTY MLN_FFI_TEST_LINK_LIBRARIES mln_ffi_vulkan_loader)
 
   get_filename_component(
     MLN_FFI_VULKAN_LOADER_DIR "${MLN_FFI_VULKAN_LOADER_LIBRARY}"
@@ -76,6 +81,7 @@ function(mln_configure_renderer target)
   set(MLN_FFI_VENDOR_VULKAN_SOURCES
       ${MLN_SOURCE_DIR}/platform/default/src/mbgl/vulkan/headless_backend.cpp)
   set(MLN_FFI_VULKAN_SOURCES
+      ${PROJECT_SOURCE_DIR}/src/render/vulkan/vulkan_dispatch.cpp
       ${PROJECT_SOURCE_DIR}/src/render/vulkan/vulkan_texture_session.cpp
       ${PROJECT_SOURCE_DIR}/src/render/vulkan/vulkan_texture_backend.cpp
       ${PROJECT_SOURCE_DIR}/src/render/vulkan/vulkan_surface_session.cpp)

--- a/mise.toml
+++ b/mise.toml
@@ -156,7 +156,10 @@ run = [{ task = "//:archive-native", args = ["{{usage.preset}}"] }]
 [tasks.archive-native]
 description = "Archive an already-built native CMake preset."
 usage = 'arg "<preset>"'
-run = 'cpack --preset "$usage_preset"'
+run = [
+  'cpack --preset "$usage_preset"',
+  { task = "//:verify-native-package", args = ["{{usage.preset}}"] },
+]
 
 [tasks.test]
 description = "Build and run C API tests for a CMake preset."

--- a/src/render/vulkan/vulkan_dispatch.cpp
+++ b/src/render/vulkan/vulkan_dispatch.cpp
@@ -1,0 +1,26 @@
+// The dispatch header sets the vulkan.hpp configuration this translation unit
+// has to agree on, so it stays the first include.
+#include "render/vulkan/vulkan_dispatch.hpp"
+
+namespace mln::core {
+
+auto vulkan_system_get_instance_proc_addr() noexcept
+  -> PFN_vkGetInstanceProcAddr {
+  // The loader stays mapped for the process lifetime, so the pointer is
+  // resolved once and cached.
+  static PFN_vkGetInstanceProcAddr get_instance_proc_addr =
+    []() noexcept -> PFN_vkGetInstanceProcAddr {
+    try {
+      // MapLibre Native reaches the loader through this same search order.
+      static const vk::detail::DynamicLoader loader;
+      return loader.getProcAddress<PFN_vkGetInstanceProcAddr>(
+        "vkGetInstanceProcAddr"
+      );
+    } catch (...) {
+      return nullptr;
+    }
+  }();
+  return get_instance_proc_addr;
+}
+
+}  // namespace mln::core

--- a/src/render/vulkan/vulkan_dispatch.hpp
+++ b/src/render/vulkan/vulkan_dispatch.hpp
@@ -18,6 +18,12 @@
 
 namespace mln::core {
 
+// Resolves vkGetInstanceProcAddr from a Vulkan loader mapped on first use, or
+// null when the host has no loader. Resolving at runtime keeps build-host
+// loader paths out of the shipped library.
+auto vulkan_system_get_instance_proc_addr() noexcept
+  -> PFN_vkGetInstanceProcAddr;
+
 inline auto vulkan_get_instance_proc_addr(
   const mln_vulkan_context_descriptor& context
 ) noexcept -> PFN_vkGetInstanceProcAddr {
@@ -28,7 +34,7 @@ inline auto vulkan_get_instance_proc_addr(
       context.get_instance_proc_addr
     );
   }
-  return ::vkGetInstanceProcAddr;
+  return vulkan_system_get_instance_proc_addr();
 }
 
 inline auto vulkan_get_device_proc_addr(
@@ -47,13 +53,22 @@ inline auto vulkan_get_device_proc_addr(
 inline auto vulkan_dispatch_loader(
   const mln_vulkan_context_descriptor& context
 ) noexcept -> mbgl::vulkan::DispatchLoaderDynamic {
-  return {vulkan_get_instance_proc_addr(context)};
+  const auto get_instance_proc_addr = vulkan_get_instance_proc_addr(context);
+  if (get_instance_proc_addr == nullptr) {
+    // Every dispatch entry stays null so callers report an unresolved loader
+    // instead of dispatching through a null bootstrap pointer.
+    return {};
+  }
+  return {get_instance_proc_addr};
 }
 
 inline auto vulkan_init_instance_dispatch(
   mbgl::vulkan::DispatchLoaderDynamic& dispatcher,
   const mln_vulkan_context_descriptor& context
 ) noexcept -> void {
+  if (dispatcher.vkGetInstanceProcAddr == nullptr) {
+    return;
+  }
   dispatcher.init(vk::Instance(static_cast<VkInstance>(context.instance)));
 }
 


### PR DESCRIPTION
## Summary

The C API linked the Vulkan loader for a single symbol, `vkGetInstanceProcAddr`, which baked the build host's loader path into the artifact — the published macOS ARM64 Vulkan dylib named `/opt/homebrew/opt/vulkan-loader/lib/libvulkan.1.dylib`; it now resolves that bootstrap at runtime and packaging fails on any load command that only resolves on the build host.

## Test plan

`mise run test` and `//examples/zig-readback:run` on `macos-arm64-vulkan` still render, `otool -L` on the packaged dylib shows no Homebrew path, and `macos-arm64-metal`/`macos-arm64-egl` confirm the CMake change is inert for other backends.

## AI assistance

- **Tools:** Claude Code
- **Context:** Reproduced #333 locally, then used Claude Code to trace the single
  imported symbol to `vulkan_dispatch.hpp` and draft the runtime resolution and
  packaging check.

Fixes #333