### PR TITLE
Skip redundant dependency preparation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run ci:generate-workflow --check
-      - run: mise run ci:generate-devcontainer-tools --check
+      - run: mise run --no-deps ci:generate-workflow --check
+      - run: mise run --no-deps ci:generate-devcontainer-tools --check
       - run: dprint output-resolved-config > /dev/null
-      - run: mise run fix
+      - run: mise run --no-deps fix
       - name: Check generated and formatted files
         run: |
           git update-index -q --refresh
@@ -53,7 +53,7 @@ jobs:
         with:
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run //docs:build
+      - run: mise run --no-deps //docs:build
 
   target-linux-x64-egl:
     name: target / linux-x64-egl
@@ -71,49 +71,56 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test linux-x64-egl
-      - run: mise run check-glibc-floor linux-x64-egl
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test linux-x64-egl
+      - run: mise run --no-deps check-glibc-floor linux-x64-egl
       - name: Archive native artifact
-        run: mise run archive-native linux-x64-egl
+        run: mise run --no-deps archive-native linux-x64-egl
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           linux-x64-egl
           build/packages/native/dist/maplibre-native-c-linux-x64-egl.tar.gz
-      - run: mise run //bindings/rust:test linux-x64-egl
+      - run: mise run --no-deps //bindings/rust:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check linux-x64-egl
+      - run: mise run --no-deps //examples/rust-map:check linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test linux-x64-egl
+      - run: mise run --no-deps //bindings/zig:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build linux-x64-egl
+      - run: mise run --no-deps //examples/zig-map:build linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run linux-x64-egl
+      - run: mise run --no-deps //examples/zig-readback:run linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest linux-x64-egl
+      - run: mise run --no-deps //bindings/kotlin:jvmTest linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build linux-x64-egl
+      - run: mise run --no-deps //examples/compose-map:build linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build linux-x64-egl
+      - run: mise run --no-deps //examples/lwjgl-map:build linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:test linux-x64-egl
+      - run: mise run --no-deps //bindings/swift:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test linux-x64-egl
+      - run: mise run --no-deps //bindings/dotnet:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/go:test linux-x64-egl
+      - run: mise run --no-deps //bindings/go:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test linux-x64-egl
+      - run: mise run --no-deps //bindings/python:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -147,49 +154,56 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test linux-x64-vulkan
-      - run: mise run check-glibc-floor linux-x64-vulkan
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test linux-x64-vulkan
+      - run: mise run --no-deps check-glibc-floor linux-x64-vulkan
       - name: Archive native artifact
-        run: mise run archive-native linux-x64-vulkan
+        run: mise run --no-deps archive-native linux-x64-vulkan
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           linux-x64-vulkan
           build/packages/native/dist/maplibre-native-c-linux-x64-vulkan.tar.gz
-      - run: mise run //bindings/rust:test linux-x64-vulkan
+      - run: mise run --no-deps //bindings/rust:test linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check linux-x64-vulkan
+      - run: mise run --no-deps //examples/rust-map:check linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test linux-x64-vulkan
+      - run: mise run --no-deps //bindings/zig:test linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build linux-x64-vulkan
+      - run: mise run --no-deps //examples/zig-map:build linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run linux-x64-vulkan
+      - run: mise run --no-deps //examples/zig-readback:run linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest linux-x64-vulkan
+      - run: mise run --no-deps //bindings/kotlin:jvmTest linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build linux-x64-vulkan
+      - run: mise run --no-deps //examples/compose-map:build linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build linux-x64-vulkan
+      - run: mise run --no-deps //examples/lwjgl-map:build linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:test linux-x64-vulkan
+      - run: mise run --no-deps //bindings/swift:test linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test linux-x64-vulkan
+      - run: mise run --no-deps //bindings/dotnet:test linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/go:test linux-x64-vulkan
+      - run: mise run --no-deps //bindings/go:test linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test linux-x64-vulkan
+      - run: mise run --no-deps //bindings/python:test linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -223,49 +237,56 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test linux-arm64-egl
-      - run: mise run check-glibc-floor linux-arm64-egl
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test linux-arm64-egl
+      - run: mise run --no-deps check-glibc-floor linux-arm64-egl
       - name: Archive native artifact
