### PR TITLE
Restore project-scoped Bash defaults after mise #11293

### DIFF
--- a/.devcontainer/.mise/tasks/build
+++ b/.devcontainer/.mise/tasks/build
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Build the local devcontainer image for the host architecture."
+#MISE shell="bash"
 #USAGE flag "--tag <tag>" help="Final image tag" default="maplibre-native-ffi-devcontainer:local"
 #USAGE flag "--push" help="Push the final image instead of loading it into Docker"
 set -euo pipefail

--- a/.devcontainer/.mise/tasks/smoke
+++ b/.devcontainer/.mise/tasks/smoke
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Run a quick command in the local devcontainer image."
+#MISE shell="bash"
 set -euo pipefail
 
 host_arch="$(uname -m)"

--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -318,19 +318,6 @@ runs:
           throw "no vulkan-1.dll in $($candidates -join ', ') or on PATH"
         }
 
-    # mise 2026.7.14 made project-local default shell settings global-only.
-    # Keep CI on the repository's Bash contract until a trusted project-scoped
-    # replacement is available: https://github.com/maplibre/maplibre-native-ffi/issues/366
-    - name: Configure mise shells
-      shell: bash
-      run: |
-        {
-          echo 'MISE_UNIX_DEFAULT_FILE_SHELL_ARGS=bash'
-          echo 'MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS=bash -e -c'
-          echo 'MISE_WINDOWS_DEFAULT_FILE_SHELL_ARGS="C:/Program Files/Git/bin/bash.exe"'
-          echo 'MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS="C:/Program Files/Git/bin/bash.exe" -e -lc'
-        } >> "$GITHUB_ENV"
-
     # `mise-action` saves its cache inline, at the end of its own step, so
     # anything installed after it — the project toolchains below, and the rustup
     # tree that `core:rust` installs outside the mise data directory — was never

--- a/.mise/tasks/ci/check-action-pins
+++ b/.mise/tasks/ci/check-action-pins
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # MISE description="Verify GitHub Actions pins match the pins catalog."
+# MISE shell="python3"
 
 import pathlib
 import sys

--- a/.mise/tasks/ci/check-action-pins
+++ b/.mise/tasks/ci/check-action-pins
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# MISE description="Verify GitHub Actions pins match the pins catalog."
-# MISE shell="python3"
+# [MISE] description="Verify GitHub Actions pins match the pins catalog."
+# [MISE] shell="python3"
 
 import pathlib
 import sys

--- a/.mise/tasks/ci/generate-devcontainer-tools
+++ b/.mise/tasks/ci/generate-devcontainer-tools
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # MISE description="Generate the devcontainer's aggregate tool list."
+# MISE shell="python3"
 
 import argparse
 import difflib

--- a/.mise/tasks/ci/generate-devcontainer-tools
+++ b/.mise/tasks/ci/generate-devcontainer-tools
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# MISE description="Generate the devcontainer's aggregate tool list."
-# MISE shell="python3"
+# [MISE] description="Generate the devcontainer's aggregate tool list."
+# [MISE] shell="python3"
 
 import argparse
 import difflib

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# MISE description="Generate the GitHub Actions CI workflow."
-# MISE shell="python3"
+# [MISE] description="Generate the GitHub Actions CI workflow."
+# [MISE] shell="python3"
 
 import argparse
 import difflib

--- a/.mise/tasks/ci/generate-workflow
+++ b/.mise/tasks/ci/generate-workflow
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # MISE description="Generate the GitHub Actions CI workflow."
+# MISE shell="python3"
 
 import argparse
 import difflib

--- a/.mise/tasks/ci/prepare-native-package-snapshot
+++ b/.mise/tasks/ci/prepare-native-package-snapshot
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# MISE description="Prepare native package snapshot release assets."
-# MISE shell="python3"
+# [MISE] description="Prepare native package snapshot release assets."
+# [MISE] shell="python3"
 
 import hashlib
 import os

