### PR TITLE
Drain an autorelease pool at the C boundary on Apple targets

### DIFF
--- a/bindings/rust/crates/maplibre-native/src/render/tests.rs
+++ b/bindings/rust/crates/maplibre-native/src/render/tests.rs
@@ -2046,6 +2046,58 @@ fn feature_extension_queries_copy_value_and_feature_collection_results() {
     runtime.close().unwrap();
 }
 
+/// A host frame loop renders far more frames than a graphics queue keeps in
+/// flight at once. On Apple targets each frame takes objects that a pool owns
+/// until it drains, and Metal blocks a queue that reaches its in-flight command
+/// buffer limit, so a library that leaves draining to the host wedges partway
+/// through a loop like this one.
+#[test]
+fn sustained_render_loop_outlasts_the_graphics_queue_depth() {
+    if !has_test_owned_texture_session_backend() {
+        return;
+    }
+    let runtime = RuntimeHandle::with_options(&crate::RuntimeOptions::default()).unwrap();
+    let map = MapHandle::with_options(&runtime, &MapOptions::new(64, 64, 1.0)).unwrap();
+    let (_context, session) =
+        create_owned_texture_session(&map, RenderTargetExtent::new(64, 64, 1.0))
+            .expect("Metal or Vulkan owned texture test session should attach when supported");
+    // A background-only style keeps each frame to the passes that take command
+    // buffers, without the tile work that would make the loop slow.
+    map.set_style_json(CLUSTER_BASE_STYLE_JSON).unwrap();
+    render_available_updates(&runtime, &session, 3);
+
+    // Metal allows 64 command buffers in flight per queue, and a frame takes
+    // several, so this many frames clears that limit many times over. Each
+    // camera change gives the next frame something to draw.
+    const TARGET_FRAMES: u32 = 256;
+    let mut rendered_frames = 0;
+    let mut step = 0;
+    while rendered_frames < TARGET_FRAMES && step < 200 {
+        let mut camera = CameraOptions::default();
+        camera.center = Some(LatLng::new(37.0, -122.0));
+        camera.zoom = Some(10.0 + f64::from(step % 8) * 0.25);
+        map.jump_to(&camera).unwrap();
+        let _ = runtime.run_once();
+        while let Ok(Some(event)) = runtime.poll_event() {
+            if event.event_type == RuntimeEventType::MapRenderUpdateAvailable
+                && session.render_update().unwrap()
+            {
+                rendered_frames += 1;
+            }
+        }
+        step += 1;
+    }
+
+    assert!(
+        rendered_frames >= TARGET_FRAMES,
+        "the loop rendered {rendered_frames} frames before running out of steps"
+    );
+
+    session.close().unwrap();
+    map.close().unwrap();
+    runtime.close().unwrap();
+}
+
 #[test]
 // Spec coverage: BND-163.
 fn owned_texture_session_retains_parent_and_enforces_single_session() {

--- a/cmake/mln_target.cmake
+++ b/cmake/mln_target.cmake
@@ -232,6 +232,14 @@ function(mln_configure_c_api_implementation target)
       ${PROJECT_SOURCE_DIR}/src/style/style_value.cpp
       ${PROJECT_SOURCE_DIR}/src/runtime/runtime.cpp)
 
