### PR TITLE
Harden CI against ARM64 process-spawn flakes

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -307,9 +307,23 @@ runs:
 
     # The mise action may restore Rust install metadata without the rustup
     # toolchain, components, or cross targets declared in mise.toml.
+    #
+    # `--force` uninstalls the toolchain before it reinstalls one, so a single
+    # transient failure leaves the runner with no Rust at all and fails the job.
+    # ARM64 runners kill freshly spawned processes often enough to hit this:
+    # rustup has died by signal milliseconds after exec, having written nothing.
+    # Retry so the second attempt restores what the first one removed.
     - name: Repair cached Rust toolchain
       shell: bash
-      run: MISE_NO_HOOKS=1 mise install --force rust
+      run: |
+        for attempt in 1 2 3; do
+          if MISE_NO_HOOKS=1 mise install --force rust; then
+            exit 0
+          fi
+          echo "::warning::mise install --force rust failed (attempt ${attempt}/3)"
+          sleep $((attempt * 5))
+        done
+        exit 1
 
     # Project tools live in each project's config, so the root install covers
     # only the repository-wide set. Installing the rest lazily would leave every

--- a/.mise/bin/windows-msvc-env.sh
+++ b/.mise/bin/windows-msvc-env.sh
@@ -93,7 +93,8 @@ vs_version="$(vs_query installationVersion)"
 cache_key="${vs_install//[^A-Za-z0-9]/_}-${vs_version//[^A-Za-z0-9]/_}-${msvc_arch}"
 cache_file="${TMPDIR:-/tmp}/mln-msvc-env-${cache_key}.sh"
 
-msvc_path=
+vs_path_prefix=
+vs_path_suffix=
 crt_path=
 cache_complete=
 if [[ -r "$cache_file" ]]; then
@@ -153,16 +154,30 @@ EOF
   # cmd.exe inherited this shell's PATH, so its Path is those entries plus
   # VsDevCmd's. Keep the additions for the same reason the variables above are
   # filtered: the inherited half belongs to the shell that generated the cache,
-  # and prepending its copy here would let stale entries win. The tail of PATH
-  # below supplies each sourcing shell's own entries.
+  # and prepending its copy here would let stale entries win.
+  #
+  # VsDevCmd both prepends and appends, and which side an entry landed on is the
+  # whole of its precedence. Visual Studio appends its own CMake, which has to
+  # keep losing to the one mise puts on PATH; hoisting every addition in front
+  # of the inherited entries hands the build a different CMake than the pinned
+  # one. Split the additions at the first inherited entry and restore each side
+  # around the sourcing shell's own PATH.
   inherited_path=":$PATH:"
-  vs_path=
+  vs_path_prefix=
+  vs_path_suffix=
+  seen_inherited=0
   while IFS= read -r entry; do
     [[ -n "$entry" ]] || continue
-    [[ "$inherited_path" == *":$entry:"* ]] && continue
-    vs_path="${vs_path:+$vs_path:}$entry"
+    if [[ "$inherited_path" == *":$entry:"* ]]; then
+      seen_inherited=1
+      continue
+    fi
+    if ((seen_inherited)); then
+      vs_path_suffix="${vs_path_suffix:+$vs_path_suffix:}$entry"
+    else
+      vs_path_prefix="${vs_path_prefix:+$vs_path_prefix:}$entry"
+    fi
   done < <(tr ':' '\n' <<< "$msvc_path")
-  msvc_path="$vs_path"
 
   redist_root="$(cygpath -u "${vs_install}\\VC\\Redist\\MSVC")"
   crt_path="$(find "$redist_root" -path "*/${msvc_arch}/Microsoft.VC143.CRT/msvcp140_codecvt_ids.dll" -print 2>/dev/null | sort -r | sed -n '1p')"
@@ -173,7 +188,8 @@ EOF
   # Publish through a rename so a concurrent shell sees either no entry or a
   # complete one. Writing the cache is best effort: a failure here costs the
   # next shell a rebuild, which is what it would have paid anyway.
-  cache_body+="msvc_path=$(printf '%q' "$msvc_path")"$'\n'
+  cache_body+="vs_path_prefix=$(printf '%q' "$vs_path_prefix")"$'\n'
+  cache_body+="vs_path_suffix=$(printf '%q' "$vs_path_suffix")"$'\n'
   cache_body+="crt_path=$(printf '%q' "$crt_path")"$'\n'
   cache_body+="cache_complete=1"$'\n'
   if cache_staging="$(mktemp "${cache_file}.XXXXXX" 2>/dev/null)"; then
@@ -184,4 +200,4 @@ EOF
   fi
 fi
 