-        run: mise run archive-native linux-arm64-egl
+        run: mise run --no-deps archive-native linux-arm64-egl
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           linux-arm64-egl
           build/packages/native/dist/maplibre-native-c-linux-arm64-egl.tar.gz
-      - run: mise run //bindings/rust:test linux-arm64-egl
+      - run: mise run --no-deps //bindings/rust:test linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check linux-arm64-egl
+      - run: mise run --no-deps //examples/rust-map:check linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test linux-arm64-egl
+      - run: mise run --no-deps //bindings/zig:test linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build linux-arm64-egl
+      - run: mise run --no-deps //examples/zig-map:build linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run linux-arm64-egl
+      - run: mise run --no-deps //examples/zig-readback:run linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest linux-arm64-egl
+      - run: mise run --no-deps //bindings/kotlin:jvmTest linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build linux-arm64-egl
+      - run: mise run --no-deps //examples/compose-map:build linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build linux-arm64-egl
+      - run: mise run --no-deps //examples/lwjgl-map:build linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:test linux-arm64-egl
+      - run: mise run --no-deps //bindings/swift:test linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test linux-arm64-egl
+      - run: mise run --no-deps //bindings/dotnet:test linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/go:test linux-arm64-egl
+      - run: mise run --no-deps //bindings/go:test linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test linux-arm64-egl
+      - run: mise run --no-deps //bindings/python:test linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -299,49 +320,56 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test linux-arm64-vulkan
-      - run: mise run check-glibc-floor linux-arm64-vulkan
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test linux-arm64-vulkan
+      - run: mise run --no-deps check-glibc-floor linux-arm64-vulkan
       - name: Archive native artifact
-        run: mise run archive-native linux-arm64-vulkan
+        run: mise run --no-deps archive-native linux-arm64-vulkan
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           linux-arm64-vulkan
           build/packages/native/dist/maplibre-native-c-linux-arm64-vulkan.tar.gz
-      - run: mise run //bindings/rust:test linux-arm64-vulkan
+      - run: mise run --no-deps //bindings/rust:test linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check linux-arm64-vulkan
+      - run: mise run --no-deps //examples/rust-map:check linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test linux-arm64-vulkan
+      - run: mise run --no-deps //bindings/zig:test linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build linux-arm64-vulkan
+      - run: mise run --no-deps //examples/zig-map:build linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run linux-arm64-vulkan
+      - run: mise run --no-deps //examples/zig-readback:run linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest linux-arm64-vulkan
+      - run: mise run --no-deps //bindings/kotlin:jvmTest linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build linux-arm64-vulkan
+      - run: mise run --no-deps //examples/compose-map:build linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build linux-arm64-vulkan
+      - run: mise run --no-deps //examples/lwjgl-map:build linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:test linux-arm64-vulkan
+      - run: mise run --no-deps //bindings/swift:test linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test linux-arm64-vulkan
+      - run: mise run --no-deps //bindings/dotnet:test linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/go:test linux-arm64-vulkan
+      - run: mise run --no-deps //bindings/go:test linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test linux-arm64-vulkan
+      - run: mise run --no-deps //bindings/python:test linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -375,54 +403,61 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test macos-arm64-metal
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test macos-arm64-metal
       - name: Archive native artifact
-        run: mise run archive-native macos-arm64-metal
+        run: mise run --no-deps archive-native macos-arm64-metal
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           macos-arm64-metal
           build/packages/native/dist/maplibre-native-c-macos-arm64-metal.tar.gz
-      - run: mise run //bindings/rust:test macos-arm64-metal
+      - run: mise run --no-deps //bindings/rust:test macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check macos-arm64-metal
+      - run: mise run --no-deps //examples/rust-map:check macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test macos-arm64-metal
+      - run: mise run --no-deps //bindings/zig:test macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build macos-arm64-metal
+      - run: mise run --no-deps //examples/zig-map:build macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run macos-arm64-metal
+      - run: mise run --no-deps //examples/zig-readback:run macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest macos-arm64-metal
+      - run: mise run --no-deps //bindings/kotlin:jvmTest macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:nativeTest macos-arm64-metal
+      - run: mise run --no-deps //bindings/kotlin:nativeTest macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build macos-arm64-metal
+      - run: mise run --no-deps //examples/compose-map:build macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build macos-arm64-metal
+      - run: mise run --no-deps //examples/lwjgl-map:build macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:test macos-arm64-metal
+      - run: mise run --no-deps //bindings/swift:test macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/swift-map:build macos-arm64-metal
+      - run: mise run --no-deps //examples/swift-map:build macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test macos-arm64-metal
+      - run: mise run --no-deps //bindings/dotnet:test macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/go:test macos-arm64-metal
+      - run: mise run --no-deps //bindings/go:test macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test macos-arm64-metal
+      - run: mise run --no-deps //bindings/python:test macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -456,51 +491,58 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test macos-arm64-vulkan
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test macos-arm64-vulkan
       - name: Archive native artifact
