### PR TITLE
Retry Windows Rust repair outside Git Bash

### DIFF
--- a/.github/actions/setup-ci-deps/action.yml
+++ b/.github/actions/setup-ci-deps/action.yml
@@ -359,7 +359,8 @@ runs:
     # ARM64 runners kill freshly spawned processes often enough to hit this:
     # rustup has died by signal milliseconds after exec, having written nothing.
     # Retry so the second attempt restores what the first one removed.
-    - name: Repair cached Rust toolchain
+    - name: Repair cached Rust toolchain (Unix)
+      if: runner.os != 'Windows'
       shell: bash
       env:
         TOOLCHAINS_CACHE_HIT: ${{ steps.toolchains.outputs.cache-hit }}
@@ -376,6 +377,40 @@ runs:
           echo "::warning::mise install --force rust failed (attempt ${attempt}/3)"
           sleep $((attempt * 5))
         done
+        exit 1
+
+    # Windows ARM64 can terminate Git Bash itself with a native exception while
+    # it waits for the forced reinstall. Keep the retry supervisor in PowerShell
+    # so a crashed mise or rustup process returns control for the next attempt.
+    - name: Repair cached Rust toolchain (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        TOOLCHAINS_CACHE_HIT: ${{ steps.toolchains.outputs.cache-hit }}
+      run: |
+        if (
+          $env:TOOLCHAINS_CACHE_HIT -eq "true" -and
+          (Get-Command cargo -ErrorAction SilentlyContinue) -and
+          (Get-Command rustc -ErrorAction SilentlyContinue)
+        ) {
+          cargo --version
+          if ($LASTEXITCODE -eq 0) {
+            rustc --version
+            if ($LASTEXITCODE -eq 0) {
+              Write-Output "Rust toolchain restored from cache"
+              exit 0
+            }
+          }
+        }
+        $env:MISE_NO_HOOKS = "1"
+        foreach ($attempt in 1..3) {
+          mise install --force rust
+          if ($LASTEXITCODE -eq 0) {
+            exit 0
+          }
+          Write-Output "::warning::mise install --force rust failed (attempt $attempt/3)"
+          Start-Sleep -Seconds ($attempt * 5)
+        }
         exit 1
 
     # `mise bootstrap` above installs the root config's tools; `--monorepo` adds


### PR DESCRIPTION
## Summary

Supervise Windows Rust cache repair from PowerShell so native ARM64 process crashes reach the existing retry policy instead of terminating Git Bash.

## Test plan

Ran `mise exec -- hk check .github/actions/setup-ci-deps/action.yml` and `mise run ci:check-action-pins`.

## AI assistance

- **Tools:** Codex
- **Context:** Root-caused the Windows ARM64 CI failure at `bf4ce99cfc52cf904500e3c641d64c5f17e57c53`, implemented the scoped repair, and ran targeted validation.