--- a/.mise/tasks/ci/prepare-native-package-snapshot
+++ b/.mise/tasks/ci/prepare-native-package-snapshot
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # MISE description="Prepare native package snapshot release assets."
+# MISE shell="python3"
 
 import hashlib
 import os

--- a/.mise/tasks/install-native-package
+++ b/.mise/tasks/install-native-package
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Replace a native build tree with its packaged install."
+#MISE shell="bash"
 #USAGE arg "<preset>" help="Native CMake preset"
 #USAGE arg "<archive>" help="Native package archive"
 

--- a/.mise/tasks/kotlin/check-android-api-floor
+++ b/.mise/tasks/kotlin/check-android-api-floor
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # MISE description="Verify compiled androidMain bytecode stays on the android-minSdk floor."
+# MISE shell="python3"
 
 """Reject Android platform APIs introduced above the ``android-minSdk`` floor.
 

--- a/.mise/tasks/kotlin/check-android-api-floor
+++ b/.mise/tasks/kotlin/check-android-api-floor
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# MISE description="Verify compiled androidMain bytecode stays on the android-minSdk floor."
-# MISE shell="python3"
+# [MISE] description="Verify compiled androidMain bytecode stays on the android-minSdk floor."
+# [MISE] shell="python3"
 
 """Reject Android platform APIs introduced above the ``android-minSdk`` floor.
 

--- a/.mise/tasks/kotlin/publish-snapshot
+++ b/.mise/tasks/kotlin/publish-snapshot
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Stage, verify, or publish Kotlin Multiplatform snapshots."
+#MISE shell="bash"
 #MISE tools={java="{{vars.java_version}}"}
 
 set -euo pipefail

--- a/.mise/tasks/kotlin/verify-android-multi-abi
+++ b/.mise/tasks/kotlin/verify-android-multi-abi
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Verify multi-ABI Android runtime AARs from packaged native artifacts."
+#MISE shell="bash"
 #MISE tools={java="{{vars.java_version}}"}
 
 set -euo pipefail

--- a/.mise/tasks/kotlin/verify-staging
+++ b/.mise/tasks/kotlin/verify-staging
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 #MISE description="Verify staged Kotlin Maven snapshot payloads."
+#MISE shell="python3"
 
 import json
 import pathlib

--- a/.mise/tasks/kotlin/verify-staging
+++ b/.mise/tasks/kotlin/verify-staging
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#MISE description="Verify staged Kotlin Maven snapshot payloads."
-#MISE shell="python3"
+# [MISE] description="Verify staged Kotlin Maven snapshot payloads."
+# [MISE] shell="python3"
 
 import json
 import pathlib

--- a/.mise/tasks/verify-native-package
+++ b/.mise/tasks/verify-native-package
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# MISE description="Reject build-host paths in a packaged native artifact."
-# MISE shell="python3"
+# [MISE] description="Reject build-host paths in a packaged native artifact."
+# [MISE] shell="python3"
 # USAGE arg "<preset>" help="Native CMake preset"
 
 """Check that a packaged shared library only names portable dependencies.

--- a/.mise/tasks/verify-native-package
+++ b/.mise/tasks/verify-native-package
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # MISE description="Reject build-host paths in a packaged native artifact."
+# MISE shell="python3"
 # USAGE arg "<preset>" help="Native CMake preset"
 
 """Check that a packaged shared library only names portable dependencies.

--- a/bindings/dotnet/mise.toml
+++ b/bindings/dotnet/mise.toml
@@ -5,6 +5,8 @@
 auto = true
 dir = "../.."
 sources = ["dotnet-tools.json", "bindings/dotnet/dotnet-tools.json"]
+# Dependency providers run through the platform shell, so both manifests restore
+# from one `&&` line that `sh` and `cmd` each understand.
 run = "dotnet tool restore --tool-manifest dotnet-tools.json --verbosity quiet && dotnet tool restore --tool-manifest bindings/dotnet/dotnet-tools.json --verbosity quiet"
 
 [tasks.generate]