-        run: mise run archive-native macos-arm64-vulkan
+        run: mise run --no-deps archive-native macos-arm64-vulkan
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           macos-arm64-vulkan
           build/packages/native/dist/maplibre-native-c-macos-arm64-vulkan.tar.gz
-      - run: mise run //bindings/rust:test macos-arm64-vulkan
+      - run: mise run --no-deps //bindings/rust:test macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check macos-arm64-vulkan
+      - run: mise run --no-deps //examples/rust-map:check macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test macos-arm64-vulkan
+      - run: mise run --no-deps //bindings/zig:test macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build macos-arm64-vulkan
+      - run: mise run --no-deps //examples/zig-map:build macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run macos-arm64-vulkan
+      - run: mise run --no-deps //examples/zig-readback:run macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest macos-arm64-vulkan
+      - run: mise run --no-deps //bindings/kotlin:jvmTest macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:nativeTest macos-arm64-vulkan
+      - run: mise run --no-deps //bindings/kotlin:nativeTest macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build macos-arm64-vulkan
+      - run: mise run --no-deps //examples/compose-map:build macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build macos-arm64-vulkan
+      - run: mise run --no-deps //examples/lwjgl-map:build macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:test macos-arm64-vulkan
+      - run: mise run --no-deps //bindings/swift:test macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test macos-arm64-vulkan
+      - run: mise run --no-deps //bindings/dotnet:test macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/go:test macos-arm64-vulkan
+      - run: mise run --no-deps //bindings/go:test macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test macos-arm64-vulkan
+      - run: mise run --no-deps //bindings/python:test macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -534,48 +576,55 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test macos-arm64-egl
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test macos-arm64-egl
       - name: Archive native artifact
-        run: mise run archive-native macos-arm64-egl
+        run: mise run --no-deps archive-native macos-arm64-egl
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           macos-arm64-egl
           build/packages/native/dist/maplibre-native-c-macos-arm64-egl.tar.gz
-      - run: mise run //bindings/rust:test macos-arm64-egl
+      - run: mise run --no-deps //bindings/rust:test macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test macos-arm64-egl
+      - run: mise run --no-deps //bindings/zig:test macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build macos-arm64-egl
+      - run: mise run --no-deps //examples/zig-map:build macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run macos-arm64-egl
+      - run: mise run --no-deps //examples/zig-readback:run macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest macos-arm64-egl
+      - run: mise run --no-deps //bindings/kotlin:jvmTest macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:nativeTest macos-arm64-egl
+      - run: mise run --no-deps //bindings/kotlin:nativeTest macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build macos-arm64-egl
+      - run: mise run --no-deps //examples/compose-map:build macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build macos-arm64-egl
+      - run: mise run --no-deps //examples/lwjgl-map:build macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:test macos-arm64-egl
+      - run: mise run --no-deps //bindings/swift:test macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test macos-arm64-egl
+      - run: mise run --no-deps //bindings/dotnet:test macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/go:test macos-arm64-egl
+      - run: mise run --no-deps //bindings/go:test macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test macos-arm64-egl
+      - run: mise run --no-deps //bindings/python:test macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -607,21 +656,21 @@ jobs:
           target: ios-arm64-metal
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run build ios-arm64-metal
+      - run: mise run --no-deps build ios-arm64-metal
       - name: Archive native artifact
-        run: mise run archive-native ios-arm64-metal
+        run: mise run --no-deps archive-native ios-arm64-metal
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           ios-arm64-metal
           build/packages/native/dist/maplibre-native-c-ios-arm64-metal.tar.gz