-export PATH="${crt_path:+$crt_path:}$standalone_llvm_bin:${msvc_path:+$msvc_path:}$original_path"
+export PATH="${crt_path:+$crt_path:}$standalone_llvm_bin:${vs_path_prefix:+$vs_path_prefix:}$original_path${vs_path_suffix:+:$vs_path_suffix}"

--- a/.mise/bin/windows-msvc-env.sh
+++ b/.mise/bin/windows-msvc-env.sh
@@ -59,6 +59,26 @@ if [[ -z "$vs_install" ]]; then
   return 1
 fi
 
+# `set` reports every variable cmd.exe inherited, not just what VsDevCmd added.
+# Replaying an inherited value in a later shell is what makes it wrong: a GitHub
+# Actions step's $GITHUB_ENV names a file the runner consumes and retires when
+# that step ends, so a second step handed the first one's path writes where
+# nothing reads. Keep the cache to what VsDevCmd itself contributed.
+is_vsdevcmd_contribution() {
+  local name="$1" value="$2"
+  case "$name" in
+    # Per-step or per-shell state VsDevCmd never sets. MSYS2 can rewrite paths
+    # on the way into cmd.exe, so these can differ without VsDevCmd's help.
+    GITHUB_* | RUNNER_* | ACTIONS_* | INPUT_* | \
+      HOME | PWD | OLDPWD | SHLVL | CD | PROMPT | \
+      TMP | TEMP | TMPDIR | BASH_ENV | MSYS* | CYGWIN)
+      return 1
+      ;;
+  esac
+  [[ -z "${!name+set}" ]] && return 0
+  [[ "${!name}" != "$value" ]]
+}
+
 # Every mise task, and on CI every `shell: bash` step, starts a fresh Git Bash
 # that sources this file. Resolving the environment from scratch each time costs
 # a cmd.exe running VsDevCmd.bat plus a walk of the redist tree, which is slow
@@ -75,14 +95,17 @@ cache_file="${TMPDIR:-/tmp}/mln-msvc-env-${cache_key}.sh"
 
 msvc_path=
 crt_path=
+cache_complete=
 if [[ -r "$cache_file" ]]; then
   # shellcheck source=/dev/null
   source "$cache_file"
 fi
 
-# A cache written by a killed shell can be truncated, so treat a missing
-# msvc_path as a miss rather than trusting a partial replay.
-if [[ -z "$msvc_path" ]]; then
+# The cache sets its completion marker last, so a truncated file reads as a miss
+# rather than a partial replay. The resolved values cannot serve as the marker:
+# both are legitimately empty when this shell already has the entries VsDevCmd
+# would add.
+if [[ -z "$cache_complete" ]]; then
   vs_dev_cmd="${vs_install}\\Common7\\Tools\\VsDevCmd.bat"
   loader="$(mktemp "${TMPDIR:-/tmp}/mln-vsdev.XXXXXX.bat")"
   cat > "$loader" <<EOF
@@ -106,10 +129,26 @@ EOF
       Path | PATH) msvc_path="$(cygpath -u -p "$value")" ;;
       *)
         export "$name=$value"
-        cache_body+="export $name=$(printf '%q' "$value")"$'\n'
+        if is_vsdevcmd_contribution "$name" "$value"; then
+          cache_body+="export $name=$(printf '%q' "$value")"$'\n'
+        fi
         ;;
     esac
   done < <(tr -d '\r' <<< "$environment")
+
+  # cmd.exe inherited this shell's PATH, so its Path is those entries plus
+  # VsDevCmd's. Keep the additions for the same reason the variables above are
+  # filtered: the inherited half belongs to the shell that generated the cache,
+  # and prepending its copy here would let stale entries win. The tail of PATH
+  # below supplies each sourcing shell's own entries.
+  inherited_path=":$PATH:"
+  vs_path=
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    [[ "$inherited_path" == *":$entry:"* ]] && continue
+    vs_path="${vs_path:+$vs_path:}$entry"
+  done < <(tr ':' '\n' <<< "$msvc_path")
+  msvc_path="$vs_path"
 
   redist_root="$(cygpath -u "${vs_install}\\VC\\Redist\\MSVC")"
   crt_path="$(find "$redist_root" -path "*/${msvc_arch}/Microsoft.VC143.CRT/msvcp140_codecvt_ids.dll" -print 2>/dev/null | sort -r | sed -n '1p')"
@@ -122,6 +161,7 @@ EOF
   # next shell a rebuild, which is what it would have paid anyway.
   cache_body+="msvc_path=$(printf '%q' "$msvc_path")"$'\n'
   cache_body+="crt_path=$(printf '%q' "$crt_path")"$'\n'
