### PR TITLE
Accept mise x64 in the MSVC environment setup

### DIFF
--- a/.mise/bin/windows-msvc-env.sh
+++ b/.mise/bin/windows-msvc-env.sh
@@ -8,7 +8,7 @@ esac
 windows_host_architecture="${MLN_FFI_WINDOWS_HOST_ARCHITECTURE:-$(uname -m)}"
 case "$windows_host_architecture" in
   aarch64 | arm64) msvc_arch=arm64 ;;
-  x86_64 | amd64) msvc_arch=x64 ;;
+  x64 | x86_64 | amd64) msvc_arch=x64 ;;
   *) echo "Unsupported Windows host architecture: $windows_host_architecture" >&2; return 1 ;;
 esac
 


### PR DESCRIPTION
## Summary

Accept mise's `x64` architecture spelling when selecting the x64 MSVC environment so Windows x64 tasks use the cached VsDevCmd setup instead of rejecting `BASH_ENV`.

## Test plan

Ran the targeted formatter and ShellCheck on `.mise/bin/windows-msvc-env.sh`.

## AI assistance

- **Tools:** Codex
- **Context:** Identified the architecture spelling mismatch from Windows CI logs and prepared the one-line fix and draft PR.