-      - run: mise run //bindings/kotlin:iosBuild ios-arm64-metal
+      - run: mise run --no-deps //bindings/kotlin:iosBuild ios-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:build:ios
+      - run: mise run --no-deps //bindings/swift:build:ios
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/swift-map:build:ios
+      - run: mise run --no-deps //examples/swift-map:build:ios
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
@@ -645,25 +694,29 @@ jobs:
           target: ios-simulator-arm64-metal
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test ios-simulator-arm64-metal
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/zig:zig
+      - run: mise run --no-deps test ios-simulator-arm64-metal
       - name: Archive native artifact
-        run: mise run archive-native ios-simulator-arm64-metal
+        run: mise run --no-deps archive-native ios-simulator-arm64-metal
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           ios-simulator-arm64-metal
           build/packages/native/dist/maplibre-native-c-ios-simulator-arm64-metal.tar.gz
-      - run: mise run //bindings/kotlin:iosBuild ios-simulator-arm64-metal
+      - run: mise run --no-deps //bindings/kotlin:iosBuild ios-simulator-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/swift:build:ios-simulator
+      - run: mise run --no-deps //bindings/swift:build:ios-simulator
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test:ios-simulator
+      - run: mise run --no-deps //bindings/zig:test:ios-simulator
         env:
           MISE_TASK_SKIP: "//:build"
       - run: bash scripts/run-ios-simulator-test.sh bindings/swift/.build/ios-simulator/arm64-apple-ios-simulator/debug/MaplibreNativeIOSSimulatorTests 120
-      - run: mise run //examples/swift-map:build:ios-simulator
+      - run: mise run --no-deps //examples/swift-map:build:ios-simulator
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
@@ -687,18 +740,18 @@ jobs:
           target: android-arm64-egl
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run build android-arm64-egl
+      - run: mise run --no-deps build android-arm64-egl
       - name: Archive native artifact
-        run: mise run archive-native android-arm64-egl
+        run: mise run --no-deps archive-native android-arm64-egl
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           android-arm64-egl
           build/packages/native/dist/maplibre-native-c-android-arm64-egl.tar.gz
-      - run: mise run //bindings/kotlin:androidBuild opengl arm64-v8a --prebuilt
+      - run: mise run --no-deps //bindings/kotlin:androidBuild opengl arm64-v8a --prebuilt
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/android-map:build opengl arm64-v8a --prebuilt
+      - run: mise run --no-deps //examples/android-map:build opengl arm64-v8a --prebuilt
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
@@ -722,15 +775,15 @@ jobs:
           target: android-arm64-vulkan
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run build android-arm64-vulkan
+      - run: mise run --no-deps build android-arm64-vulkan
       - name: Archive native artifact
-        run: mise run archive-native android-arm64-vulkan
+        run: mise run --no-deps archive-native android-arm64-vulkan
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           android-arm64-vulkan
           build/packages/native/dist/maplibre-native-c-android-arm64-vulkan.tar.gz
-      - run: mise run //bindings/kotlin:androidBuild vulkan arm64-v8a --prebuilt
+      - run: mise run --no-deps //bindings/kotlin:androidBuild vulkan arm64-v8a --prebuilt
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
@@ -754,18 +807,18 @@ jobs:
           target: android-x64-egl
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run build android-x64-egl
+      - run: mise run --no-deps build android-x64-egl
       - name: Archive native artifact
-        run: mise run archive-native android-x64-egl
+        run: mise run --no-deps archive-native android-x64-egl
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           android-x64-egl
           build/packages/native/dist/maplibre-native-c-android-x64-egl.tar.gz
-      - run: mise run //bindings/kotlin:androidBuild opengl x86_64 --prebuilt
+      - run: mise run --no-deps //bindings/kotlin:androidBuild opengl x86_64 --prebuilt
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/android-map:build opengl x86_64 --prebuilt
+      - run: mise run --no-deps //examples/android-map:build opengl x86_64 --prebuilt
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
@@ -789,15 +842,15 @@ jobs:
           target: android-x64-vulkan
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run build android-x64-vulkan
+      - run: mise run --no-deps build android-x64-vulkan
       - name: Archive native artifact