+  # Every Apple target needs the pool, not just the Metal backend: MoltenVK and
+  # the platform frameworks hand back autoreleased objects under Vulkan and
+  # OpenGL too.
+  if(APPLE)
+    list(APPEND MLN_FFI_C_API_SOURCES
+         ${PROJECT_SOURCE_DIR}/src/c_api/autorelease_pool.mm)
+  endif()
+
   mln_target_project_sources(${target} ${MLN_FFI_C_API_SOURCES})
 
   target_include_directories(

--- a/docs/src/content/docs/development/c-conventions.md
+++ b/docs/src/content/docs/development/c-conventions.md
@@ -83,6 +83,11 @@ Cross-thread dispatch belongs in public functions designed as enqueueing
 commands. Document that behavior on the function. Higher-level adapters build
 threaded models above the C API.
 
+On Apple targets each entry point drains its own Objective-C autorelease pool,
+so a host may pump frames from a thread that never returns to a run loop.
+Objects that cross the C boundary are retained rather than autoreleased, which
+keeps them valid after the entry point that produced them returns.
+
 MapLibre's `RunLoop` is owner-thread scheduler state. Each owner thread may hold
 one live runtime. `mln_runtime_run_once()` pumps that runtime's run loop. One
 call drains the queued tasks, expired timers, and ready I/O it finds, including

--- a/src/c_api/autorelease_pool.hpp
+++ b/src/c_api/autorelease_pool.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "maplibre_native_c.h"
+
+namespace mln::c_api {
+
+#if defined(__APPLE__)
+
+// Implemented in Objective-C++ because `@autoreleasepool` is the only pool
+// construct available under ARC. The body crosses as a plain function pointer
+// so C++ translation units can drain a pool without being Objective-C++
+// themselves.
+auto run_in_autorelease_pool(void* context, mln_status (*body)(void*))
+  -> mln_status;
+
+// Apple frameworks return autoreleased objects, and a host frame loop that
+// never returns to a run loop has no pool to drain them. Metal in particular
+// caps the command buffers a queue may have in flight and frees a slot only
+// once a buffer is deallocated, so an undrained pool blocks the next frame
+// forever. Draining one pool per call keeps that bounded no matter how the
+// host drives the library.
+//
+// Objects that cross the C boundary are retained rather than autoreleased, so
+// draining here cannot outlive a value the caller still holds.
+template <typename Function>
+auto with_autorelease_pool(Function& function) -> mln_status {
+  return run_in_autorelease_pool(&function, [](void* context) -> mln_status {
+    return (*static_cast<Function*>(context))();
+  });
+}
+
+#else
+
+template <typename Function>
+auto with_autorelease_pool(Function& function) -> mln_status {
+  return function();
+}
+
+#endif
+
+}  // namespace mln::c_api

--- a/src/c_api/autorelease_pool.mm
+++ b/src/c_api/autorelease_pool.mm
@@ -1,0 +1,14 @@
+#include "c_api/autorelease_pool.hpp"
+
+namespace mln::c_api {
+
+// An exception thrown by the body unwinds through the pool, which drains as
+// part of the cleanup before `status_boundary` catches it.
+auto run_in_autorelease_pool(void* context, mln_status (*body)(void*))
+  -> mln_status {
+  @autoreleasepool {
+    return body(context);
+  }
+}
+
+}  // namespace mln::c_api

--- a/src/c_api/boundary.hpp
+++ b/src/c_api/boundary.hpp
@@ -2,6 +2,7 @@
 
 #include <exception>
 
+#include "c_api/autorelease_pool.hpp"
 #include "diagnostics/diagnostics.hpp"
 #include "maplibre_native_c.h"
 
@@ -11,7 +12,7 @@ template <typename Function>
 auto status_boundary(Function function) noexcept -> mln_status {
   mln::core::clear_thread_error();
   try {
-    return function();
+    return with_autorelease_pool(function);
   } catch (const std::exception& exception) {
     mln::core::set_thread_error(exception);
     return MLN_STATUS_NATIVE_ERROR;


### PR DESCRIPTION
## Summary

Apple entry points now drain their own autorelease pool, so a host frame loop that never reaches a run loop cannot exhaust Metal's in-flight command buffer limit and block forever mid-render.

## Test plan

`mise run test macos-arm64-metal` and `mise run //bindings/rust:test macos-arm64-metal`, plus a new render-loop regression test that wedges without this change.

## AI assistance

- **Tools:** Claude Code
- **Context:** Diagnosed a wedged CI job down to the blocked `commandBuffer` stack, then implemented the pool and regression test.