### PR TITLE
Disable Dart tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1057,9 +1057,6 @@ jobs:
       - run: mise run //bindings/python:test windows-arm64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test windows-arm64-wgl
-        env:
-          MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,6 @@ jobs:
       - run: mise run //bindings/python:test linux-x64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test linux-x64-egl
-        env:
-          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -196,9 +193,6 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/python:test linux-x64-vulkan
-        env:
-          MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test linux-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -278,9 +272,6 @@ jobs:
       - run: mise run //bindings/python:test linux-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test linux-arm64-egl
-        env:
-          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -355,9 +346,6 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/python:test linux-arm64-vulkan
-        env:
-          MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test linux-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -442,9 +430,6 @@ jobs:
       - run: mise run //bindings/python:test macos-arm64-metal
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test macos-arm64-metal
-        env:
-          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -523,9 +508,6 @@ jobs:
       - run: mise run //bindings/python:test macos-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test macos-arm64-vulkan
-        env:
-          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -599,9 +581,6 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/python:test macos-arm64-egl
-        env:
-          MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test macos-arm64-egl
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -923,9 +902,6 @@ jobs:
       - run: mise run //bindings/python:test windows-x64-wgl
         env:
           MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test windows-x64-wgl
-        env:
-          MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
         if: ${{ steps.setup.outputs.zig-cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -993,9 +969,6 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/python:test windows-x64-vulkan
-        env:
-          MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test windows-x64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Save Zig packages
@@ -1105,9 +1078,6 @@ jobs:
         env:
           MISE_TASK_SKIP: "//:build"
       - run: mise run //bindings/python:test windows-arm64-vulkan
-        env:
-          MISE_TASK_SKIP: "//:build"
-      - run: mise run //bindings/dart:test windows-arm64-vulkan
         env:
           MISE_TASK_SKIP: "//:build"
       - name: Upload native artifact

--- a/ci/workflow.toml
+++ b/ci/workflow.toml
@@ -44,10 +44,5 @@ commands = [{ task = "//bindings/go:test" }]
 platforms = ["linux", "macos", "windows"]
 commands = [{ task = "//bindings/python:test" }]
 
-[[suites]]
-platforms = ["linux", "macos", "windows"]
-# TODO(#412): Re-enable Windows ARM64 WGL after Dart thread-affine ownership is
-# safe across isolate migration; this test can otherwise wedge until timeout.
-commands = [
-  { task = "//bindings/dart:test", exclude = ["windows-arm64-wgl"] },
-]
+# TODO(#412): Re-enable Dart CI after thread-affine ownership is safe across
+# isolate migration; affected test processes can otherwise wedge until timeout.

--- a/ci/workflow.toml
+++ b/ci/workflow.toml
@@ -46,4 +46,8 @@ commands = [{ task = "//bindings/python:test" }]
 
 [[suites]]
 platforms = ["linux", "macos", "windows"]
-commands = [{ task = "//bindings/dart:test" }]
+# TODO(#412): Re-enable Windows ARM64 WGL after Dart thread-affine ownership is
+# safe across isolate migration; this test can otherwise wedge until timeout.
+commands = [
+  { task = "//bindings/dart:test", exclude = ["windows-arm64-wgl"] },
+]


### PR DESCRIPTION
## Summary

Temporarily remove Dart tests from generated CI target jobs because #412 causes intermittent wrong-thread failures and wedged test processes across multiple targets.

## Test plan

Ran `mise run ci:generate-workflow --check` and `mise exec -- hk check .github/workflows/ci.yml ci/workflow.toml`.

## AI assistance

- **Tools:** Codex
- **Context:** Codex investigated the linked Actions hang, confirmed that the ownership defect is not WGL-specific, and implemented and validated this quarantine under maintainer direction.