-        run: mise run archive-native android-x64-vulkan
+        run: mise run --no-deps archive-native android-x64-vulkan
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           android-x64-vulkan
           build/packages/native/dist/maplibre-native-c-android-x64-vulkan.tar.gz
-      - run: mise run //bindings/kotlin:androidBuild vulkan x86_64 --prebuilt
+      - run: mise run --no-deps //bindings/kotlin:androidBuild vulkan x86_64 --prebuilt
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
@@ -821,7 +874,7 @@ jobs:
           target: ohos-arm64-egl
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run //bindings/rust:build:ohos ohos-arm64-egl
+      - run: mise run --no-deps //bindings/rust:build:ohos ohos-arm64-egl
 
   target-ohos-arm64-vulkan:
     name: target / ohos-arm64-vulkan
@@ -837,7 +890,7 @@ jobs:
           target: ohos-arm64-vulkan
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run //bindings/rust:build:ohos ohos-arm64-vulkan
+      - run: mise run --no-deps //bindings/rust:build:ohos ohos-arm64-vulkan
 
   target-windows-x64-wgl:
     name: target / windows-x64-wgl
@@ -855,42 +908,49 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test windows-x64-wgl
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test windows-x64-wgl
       - name: Archive native artifact
-        run: mise run archive-native windows-x64-wgl
+        run: mise run --no-deps archive-native windows-x64-wgl
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           windows-x64-wgl
           build/packages/native/dist/maplibre-native-c-windows-x64-wgl.tar.gz
-      - run: mise run //bindings/rust:test windows-x64-wgl
+      - run: mise run --no-deps //bindings/rust:test windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check windows-x64-wgl
+      - run: mise run --no-deps //examples/rust-map:check windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test windows-x64-wgl
+      - run: mise run --no-deps //bindings/zig:test windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build windows-x64-wgl
+      - run: mise run --no-deps //examples/zig-map:build windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run windows-x64-wgl
+      - run: mise run --no-deps //examples/zig-readback:run windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest windows-x64-wgl
+      - run: mise run --no-deps //bindings/kotlin:jvmTest windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build windows-x64-wgl
+      - run: mise run --no-deps //examples/compose-map:build windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build windows-x64-wgl
+      - run: mise run --no-deps //examples/lwjgl-map:build windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test windows-x64-wgl
+      - run: mise run --no-deps //bindings/dotnet:test windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test windows-x64-wgl
+      - run: mise run --no-deps //bindings/python:test windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -924,42 +984,49 @@ jobs:
           zig: true
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test windows-x64-vulkan
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+          --only //bindings/zig:zig
+          --only //examples/zig-map:zig
+          --only //examples/zig-readback:zig
+      - run: mise run --no-deps test windows-x64-vulkan
       - name: Archive native artifact
-        run: mise run archive-native windows-x64-vulkan
+        run: mise run --no-deps archive-native windows-x64-vulkan
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           windows-x64-vulkan
           build/packages/native/dist/maplibre-native-c-windows-x64-vulkan.tar.gz
-      - run: mise run //bindings/rust:test windows-x64-vulkan
+      - run: mise run --no-deps //bindings/rust:test windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check windows-x64-vulkan
+      - run: mise run --no-deps //examples/rust-map:check windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/zig:test windows-x64-vulkan
+      - run: mise run --no-deps //bindings/zig:test windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-map:build windows-x64-vulkan
+      - run: mise run --no-deps //examples/zig-map:build windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/zig-readback:run windows-x64-vulkan
+      - run: mise run --no-deps //examples/zig-readback:run windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest windows-x64-vulkan
+      - run: mise run --no-deps //bindings/kotlin:jvmTest windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build windows-x64-vulkan
+      - run: mise run --no-deps //examples/compose-map:build windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build windows-x64-vulkan
+      - run: mise run --no-deps //examples/lwjgl-map:build windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test windows-x64-vulkan
+      - run: mise run --no-deps //bindings/dotnet:test windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test windows-x64-vulkan
+      - run: mise run --no-deps //bindings/python:test windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -991,33 +1058,37 @@ jobs:
           target: windows-arm64-wgl
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test windows-arm64-wgl
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+      - run: mise run --no-deps test windows-arm64-wgl
       - name: Archive native artifact