+  cache_body+="cache_complete=1"$'\n'
   if cache_staging="$(mktemp "${cache_file}.XXXXXX" 2>/dev/null)"; then
     if ! { printf '%s' "$cache_body" > "$cache_staging" &&
       mv -f "$cache_staging" "$cache_file"; }; then

--- a/.mise/bin/windows-msvc-env.sh
+++ b/.mise/bin/windows-msvc-env.sh
@@ -108,9 +108,13 @@ fi
 if [[ -z "$cache_complete" ]]; then
   vs_dev_cmd="${vs_install}\\Common7\\Tools\\VsDevCmd.bat"
   loader="$(mktemp "${TMPDIR:-/tmp}/mln-vsdev.XXXXXX.bat")"
+  # `set` is what cmd.exe reports the status of, so a failed call has to stop the
+  # script before it runs. Without this a half-initialized environment reads as
+  # success, and now that the result is cached it would be replayed all job.
   cat > "$loader" <<EOF
 @echo off
 call "$vs_dev_cmd" -arch=$msvc_arch -host_arch=$msvc_arch >nul
+if errorlevel 1 exit /b 1
 set
 EOF
 
@@ -128,13 +132,23 @@ EOF
     case "$name" in
       Path | PATH) msvc_path="$(cygpath -u -p "$value")" ;;
       *)
-        export "$name=$value"
+        # Compare before exporting: the test reads the variable's current value,
+        # which an export on this line would have already overwritten.
         if is_vsdevcmd_contribution "$name" "$value"; then
           cache_body+="export $name=$(printf '%q' "$value")"$'\n'
         fi
+        export "$name=$value"
         ;;
     esac
   done < <(tr -d '\r' <<< "$environment")
+
+  # clang-cl locates MSVC, and derives the _MSC_VER that decides which language
+  # dialects CMake will offer, from these. Refuse to publish an entry without
+  # them rather than hand every later shell a toolchain it cannot find.
+  if [[ -z "${VCToolsInstallDir:-}" || -z "${INCLUDE:-}" ]]; then
+    echo "VsDevCmd.bat did not set VCToolsInstallDir and INCLUDE" >&2
+    return 1
+  fi
 
   # cmd.exe inherited this shell's PATH, so its Path is those entries plus
   # VsDevCmd's. Keep the additions for the same reason the variables above are

--- a/.mise/bin/windows-msvc-env.sh
+++ b/.mise/bin/windows-msvc-env.sh
@@ -47,42 +47,87 @@ if [[ ! -x "$vswhere" ]]; then
   return 1
 fi
 
-vs_install="$("$vswhere" -latest -version '[17.0,18.0)' -products '*' \
-  -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
-  -property installationPath | tr -d '\r' | sed -n '1p')"
+vs_query() {
+  "$vswhere" -latest -version '[17.0,18.0)' -products '*' \
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
+    -property "$1" | tr -d '\r' | sed -n '1p'
+}
+
+vs_install="$(vs_query installationPath)"
 if [[ -z "$vs_install" ]]; then
   echo "Visual Studio 2022 with the Desktop development with C++ workload was not found" >&2
   return 1
 fi
 
-vs_dev_cmd="${vs_install}\\Common7\\Tools\\VsDevCmd.bat"
-loader="$(mktemp "${TMPDIR:-/tmp}/mln-vsdev.XXXXXX.bat")"
-cat > "$loader" <<EOF
+# Every mise task, and on CI every `shell: bash` step, starts a fresh Git Bash
+# that sources this file. Resolving the environment from scratch each time costs
+# a cmd.exe running VsDevCmd.bat plus a walk of the redist tree, which is slow
+# everywhere and is the dominant source of process creation on Windows ARM64,
+# where the MSYS2 runtime crashes under that churn. Resolving it once per
+# toolchain and replaying the result keeps later shells to one vswhere pair.
+#
+# The key covers everything the cached values derive from: the install path, the
+# installed version, and the target architecture. An in-place Visual Studio
+# update changes the version and so retires the entry.
+vs_version="$(vs_query installationVersion)"
+cache_key="${vs_install//[^A-Za-z0-9]/_}-${vs_version//[^A-Za-z0-9]/_}-${msvc_arch}"
+cache_file="${TMPDIR:-/tmp}/mln-msvc-env-${cache_key}.sh"
+
+msvc_path=
+crt_path=
+if [[ -r "$cache_file" ]]; then
+  # shellcheck source=/dev/null
+  source "$cache_file"
+fi
+
+# A cache written by a killed shell can be truncated, so treat a missing
+# msvc_path as a miss rather than trusting a partial replay.
+if [[ -z "$msvc_path" ]]; then
+  vs_dev_cmd="${vs_install}\\Common7\\Tools\\VsDevCmd.bat"
+  loader="$(mktemp "${TMPDIR:-/tmp}/mln-vsdev.XXXXXX.bat")"
+  cat > "$loader" <<EOF
 @echo off
 call "$vs_dev_cmd" -arch=$msvc_arch -host_arch=$msvc_arch >nul
 set
 EOF
 