--- a/bindings/dotnet/mise.toml
+++ b/bindings/dotnet/mise.toml
@@ -5,10 +5,7 @@
 auto = true
 dir = "../.."
 sources = ["dotnet-tools.json", "bindings/dotnet/dotnet-tools.json"]
-run = '''
-dotnet tool restore --tool-manifest dotnet-tools.json --verbosity quiet
-dotnet tool restore --tool-manifest bindings/dotnet/dotnet-tools.json --verbosity quiet
-'''
+run = "dotnet tool restore --tool-manifest dotnet-tools.json --verbosity quiet && dotnet tool restore --tool-manifest bindings/dotnet/dotnet-tools.json --verbosity quiet"
 
 [tasks.generate]
 run = "scripts/generate-clangsharp.sh"

--- a/examples/swift-map/.mise/tasks/package/ios-simulator
+++ b/examples/swift-map/.mise/tasks/package/ios-simulator
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Package the Swift map iOS simulator app bundle."
+#MISE shell="bash"
 set -euo pipefail
 
 mise run build:ios-simulator

--- a/examples/swift-map/.mise/tasks/run/ios-simulator
+++ b/examples/swift-map/.mise/tasks/run/ios-simulator
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Install and launch the Swift map iOS simulator app."
+#MISE shell="bash"
 set -euo pipefail
 
 mise run package:ios-simulator

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 # repository tasks.
 
 monorepo_root = true
-min_version = "2026.7.10"
+min_version = "2026.7.15"
 
 [settings]
 lockfile = true
@@ -29,6 +29,10 @@ dotnet.isolated = true
 [monorepo]
 config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 lockfile = true
+
+[task_config]
+cascade = true
+shell = "bash -e -c"
 
 [vars]
 actionlint_version = "1.7.8"
@@ -112,7 +116,7 @@ auto = true
 
 [deps.submodules]
 auto = true