-        run: mise run archive-native windows-arm64-wgl
+        run: mise run --no-deps archive-native windows-arm64-wgl
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           windows-arm64-wgl
           build/packages/native/dist/maplibre-native-c-windows-arm64-wgl.tar.gz
-      - run: mise run //bindings/rust:test windows-arm64-wgl
+      - run: mise run --no-deps //bindings/rust:test windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check windows-arm64-wgl
+      - run: mise run --no-deps //examples/rust-map:check windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest windows-arm64-wgl
+      - run: mise run --no-deps //bindings/kotlin:jvmTest windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build windows-arm64-wgl
+      - run: mise run --no-deps //examples/compose-map:build windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build windows-arm64-wgl
+      - run: mise run --no-deps //examples/lwjgl-map:build windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test windows-arm64-wgl
+      - run: mise run --no-deps //bindings/dotnet:test windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test windows-arm64-wgl
+      - run: mise run --no-deps //bindings/python:test windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
@@ -1041,33 +1112,37 @@ jobs:
           target: windows-arm64-vulkan
           sccache-access-key-id: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
           sccache-secret-access-key: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
-      - run: mise run test windows-arm64-vulkan
+      - name: Prepare project dependencies
+        run: >-
+          mise deps --monorepo
+          --only //bindings/dotnet:dotnet-tools
+      - run: mise run --no-deps test windows-arm64-vulkan
       - name: Archive native artifact
-        run: mise run archive-native windows-arm64-vulkan
+        run: mise run --no-deps archive-native windows-arm64-vulkan
       - name: Install packaged native artifact
         run: >-
-          mise run install-native-package
+          mise run --no-deps install-native-package
           windows-arm64-vulkan
           build/packages/native/dist/maplibre-native-c-windows-arm64-vulkan.tar.gz
-      - run: mise run //bindings/rust:test windows-arm64-vulkan
+      - run: mise run --no-deps //bindings/rust:test windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/rust-map:check windows-arm64-vulkan
+      - run: mise run --no-deps //examples/rust-map:check windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/kotlin:jvmTest windows-arm64-vulkan
+      - run: mise run --no-deps //bindings/kotlin:jvmTest windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/compose-map:build windows-arm64-vulkan
+      - run: mise run --no-deps //examples/compose-map:build windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //examples/lwjgl-map:build windows-arm64-vulkan
+      - run: mise run --no-deps //examples/lwjgl-map:build windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dotnet:test windows-arm64-vulkan
+      - run: mise run --no-deps //bindings/dotnet:test windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/python:test windows-arm64-vulkan
+      - run: mise run --no-deps //bindings/python:test windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
@@ -1102,7 +1177,7 @@ jobs:
           pattern: native-package-android-*-${{ github.sha }}
           path: build/packages/native/android-multi-input
       - run: >-
-          mise run //:kotlin:verify-android-multi-abi
+          mise run --no-deps //:kotlin:verify-android-multi-abi
           build/packages/native/android-multi-input
 
   required:

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -12,7 +12,7 @@ OUTPUT = ROOT / ".github" / "workflows" / "ci.yml"
 sys.path.insert(0, str(ROOT))
 
 from ci.action_pins import load_pins  # noqa: E402
-from ci.workflow import load_configuration, target_rows  # noqa: E402
+from ci.workflow import load_configuration, mise_run, target_rows  # noqa: E402
 
 # Pins come from `.github/workflows/action-pins.yml` so Dependabot updates them.
 PINS = load_pins(ROOT)
@@ -64,6 +64,18 @@ def run_step(command: str, *, env: dict[str, str] | None = None) -> list[str]:
     return lines
 
 
+def prepare_project_dependencies(providers: list[str]) -> list[str]:
+    if not providers:
+        return []
+    lines = [
+        "      - name: Prepare project dependencies",
+        "        run: >-",
+        "          mise deps --monorepo",
+    ]
+    lines.extend(f"          --only {provider}" for provider in providers)
+    return lines
+
+
 CONSUMER_ENV = {"MISE_TASK_SKIP": '"//:build"'}
 
 
@@ -71,6 +83,7 @@ def target_job(row: dict[str, object]) -> list[str]:
     preset = str(row["preset"])
     package = bool(row["package"])
     zig = bool(row["zig"])
+    project_dependencies = list(row["project_dependencies"])
     native = list(row["native_commands"])
     consumers = list(row.get("consumer_commands", []))
 