-loader_windows="$(cygpath -w "$loader")"
-if ! environment="$(cmd.exe //d //s //c "$loader_windows")"; then
+  loader_windows="$(cygpath -w "$loader")"
+  if ! environment="$(cmd.exe //d //s //c "$loader_windows")"; then
+    rm -f "$loader"
+    echo "VsDevCmd.bat failed to initialize the Visual Studio environment" >&2
+    return 1
+  fi
   rm -f "$loader"
-  echo "VsDevCmd.bat failed to initialize the Visual Studio environment" >&2
-  return 1
-fi
-rm -f "$loader"
 
-while IFS='=' read -r name value; do
-  [[ "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-  case "$name" in
-    Path | PATH) msvc_path="$(cygpath -u -p "$value")" ;;
-    *) export "$name=$value" ;;
-  esac
-done < <(tr -d '\r' <<< "$environment")
+  cache_body=
+  while IFS='=' read -r name value; do
+    [[ "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    case "$name" in
+      Path | PATH) msvc_path="$(cygpath -u -p "$value")" ;;
+      *)
+        export "$name=$value"
+        cache_body+="export $name=$(printf '%q' "$value")"$'\n'
+        ;;
+    esac
+  done < <(tr -d '\r' <<< "$environment")
 
-redist_root="$(cygpath -u "${vs_install}\\VC\\Redist\\MSVC")"
-crt_path="$(find "$redist_root" -path "*/${msvc_arch}/Microsoft.VC143.CRT/msvcp140_codecvt_ids.dll" -print 2>/dev/null | sort -r | sed -n '1p')"
-if [[ -n "$crt_path" ]]; then
-  crt_path="$(dirname "$crt_path")"
+  redist_root="$(cygpath -u "${vs_install}\\VC\\Redist\\MSVC")"
+  crt_path="$(find "$redist_root" -path "*/${msvc_arch}/Microsoft.VC143.CRT/msvcp140_codecvt_ids.dll" -print 2>/dev/null | sort -r | sed -n '1p')"
+  if [[ -n "$crt_path" ]]; then
+    crt_path="$(dirname "$crt_path")"
+  fi
+
+  # Publish through a rename so a concurrent shell sees either no entry or a
+  # complete one. Writing the cache is best effort: a failure here costs the
+  # next shell a rebuild, which is what it would have paid anyway.
+  cache_body+="msvc_path=$(printf '%q' "$msvc_path")"$'\n'
+  cache_body+="crt_path=$(printf '%q' "$crt_path")"$'\n'
+  if cache_staging="$(mktemp "${cache_file}.XXXXXX" 2>/dev/null)"; then
+    if ! { printf '%s' "$cache_body" > "$cache_staging" &&
+      mv -f "$cache_staging" "$cache_file"; }; then
+      rm -f "$cache_staging"
+    fi
+  fi
 fi
 
 export PATH="${crt_path:+$crt_path:}$standalone_llvm_bin:${msvc_path:+$msvc_path:}$original_path"

--- a/mise.windows.toml
+++ b/mise.windows.toml
@@ -4,5 +4,6 @@ host_native_preset = "windows-{{ arch() }}-vulkan"
 [env]
 # Mise tasks use non-interactive Git Bash on Windows. Source VsDevCmd before each
 # task because mise cannot activate Visual Studio's batch environment directly.
+# The script caches the resolved environment so only the first shell pays for it.
 MLN_FFI_WINDOWS_HOST_ARCHITECTURE = "{{ arch() }}"
 BASH_ENV = "{{config_root}}/.mise/bin/windows-msvc-env.sh"


### PR DESCRIPTION
## Summary

Cache the resolved MSVC environment so `windows-msvc-env.sh` stops re-running
`VsDevCmd.bat` in every Git Bash that sources it, and retry the Rust toolchain
repair, whose `--force` uninstall otherwise leaves a runner with no toolchain
when a spawn dies.

## Test plan

CI; the MSVC environment script was linted with shellcheck and its cache
round-trip covered locally against VsDevCmd-shaped values.

## AI assistance

- **Tools:** Claude Code
- **Context:** Investigated two ARM64-only CI flakes (`rustup` killed by signal
  on `macos-26`, `bash.exe` crashing with `0xC0000005` / `0x80000004` on
  `windows-11-arm`) across the 41 most recent CI runs, then wrote these
  mitigations.
