### PR TITLE
Authenticate devcontainer mise bootstrap

### DIFF
--- a/.devcontainer/.mise/tasks/build
+++ b/.devcontainer/.mise/tasks/build
@@ -18,11 +18,14 @@ case "$host_arch" in
   *) echo "unsupported host architecture: $host_arch" >&2; exit 1 ;;
 esac
 
+# The bootstrap verifies GitHub artifact attestations. Forward mise's existing
+# token when the caller configured one so CI uses its authenticated API quota.
 docker run --rm \
   --platform "$platform" \
   --volume "$PWD/..:/src" \
   --workdir /src \
   --env MISE_EXPERIMENTAL=1 \
+  --env MISE_GITHUB_TOKEN \
   --env MISE_JOBS=1 \
   --env MISE_ENV="$mise_env" \
   --env OUTPUT_GID="$(id -g)" \


### PR DESCRIPTION
## Summary

Forward mise's configured GitHub token into the devcontainer tooling bootstrap so artifact attestation checks use authenticated API quota.

## Test plan

Ran `bash -n`, `mise exec -- hk check .devcontainer/.mise/tasks/build`, and a mocked Docker invocation that verified token forwarding without embedding its value in the command line.

## AI assistance

- **Tools:** Codex
- **Context:** Root-caused the devcontainer image failure at `bf4ce99cfc52cf904500e3c641d64c5f17e57c53`, implemented the scoped authentication boundary fix, and ran targeted validation.