@@ -82,6 +95,7 @@ def target_job(row: dict[str, object]) -> list[str]:
         SCCACHE_ENVIRONMENT,
         "    steps:",
         *setup(preset, zig=zig),
+        *prepare_project_dependencies(project_dependencies),
     ]
     for command in native:
         lines.extend(run_step(command))
@@ -89,10 +103,10 @@ def target_job(row: dict[str, object]) -> list[str]:
         lines.extend(
             [
                 "      - name: Archive native artifact",
-                f"        run: mise run archive-native {preset}",
+                f"        run: {mise_run('archive-native', preset)}",
                 "      - name: Install packaged native artifact",
                 "        run: >-",
-                "          mise run install-native-package",
+                "          mise run --no-deps install-native-package",
                 f"          {preset}",
                 f"          build/packages/native/dist/maplibre-native-c-{preset}.tar.gz",
             ]
@@ -169,12 +183,12 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         SCCACHE_ENVIRONMENT,
         "    steps:",
         *setup(),
-        "      - run: mise run ci:generate-workflow --check",
-        "      - run: mise run ci:generate-devcontainer-tools --check",
+        f"      - run: {mise_run('ci:generate-workflow', '--check')}",
+        f"      - run: {mise_run('ci:generate-devcontainer-tools', '--check')}",
         "      - run: dprint output-resolved-config > /dev/null",
         # `mise run fix` provides the project-scoped formatter tools that the
         # dprint wrappers expect; calling hk directly leaves them uninstalled.
-        "      - run: mise run fix",
+        f"      - run: {mise_run('fix')}",
         "      - name: Check generated and formatted files",
         "        run: |",
         "          git update-index -q --refresh",
@@ -188,7 +202,7 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
         SCCACHE_ENVIRONMENT,
         "    steps:",
         *setup(),
-        "      - run: mise run //docs:build",
+        f"      - run: {mise_run('//docs:build')}",
         "",
     ]
     for row in rows:
@@ -211,7 +225,7 @@ def render(source: dict[str, object], presets: dict[str, object]) -> str:
             "          pattern: native-package-android-*-${{ github.sha }}",
             "          path: build/packages/native/android-multi-input",
             "      - run: >-",
-            "          mise run //:kotlin:verify-android-multi-abi",
+            "          mise run --no-deps //:kotlin:verify-android-multi-abi",
             "          build/packages/native/android-multi-input",
             "",
             "  required:",

--- a/.mise/tasks/install-native-package
+++ b/.mise/tasks/install-native-package
@@ -23,7 +23,7 @@ staging_dir="$build_dir/.package-staging"
 package_root="$staging_dir/maplibre-native-c-$preset"
 install_dir="$build_dir/install"
 