-run = ".mise/bin/sync-submodules"
+run = "bash .mise/bin/sync-submodules"
 
 [hooks]
 postinstall = [

--- a/mise.toml
+++ b/mise.toml
@@ -30,11 +30,14 @@ dotnet.isolated = true
 config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 lockfile = true
 
-# Task scripts across the workspace are Bash. Cascading the shell gives every
-# monorepo config root the same contract without repeating it, and keeps the
-# choice scoped to tasks: hooks, tool installs, and dependency providers still
-# use the platform shell. File tasks take their arguments through `#USAGE`
-# variables, which stay available under this shell on every platform.
+# Inline task scripts across the workspace are Bash. Cascading the shell gives
+# every monorepo config root the same contract without repeating it, and keeps
+# the choice scoped to tasks: hooks, tool installs, and dependency providers
+# still use the platform shell.
+#
+# This default reaches file tasks too, and on Windows mise applies it in place
+# of the shebang, so each file task names its own interpreter with
+# `#MISE shell=`.
 [task_config]
 cascade = true
 shell = "bash -e -c"

--- a/mise.toml
+++ b/mise.toml
@@ -30,6 +30,11 @@ dotnet.isolated = true
 config_roots = [".devcontainer", "bindings/*", "examples/*", "docs"]
 lockfile = true
 
+# Task scripts across the workspace are Bash. Cascading the shell gives every
+# monorepo config root the same contract without repeating it, and keeps the
+# choice scoped to tasks: hooks, tool installs, and dependency providers still
+# use the platform shell. File tasks take their arguments through `#USAGE`
+# variables, which stay available under this shell on every platform.
 [task_config]
 cascade = true
 shell = "bash -e -c"
@@ -60,7 +65,6 @@ swiftformat_version = "0.61.1"
 uv_version = "0.11.11"
 xtool_version = "1.17.0"
 zig_version = "0.16.0"
-sync_submodules_run = '{% if os() == "windows" %}"C:/Program Files/Git/bin/bash.exe" .mise/bin/sync-submodules{% else %}bash .mise/bin/sync-submodules{% endif %}'
 
 [tools]
 # Repository and native tooling
@@ -93,7 +97,6 @@ swiftformat = { version = "{{vars.swiftformat_version}}", backend = "github:nick
 [env]
 MLN_FFI_ANDROID_CMAKE_VERSION = "4.1.2"
 MLN_FFI_ANDROID_NDK_VERSION = "28.2.13676358"
-SYNC_SUBMODULES_RUN = "{{ vars.sync_submodules_run }}"
 
 # Public sccache reads via the R2 custom domain (no credentials). CI pushes
 # override these with write credentials in .github/actions/setup-ci-deps.
@@ -111,14 +114,15 @@ auto = true
 run = "uv sync --locked --all-packages --all-groups --no-install-workspace"
 
 [deps.pnpm]
-# The built-in provider runs pnpm directly. A `run` script would go through Git
-# Bash, and on Windows ARM64 the lifecycle scripts pnpm spawns through cmd then
-# fail to resolve mise's node, so the workspace-wide install stays.
+# The built-in provider runs pnpm directly. A `run` script would put a shell
+# between mise and pnpm, and on Windows ARM64 the lifecycle scripts pnpm spawns
+# through cmd then fail to resolve mise's node, so the workspace-wide install
+# stays.
 auto = true
 
 [deps.submodules]
 auto = true
-run = "$SYNC_SUBMODULES_RUN"
+run = ".mise/bin/sync-submodules"
 
 [hooks]
 postinstall = [

--- a/mise.toml
+++ b/mise.toml
@@ -60,6 +60,7 @@ swiftformat_version = "0.61.1"
 uv_version = "0.11.11"
 xtool_version = "1.17.0"
 zig_version = "0.16.0"
+sync_submodules_run = '{% if os() == "windows" %}"C:/Program Files/Git/bin/bash.exe" .mise/bin/sync-submodules{% else %}bash .mise/bin/sync-submodules{% endif %}'
 
 [tools]
 # Repository and native tooling
@@ -92,6 +93,7 @@ swiftformat = { version = "{{vars.swiftformat_version}}", backend = "github:nick
 [env]
 MLN_FFI_ANDROID_CMAKE_VERSION = "4.1.2"
 MLN_FFI_ANDROID_NDK_VERSION = "28.2.13676358"
+SYNC_SUBMODULES_RUN = "{{ vars.sync_submodules_run }}"
 
 # Public sccache reads via the R2 custom domain (no credentials). CI pushes
 # override these with write credentials in .github/actions/setup-ci-deps.
@@ -116,7 +118,7 @@ auto = true
 
 [deps.submodules]
 auto = true
-run = "bash .mise/bin/sync-submodules"
+run = "$SYNC_SUBMODULES_RUN"
 
 [hooks]
 postinstall = [

--- a/mise.windows.toml
+++ b/mise.windows.toml
@@ -1,3 +1,5 @@
+# Git Bash carries the repository's Bash contract on Windows, where the platform
+# default is `cmd`.
 [task_config]
 shell = '"C:/Program Files/Git/bin/bash.exe" -e -lc'
 
@@ -10,3 +12,8 @@ host_native_preset = "windows-{{ arch() }}-vulkan"
 # The script caches the resolved environment so only the first shell pays for it.
 MLN_FFI_WINDOWS_HOST_ARCHITECTURE = "{{ arch() }}"
 BASH_ENV = "{{config_root}}/.mise/bin/windows-msvc-env.sh"
+
+[deps.submodules]
+# Dependency providers run through the platform shell rather than
+# `task_config.shell`, so name the Bash interpreter for the sync script here.
+run = '"C:/Program Files/Git/bin/bash.exe" .mise/bin/sync-submodules'

--- a/mise.windows.toml
+++ b/mise.windows.toml
@@ -1,3 +1,6 @@
+[task_config]
+shell = '"C:/Program Files/Git/bin/bash.exe" -e -lc'
+
 [vars]
 host_native_preset = "windows-{{ arch() }}-vulkan"
 

--- a/mise.windows.toml
+++ b/mise.windows.toml
@@ -12,6 +12,10 @@ host_native_preset = "windows-{{ arch() }}-vulkan"
 # The script caches the resolved environment so only the first shell pays for it.
 MLN_FFI_WINDOWS_HOST_ARCHITECTURE = "{{ arch() }}"
 BASH_ENV = "{{config_root}}/.mise/bin/windows-msvc-env.sh"
+# Git's installer puts its `cmd` directory on `PATH` and leaves out the `bin`
+# directory holding `bash.exe`. File tasks and dprint plugins name `bash`
+# directly, so put the same Git Bash the task shell uses within their reach.
+_.path = ["C:/Program Files/Git/bin"]
 
 [deps.submodules]
 # Dependency providers run through the platform shell rather than


### PR DESCRIPTION
Resolve #366

## Summary

Bump `min_version` to 2026.7.15 and replace the CI `MISE_*_DEFAULT_*` workaround with a cascading `[task_config] shell`, a Windows override in `mise.windows.toml` for the task shell and the one dependency provider that needs Bash, and a `#MISE shell=` line per file task, which mise consults ahead of the shebang.

## Test plan

On mise 2026.7.15 verified task loading across all monorepo roots, Bash resolution through the cascade, and that every file task still receives its arguments when mise routes it through the task shell as it does on Windows.

---

<details>
<summary>Upstream bug report for jdx/mise (copy to a new issue)</summary>

### `task_config.shell` is applied to file tasks, overriding their shebang and dropping their arguments

**Version:** 2026.7.15 (`task_config.shell` from #11354)

`task_config.shell` is documented as the project-scoped replacement for the now global-only `*_default_inline_shell_args` settings. It is also applied to **file** tasks, where `Task::shell` takes precedence over the shebang. Because the configured shell ends in `-c`, `get_file_program_and_args` builds `<shell> -c <task-file> <args…>`, so the task file becomes the `-c` command string and the task's own arguments shift onto `$0`.

**Repro** (`use_file_shell_for_executable_tasks` selects the same dispatch path Windows always takes, so this reproduces on Unix):

```toml
# mise.toml
[settings]
experimental = true
use_file_shell_for_executable_tasks = true

[task_config]
shell = "bash -e -c"
```

```bash
# mise-tasks/greet
#!/usr/bin/env bash
#USAGE arg "<name>"
echo "argv=[$*]"
```

```
$ mise run greet world
argv=[]           # expected: argv=[world]
```

Removing `[task_config]` restores `argv=[world]`.

**On Windows this is fatal rather than cosmetic**, since file tasks always take this path and the task path contains backslashes that Bash then consumes as escapes:

```
[//:verify-native-package] $ D:\a\maplibre-native-ffi\maplibre-native-ffi\.mise/tasks\verify-native-package windows-x64-vulkan
windows-x64-vulkan: line 1: D:amaplibre-native-ffimaplibre-native-ffi.mise/tasksverify-native-package: No such file or directory
```

A Python file task (`#!/usr/bin/env python3`) is affected the same way — the configured Bash shell replaces the interpreter its shebang names.

**Expected:** a config-scoped default should not preempt a file task's shebang. A task-local `shell` reasonably wins over the shebang, but `task_config.shell` is a default for tasks that do not choose one, and a file task with a shebang has chosen. Suggested fix: in `load_tasks_includes`, apply `task_config.shell` only to tasks with no `run` file, or in `get_file_program_and_args` order `shell_from_shebang` ahead of a shell that came from `task_config` rather than from the task itself.

**Workaround:** declare `#MISE shell="bash"` (no `-c`) in every file task, which yields `<shell> <file> <args…>` and restores argument passing.

</details>