-mise run //:clean "$preset"
+mise run --no-deps //:clean "$preset"
 mkdir -p "$staging_dir"
 (
   cd "$staging_dir"

--- a/ci/workflow.py
+++ b/ci/workflow.py
@@ -7,6 +7,20 @@ import tomllib
 
 DESKTOP = {"linux", "macos", "windows"}
 
+# CI bootstraps the root providers during setup. Project providers stay scoped
+# to jobs that run their tasks, but are prepared once before those tasks so each
+# later mise invocation can skip automatic dependency checks.
+PROJECT_DEPENDENCIES = (
+    ("//bindings/dotnet:", "//bindings/dotnet:dotnet-tools"),
+    ("//bindings/zig:", "//bindings/zig:zig"),
+    ("//examples/zig-map:", "//examples/zig-map:zig"),
+    ("//examples/zig-readback:", "//examples/zig-readback:zig"),
+)
+
+
+def mise_run(task: str, *arguments: str) -> str:
+    return " ".join(("mise", "run", "--no-deps", task, *arguments))
+
 
 def load_configuration(
     root: pathlib.Path,
@@ -72,26 +86,28 @@ def suite_commands(source: dict[str, object], preset: str) -> list[str]:
                 continue
             if preset in command.get("exclude", []):
                 continue
-            commands.append(f"mise run {command['task']} {preset}")
+            commands.append(mise_run(command["task"], preset))
     return commands
 
 
 def android_commands(preset: str, abi: str, build_map: bool) -> list[str]:
     render_backend = "opengl" if backend(preset) == "egl" else backend(preset)
     arguments = f"{render_backend} {abi}"
-    commands = [f"mise run //bindings/kotlin:androidBuild {arguments} --prebuilt"]
+    commands = [mise_run("//bindings/kotlin:androidBuild", arguments, "--prebuilt")]
     if build_map:
-        commands.append(f"mise run //examples/android-map:build {arguments} --prebuilt")
+        commands.append(
+            mise_run("//examples/android-map:build", arguments, "--prebuilt")
+        )
     return commands
 
 
 def native_commands(preset: str, tested: set[str]) -> list[str]:
     target_platform = platform(preset)
     if target_platform == "ohos":
-        return [f"mise run //bindings/rust:build:ohos {preset}"]
-    commands = [f"mise run {'test' if preset in tested else 'build'} {preset}"]
+        return [mise_run("//bindings/rust:build:ohos", preset)]
+    commands = [mise_run("test" if preset in tested else "build", preset)]
     if target_platform == "linux":
-        commands.append(f"mise run check-glibc-floor {preset}")
+        commands.append(mise_run("check-glibc-floor", preset))
     return commands
 
 
@@ -104,19 +120,19 @@ def consumer_commands(source: dict[str, object], preset: str) -> list[str]:
     elif target_platform == "ios":
         commands.extend(
             [
-                f"mise run //bindings/kotlin:iosBuild {preset}",
-                "mise run //bindings/swift:build:ios",
-                "mise run //examples/swift-map:build:ios",
+                mise_run("//bindings/kotlin:iosBuild", preset),
+                mise_run("//bindings/swift:build:ios"),
+                mise_run("//examples/swift-map:build:ios"),
             ]
         )
     elif target_platform == "ios-simulator":
         commands.extend(
             [
-                f"mise run //bindings/kotlin:iosBuild {preset}",
-                "mise run //bindings/swift:build:ios-simulator",
-                "mise run //bindings/zig:test:ios-simulator",
+                mise_run("//bindings/kotlin:iosBuild", preset),
+                mise_run("//bindings/swift:build:ios-simulator"),
+                mise_run("//bindings/zig:test:ios-simulator"),
                 "bash scripts/run-ios-simulator-test.sh bindings/swift/.build/ios-simulator/arm64-apple-ios-simulator/debug/MaplibreNativeIOSSimulatorTests 120",
-                "mise run //examples/swift-map:build:ios-simulator",
+                mise_run("//examples/swift-map:build:ios-simulator"),
             ]
         )
     elif target_platform in DESKTOP:
@@ -125,10 +141,18 @@ def consumer_commands(source: dict[str, object], preset: str) -> list[str]:
 
 
 ZIG_PROJECTS = (
-    "mise run //bindings/zig:",
-    "mise run //examples/zig-map:",
-    "mise run //examples/zig-readback:",
+    "//bindings/zig:",
+    "//examples/zig-map:",
+    "//examples/zig-readback:",
 )
+
+
+def project_dependencies(commands: list[str]) -> list[str]:
+    return [
+        provider
+        for task_prefix, provider in PROJECT_DEPENDENCIES
+        if any(f" {task_prefix}" in command for command in commands)
+    ]
 
 
 def uses_zig(commands: list[str]) -> bool:
@@ -141,7 +165,7 @@ def uses_zig(commands: list[str]) -> bool:
     run the examples would then fail whenever an upstream host is unavailable.
     """
     return all(
-        any(command.startswith(project) for command in commands)
+        any(f" {project}" in command for command in commands)
         for project in ZIG_PROJECTS
     )
 
@@ -187,6 +211,7 @@ def target_rows(
             "runner": runner(preset),
             "package": preset in packaged,
             "zig": uses_zig(native + consumers),
+            "project_dependencies": project_dependencies(native + consumers),
             "native_commands": native if preset in packaged else native + consumers,
         }
         if preset in packaged:


### PR DESCRIPTION
## Summary

Prepare project-scoped dependencies once per applicable job and run subsequent mise tasks with `--no-deps` to avoid repeated provider checks.

## Test plan

Ran targeted format/lint checks, actionlint, shellcheck, Python compilation, and both CI generator consistency checks.

## AI assistance

- **Tools:** Codex
- **Context:** Investigated Windows CI timing, implemented the generated workflow and task changes, validated them locally, and prepared this pull request.